### PR TITLE
feat(engine): history record_schema_version envelope (R2 runway)

### DIFF
--- a/docs/persistence-history-record-versioning.md
+++ b/docs/persistence-history-record-versioning.md
@@ -1,0 +1,30 @@
+# History record schema_version (persistence envelope)
+
+**Scope:** This note governs **`record_schema_version`** on append-only **execution history** rows stored via `ExecutionHistoryStore` (SQLite column `record_schema_version`; in-memory rows expose `recordSchemaVersion`). It is **not** a substitute for:
+
+- **`document.schema`** in workflow definitions ([RFC-03](RFC/rfc-03-workflow-definition-schema.md)) — that versions the **workflow JSON contract**.
+- **Command/event names** in the execution model ([RFC-04 §4.4–4.5](RFC/rfc-04-execution-model.md)) — those are protocol taxonomies; persistence may carry them in `kind` + `name` without encoding the taxonomy version in this field.
+
+The history **envelope** is the adapter’s row shape (columns, JSON payload wrapping rules, and any future normalization). Bump `CURRENT_HISTORY_RECORD_SCHEMA_VERSION` in `packages/engine/src/persistence/history-record-schema-version.mjs` when a change requires replay or migration logic that an older engine cannot apply safely.
+
+## Current version
+
+- **Value:** `1` — first numbered envelope (adds an explicit persisted version; payloads unchanged from prior POC rows).
+- **Engine API:** `CURRENT_HISTORY_RECORD_SCHEMA_VERSION`, `assertHistoryReadableByEngine`, `recordSchemaVersionOf` (exported from `@agent-workflow/engine`).
+
+## Read policy (forward compatibility)
+
+1. **Missing or unknown on read:** Treat as version **1** (legacy rows pre–column and in-memory clones without the field).
+2. **Row version newer than engine support:** `hydrateReplayContext`, `getWorkflowStatus`, and any path that loads full history **fail fast** with a clear error so hosts can upgrade the package rather than silently corrupting replay.
+3. **Row version ≤ engine support:** Readers **must** accept all versions the engine advertises support for (future: optional shims per version).
+
+Orchestration (`runPocWorkflow`, `resumePocWorkflow`) and the MCP application port **must not** embed SQL or storage-specific I/O; they only call `ExecutionHistoryStore`. Only adapters implement persistence.
+
+## SQLite
+
+New databases create `history` with `record_schema_version`. Existing databases without the column get `ALTER TABLE … ADD COLUMN … DEFAULT 1` on store open (no row rewrite).
+
+## Related
+
+- Store port JSDoc: `packages/engine/src/persistence/types.mjs`
+- Operator overview: `packages/engine/README.md` (Execution history section)

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -176,8 +176,11 @@ Each checkpoint payload includes `executionId`, `workflowVersion`, `definitionHa
 | `name`         | TEXT    | Command/event name (maps to POC taxonomies) |
 | `payload_json` | TEXT    | JSON-serialized payload object |
 | `created_at`   | TEXT    | ISO 8601 timestamp when the row was appended |
+| `record_schema_version` | INTEGER | Persisted **row envelope** version (not `document.schema`); see below |
 
 Primary key: `(execution_id, seq)`. Historical rows are not updated or deleted by the adapter API.
+
+**Envelope versioning:** Each row is stamped with `record_schema_version` (currently `1`). Opening an existing database without this column runs `ALTER TABLE … ADD COLUMN … DEFAULT 1`. Replay, resume, and status paths call `assertHistoryReadableByEngine`: rows newer than this engine build fail fast so hosts upgrade `@agent-workflow/engine` instead of corrupting replay. Policy and read rules: [`docs/persistence-history-record-versioning.md`](../../docs/persistence-history-record-versioning.md).
 
 **Concurrency:** Treat the store as **single-writer per process** for a given execution (and avoid multiple processes appending to the same file for the same execution id). SQLite assigns `seq` inside a **transaction** (`BEGIN IMMEDIATE` … `COMMIT`) that reads `MAX(seq)` for the execution and then inserts the next row, so ordering stays monotonic for that writer.
 

--- a/packages/engine/src/application/workflow-application-port.mjs
+++ b/packages/engine/src/application/workflow-application-port.mjs
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { runPocWorkflow, resumePocWorkflow } from "../orchestrator/poc-runner.mjs";
+import { resumePocWorkflow, runPocWorkflow } from "../orchestrator/poc-runner.mjs";
+import { assertHistoryReadableByEngine } from "../persistence/history-record-schema-version.mjs";
 
 const PRIMARY_EVENT_NAMES = new Set(["ExecutionCompleted", "ExecutionFailed", "InterruptRaised"]);
 
@@ -131,6 +132,7 @@ export function createWorkflowApplicationPort(deps) {
      */
     async getWorkflowStatus(request) {
       const rows = store.listByExecution(request.executionId);
+      assertHistoryReadableByEngine(rows);
       if (rows.length === 0) {
         const err = new Error(`Execution "${request.executionId}" was not found.`);
         err.code = "EXECUTION_NOT_FOUND";

--- a/packages/engine/src/index.mjs
+++ b/packages/engine/src/index.mjs
@@ -10,6 +10,12 @@ export { StubActivityExecutor } from "./orchestrator/activity-executor.mjs";
 export { MemoryExecutionHistoryStore } from "./persistence/memory-history-store.mjs";
 export { SqliteExecutionHistoryStore } from "./persistence/sqlite-history-store.mjs";
 export {
+  assertHistoryReadableByEngine,
+  coerceRecordSchemaVersion,
+  CURRENT_HISTORY_RECORD_SCHEMA_VERSION,
+  recordSchemaVersionOf,
+} from "./persistence/history-record-schema-version.mjs";
+export {
   assertNoCustomReducers,
   applyOutputWithReducers,
   computeLinearNodePath,

--- a/packages/engine/src/orchestrator/poc-runner.mjs
+++ b/packages/engine/src/orchestrator/poc-runner.mjs
@@ -12,6 +12,7 @@ import {
   applyOutputWithReducers,
   stateSchemaForValidation,
 } from "./linear-runner.mjs";
+import { assertHistoryReadableByEngine } from "../persistence/history-record-schema-version.mjs";
 import { hydrateReplayContext } from "./replay-loader.mjs";
 
 const require = createRequire(import.meta.url);
@@ -552,6 +553,7 @@ export async function resumePocWorkflow(options) {
   }
 
   const rows = store.listByExecution(executionId);
+  assertHistoryReadableByEngine(rows);
   const lastRow = latestPrimaryEvent(rows);
   if (!lastRow || lastRow.name !== "InterruptRaised") {
     const err = 'Cannot resume: last history event is not "InterruptRaised".';

--- a/packages/engine/src/orchestrator/replay-loader.mjs
+++ b/packages/engine/src/orchestrator/replay-loader.mjs
@@ -1,3 +1,5 @@
+import { assertHistoryReadableByEngine } from "../persistence/history-record-schema-version.mjs";
+
 /**
  * @typedef {import("../persistence/types.mjs").HistoryRow} HistoryRow
  * @typedef {import("../persistence/types.mjs").ExecutionHistoryStore} ExecutionHistoryStore
@@ -46,6 +48,7 @@ export function hydrateReplayContext(options) {
   }
 
   const allRows = store.listByExecution(executionId);
+  assertHistoryReadableByEngine(allRows);
   let startSeq = 1;
   const checkpoint = { used: false };
   if (startMode === "safe_point") {

--- a/packages/engine/src/persistence/history-record-schema-version.mjs
+++ b/packages/engine/src/persistence/history-record-schema-version.mjs
@@ -1,0 +1,42 @@
+/**
+ * Version of the **persisted history row envelope** (store columns + payload interpretation
+ * contract), not the workflow definition `document.schema` (RFC-03) and not RFC-04 command/event
+ * taxonomy names.
+ *
+ * Bump when adding required columns, changing payload normalization, or breaking replay in a way
+ * that requires migration or a compatibility shim.
+ */
+export const CURRENT_HISTORY_RECORD_SCHEMA_VERSION = 1;
+
+/**
+ * @param {unknown} v
+ * @returns {number}
+ */
+export function coerceRecordSchemaVersion(v) {
+  if (typeof v === "number" && Number.isInteger(v) && v >= 1) return v;
+  return 1;
+}
+
+/**
+ * @param {import("./types.mjs").HistoryRow} row
+ * @returns {number}
+ */
+export function recordSchemaVersionOf(row) {
+  return coerceRecordSchemaVersion(row.recordSchemaVersion);
+}
+
+/**
+ * Ensures every row in a loaded execution can be interpreted by this engine build.
+ *
+ * @param {import("./types.mjs").HistoryRow[]} rows
+ */
+export function assertHistoryReadableByEngine(rows) {
+  for (const row of rows) {
+    const v = recordSchemaVersionOf(row);
+    if (v > CURRENT_HISTORY_RECORD_SCHEMA_VERSION) {
+      throw new Error(
+        `History row seq ${row.seq} uses record_schema_version ${v}; this engine supports up to ${CURRENT_HISTORY_RECORD_SCHEMA_VERSION}. Upgrade @agent-workflow/engine.`
+      );
+    }
+  }
+}

--- a/packages/engine/src/persistence/memory-history-store.mjs
+++ b/packages/engine/src/persistence/memory-history-store.mjs
@@ -1,3 +1,5 @@
+import { CURRENT_HISTORY_RECORD_SCHEMA_VERSION } from "./history-record-schema-version.mjs";
+
 /** @typedef {import("./types.mjs").HistoryAppendInput} HistoryAppendInput */
 /** @typedef {import("./types.mjs").HistoryRow} HistoryRow */
 /** @typedef {import("./types.mjs").ExecutionHistoryStore} ExecutionHistoryStore */
@@ -29,6 +31,7 @@ export class MemoryExecutionHistoryStore {
       name: input.name,
       payload: structuredClone(input.payload),
       createdAt,
+      recordSchemaVersion: CURRENT_HISTORY_RECORD_SCHEMA_VERSION,
     };
     rows.push(row);
     this.#byExecution.set(executionId, rows);

--- a/packages/engine/src/persistence/sqlite-history-store.mjs
+++ b/packages/engine/src/persistence/sqlite-history-store.mjs
@@ -1,4 +1,5 @@
 import { DatabaseSync } from "node:sqlite";
+import { CURRENT_HISTORY_RECORD_SCHEMA_VERSION } from "./history-record-schema-version.mjs";
 
 /** @typedef {import("./types.mjs").HistoryAppendInput} HistoryAppendInput */
 /** @typedef {import("./types.mjs").HistoryRow} HistoryRow */
@@ -16,9 +17,16 @@ function ensureSchema(db) {
       name TEXT NOT NULL,
       payload_json TEXT NOT NULL,
       created_at TEXT NOT NULL,
+      record_schema_version INTEGER NOT NULL DEFAULT 1,
       PRIMARY KEY (execution_id, seq)
     );
   `);
+  /** @type {Array<{ name: string }>} */
+  const cols = db.prepare("PRAGMA table_info(history)").all();
+  const names = new Set(cols.map((c) => c.name));
+  if (!names.has("record_schema_version")) {
+    db.exec(`ALTER TABLE history ADD COLUMN record_schema_version INTEGER NOT NULL DEFAULT 1`);
+  }
 }
 
 /**
@@ -80,10 +88,18 @@ export class SqliteExecutionHistoryStore {
       const nextSeq = m + 1;
       this.#db
         .prepare(
-          `INSERT INTO history (execution_id, seq, kind, name, payload_json, created_at)
-           VALUES (?, ?, ?, ?, ?, ?)`
+          `INSERT INTO history (execution_id, seq, kind, name, payload_json, created_at, record_schema_version)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`
         )
-        .run(executionId, nextSeq, input.kind, input.name, payloadJson, createdAt);
+        .run(
+          executionId,
+          nextSeq,
+          input.kind,
+          input.name,
+          payloadJson,
+          createdAt,
+          CURRENT_HISTORY_RECORD_SCHEMA_VERSION
+        );
       this.#db.exec("COMMIT");
       return nextSeq;
     } catch (err) {
@@ -104,7 +120,8 @@ export class SqliteExecutionHistoryStore {
    */
   readRange(executionId, fromSeq, toSeq) {
     let sql = `
-      SELECT execution_id, seq, kind, name, payload_json, created_at
+      SELECT execution_id, seq, kind, name, payload_json, created_at,
+             COALESCE(record_schema_version, 1) AS record_schema_version
       FROM history
       WHERE execution_id = ?
     `;
@@ -121,7 +138,7 @@ export class SqliteExecutionHistoryStore {
     sql += ` ORDER BY seq ASC`;
     const raw = this.#db.prepare(sql.trim()).all(...params);
     return raw.map((r) => {
-      const row = /** @type {{ execution_id: string; seq: number; kind: string; name: string; payload_json: string; created_at: string }} */ (
+      const row = /** @type {{ execution_id: string; seq: number; kind: string; name: string; payload_json: string; created_at: string; record_schema_version?: number }} */ (
         r
       );
       return /** @type {HistoryRow} */ ({
@@ -131,6 +148,8 @@ export class SqliteExecutionHistoryStore {
         name: row.name,
         payload: JSON.parse(row.payload_json),
         createdAt: row.created_at,
+        recordSchemaVersion:
+          typeof row.record_schema_version === "number" ? row.record_schema_version : 1,
       });
     });
   }

--- a/packages/engine/src/persistence/types.mjs
+++ b/packages/engine/src/persistence/types.mjs
@@ -19,10 +19,15 @@
  * @property {string} name
  * @property {object} payload Parsed JSON object.
  * @property {string} [createdAt] ISO 8601 timestamp when stored (if available).
+ * @property {number} [recordSchemaVersion] Persisted envelope version (see `history-record-schema-version.mjs`). Omitted or unset reads as **1**.
  */
 
 /**
  * Port: append-only, execution-scoped command/event history.
+ *
+ * **Record envelope:** Adapters MUST stamp each appended row with
+ * `CURRENT_HISTORY_RECORD_SCHEMA_VERSION` (see `history-record-schema-version.mjs`) so readers
+ * can fail fast on newer stores.
  *
  * **Concurrency:** Implementations should assume a **single writer per process** for a given
  * `executionId`. SQLite uses a transaction (read max `seq` then insert) so appends stay

--- a/packages/engine/test/history-store.test.mjs
+++ b/packages/engine/test/history-store.test.mjs
@@ -24,6 +24,7 @@ function runContract(store) {
   for (let i = 0; i < listed.length; i++) {
     assert.equal(listed[i].seq, i + 1);
     assert.equal(listed[i].executionId, exA);
+    assert.equal(listed[i].recordSchemaVersion, 1);
   }
   const seqs = listed.map((r) => r.seq);
   const sorted = [...seqs].sort((a, b) => a - b);
@@ -69,5 +70,31 @@ describe("SqliteExecutionHistoryStore", () => {
     db = new DatabaseSync(":memory:");
     store = new SqliteExecutionHistoryStore({ database: db });
     runContract(store);
+  });
+
+  it("migrates legacy history table without record_schema_version", () => {
+    db = new DatabaseSync(":memory:");
+    db.exec(`
+      CREATE TABLE history (
+        execution_id TEXT NOT NULL,
+        seq INTEGER NOT NULL,
+        kind TEXT NOT NULL,
+        name TEXT NOT NULL,
+        payload_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (execution_id, seq)
+      );
+    `);
+    db.prepare(
+      `INSERT INTO history (execution_id, seq, kind, name, payload_json, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    ).run("legacy-exec", 1, "command", "StartRun", "{}", new Date().toISOString());
+    store = new SqliteExecutionHistoryStore({ database: db });
+    const rows = store.listByExecution("legacy-exec");
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].recordSchemaVersion, 1);
+    const next = store.append("legacy-exec", { kind: "event", name: "RunStarted", payload: {} });
+    assert.equal(next, 2);
+    assert.equal(store.listByExecution("legacy-exec")[1].recordSchemaVersion, 1);
   });
 });

--- a/packages/engine/test/replay-loader.test.mjs
+++ b/packages/engine/test/replay-loader.test.mjs
@@ -165,4 +165,26 @@ describe("hydrateReplayContext", () => {
     const interruptEvent = replay.events.find((row) => row.name === "InterruptRaised");
     assert.ok(interruptEvent);
   });
+
+  it("rejects history rows newer than this engine supports", () => {
+    /** @type {{ listByExecution: (id: string) => import("../src/persistence/types.mjs").HistoryRow[] }} */
+    const store = {
+      listByExecution() {
+        return [
+          {
+            executionId: "x",
+            seq: 1,
+            kind: "command",
+            name: "StartRun",
+            payload: {},
+            recordSchemaVersion: 999_999,
+          },
+        ];
+      },
+    };
+    assert.throws(
+      () => hydrateReplayContext({ executionId: "x", store }),
+      /record_schema_version 999999/
+    );
+  });
 });


### PR DESCRIPTION
## What changed

- Added persisted **history row envelope** version (\ecord_schema_version\ / \ecordSchemaVersion\) with \CURRENT_HISTORY_RECORD_SCHEMA_VERSION\ and \ssertHistoryReadableByEngine\.
- **SQLite:** new column on \history\, \ALTER TABLE\ migration for legacy DBs without the column; all appends stamp the current version.
- **Memory store:** stamps the same version on each row.
- **Replay / resume / MCP status:** fail fast when any loaded row reports a version newer than this engine build.
- **Docs:** \docs/persistence-history-record-versioning.md\ (policy); engine README table + operator note.
- **Package exports:** \CURRENT_HISTORY_RECORD_SCHEMA_VERSION\, \ssertHistoryReadableByEngine\, \coerceRecordSchemaVersion\, \ecordSchemaVersionOf\.

## Why this change

Delivers the first slice of **[RUNWAY] #4** (event envelope versioning + durable store contract clarity) so parallel/timer-heavy R2 history stays forward-compatible and hosts upgrade explicitly instead of silent replay corruption.

## Roadmap alignment

- Linked issue: Closes #4
- Parent epic: #1
- Target release: \R2\
- Type: \unway\
- RFC trace links:
  - [RFC-04 — Events and checkpointing](https://github.com/benvdbergh/workflows/blob/master/docs/RFC/rfc-04-execution-model.md) (persistence carries command/event taxonomies; this versions the **store row** contract only)

## Spec and architecture traceability

- Spec artifact link (required for feature/runway PRs):
  - [docs/persistence-history-record-versioning.md](https://github.com/benvdbergh/workflows/blob/feat/4-r2-history-record-versioning/docs/persistence-history-record-versioning.md)
- Architecture decision link (ADR/design note, if applicable):
  - ADR deferred — issue #4 + RFC-04 trace; no material divergence from RFC.
- [x] Scope and constraints reviewed against \docs/poc-scope.md\ and relevant \docs/RFC/*\ (persistence-only; POC workflow schema unchanged)
- [x] If behavior/contract changed, corresponding spec/design docs were updated first or in this PR

## Architecture runway impact

- [ ] No runway impact
- [x] Adds/updates runway enabler
- [ ] Depends on runway enabler (link issue)

## Validation

- [x] \
pm run validate-workflows\
- [x] \
pm run conformance\
- [x] \
pm test\
- [x] Docs updated when behavior/contract changed

## Risk and rollback

- Risk level: \low\
- Rollback/fallback plan: Revert PR; existing SQLite DBs keep the added column (harmless); engines without this PR ignore the column if downgrading clients (not recommended).

Made with [Cursor](https://cursor.com)