### PR TITLE
feat(engine): R2 parallel, wait, set_state (#2)

### DIFF
--- a/conformance/vectors/schema/invalid/unsupported-node-type.vector.json
+++ b/conformance/vectors/schema/invalid/unsupported-node-type.vector.json
@@ -7,8 +7,8 @@
     "ok": false,
     "diagnostics": [
       {
-        "instancePath": "/nodes/1/type",
-        "keyword": "const"
+        "instancePath": "/nodes/1",
+        "keyword": "oneOf"
       }
     ]
   }

--- a/conformance/vectors/schema/valid/r2-research-parallel.vector.json
+++ b/conformance/vectors/schema/valid/r2-research-parallel.vector.json
@@ -1,0 +1,9 @@
+{
+  "id": "schema.valid.r2-research-parallel",
+  "description": "R2 profile: parallel + set_state + wait validate against extended POC schema.",
+  "kind": "schema",
+  "definition": "examples/r2-research-parallel.workflow.json",
+  "expect": {
+    "ok": true
+  }
+}

--- a/docs/poc-scope.md
+++ b/docs/poc-scope.md
@@ -1,6 +1,6 @@
-# POC scope — first engine milestone
+# POC scope — engine profile (POC + R2 core orchestration)
 
-This note is the **authoritative subset** of the Agent Workflow Protocol RFCs that the POC execution contract (schema bundle, fixtures, first engine milestone) **MUST** support. It does **not** replace the RFCs; where this document is silent, do **not** assume full RFC behavior.
+This note is the **authoritative subset** of the Agent Workflow Protocol RFCs that the reference engine schema bundle and `@agent-workflow/engine` **MUST** support. It extends the original POC milestone with **R2** node types (`parallel`, `wait`, `set_state`) and related commands/events. It does **not** replace the RFCs; where this document is silent, do **not** assume full RFC behavior.
 
 **Normative sources (read in full for semantics):**
 
@@ -43,20 +43,20 @@ These discriminators **MUST** be supported by the POC schema bundle and honored 
 | `tool_call` | External tool; **SHOULD** be MCP-shaped (`server`, `tool`, `arguments`) for portable POC fixtures. |
 | `switch` | Conditional routing via `config.cases` (`when` jq expression, `target` node id) and optional `config.default`. |
 | `interrupt` | Human-in-the-loop; `config` **MUST** include `resume_schema` and **MUST** include `prompt` or a resolvable reference per RFC; optional `timeout`. |
+| `parallel` | Fork/join per RFC-03: `config.join` is `all` \| `any` \| `n_of_m` (with `n`), `config.branches` is `{ name, entry }[]` where `entry` is the first node id of a branch. Exactly **one** static edge leaves the parallel node to the **join target**; each branch must reach that target via its own linear chain (see golden `examples/r2-research-parallel.workflow.json`). |
+| `wait` | `config.kind`: `duration` (requires `duration_ms` or parseable `duration` string), `until` (ISO-8601 `until` timestamp), or `signal` (**requires host**; unsupported in bare engine — fails at runtime). |
+| `set_state` | `config.assignments`: map of state keys to `{ "jq": "<expr>" }` or `{ "literal": <value> }`; merged with `state_schema` reducers. |
 
 Common node fields [RFC-03 §3.5](rfc-03-workflow-definition-schema.md#35-node-object-common-fields): `id`, `type`, optional `config`, `retry`, `timeout`, `metadata` — all **in scope** where applicable.
 
-### 2.1 Node `type` values (explicitly out of scope for POC)
+### 2.1 Node `type` values (explicitly out of scope for this profile)
 
 Implementers **MUST NOT** infer support from the full RFC for:
 
-- `parallel`
 - `agent_delegate`
 - `subworkflow`
-- `wait`
-- `set_state`
 
-POC validators **MUST** reject unknown `type` values (including the above until promoted into a future scope revision).
+Validators **MUST** reject unknown `type` values (including the above until promoted).
 
 ### 2.2 Delegation profile boundary (north star vs POC bridge)
 
@@ -75,9 +75,7 @@ Per [RFC-03 §3.6](rfc-03-workflow-definition-schema.md#36-edges):
 - Synthetic source `__start__` **MAY** be used for the unique entry edge to the `start` node’s successor (or as specified in golden fixtures).
 - For `switch`, outgoing routing **MAY** be expressed only via `config.cases` / `default`; static `edges` from the `switch` node **MAY** coexist only if the engine documents precedence. **POC recommendation:** prefer `cases` + `default` for switch successors; avoid duplicate routing channels until conformance tests lock precedence.
 
-**Out of scope:**
-
-- Graph patterns that require `parallel` join semantics or nested subgraph wiring per `parallel` (deferred with the `parallel` type).
+**Parallel (R2):** The parallel node lists branch **entry** node ids; each branch follows static edges until it reaches the parallel node’s unique **join target** (the sole edge leaving the parallel node). Nested `parallel` and `switch` inside branches are allowed; **interrupt inside a parallel branch** is not resume-safe in this profile — avoid until correlation is modeled.
 
 ---
 
@@ -114,17 +112,17 @@ After reducer application, engines **SHOULD** validate state against `state_sche
 
 ## 6. Execution model subset (commands and events)
 
-The full taxonomies are [RFC-04 §4.4](rfc-04-execution-model.md#44-command-taxonomy-normative) and [§4.5](rfc-04-execution-model.md#45-event-taxonomy-normative). For the **POC graph subset** (no `parallel`, `subworkflow`, `wait`):
+The full taxonomies are [RFC-04 §4.4](rfc-04-execution-model.md#44-command-taxonomy-normative) and [§4.5](rfc-04-execution-model.md#45-event-taxonomy-normative).
 
 **Commands — in scope**
 
 - `ScheduleNode`, `CompleteNode`, `FailNode`
 - `RaiseInterrupt`, `ResumeInterrupt`
+- **R2:** `StartParallel`, `JoinParallel`, `CancelParallelBranch`, `StartTimer`
 
-**Commands — out of scope (deferred with node types above)**
+**Commands — out of scope**
 
-- `StartParallel`, `JoinParallel`
-- `StartTimer`, `CancelTimer`
+- `CancelTimer` (reserved; not emitted by current reference `wait` paths)
 - `StartSubworkflow`, `CompleteSubworkflow`
 - `EmitSignal`
 
@@ -136,6 +134,7 @@ The full taxonomies are [RFC-04 §4.4](rfc-04-execution-model.md#44-command-taxo
 - `StateUpdated` (or equivalent embedding per engine profile, per [RFC-04 §4.6](rfc-04-execution-model.md#46-state-updates-and-reducers))
 - `InterruptRaised`, `InterruptResumed`
 - `ExecutionCompleted`, `ExecutionFailed`
+- **R2:** `ParallelForked`, `ParallelJoined`, `ParallelBranchCancelled`, `TimerStarted`, `TimerFired`
 
 **Events — optional / phased**
 

--- a/examples/fixtures.invalid/unsupported-node-type.workflow.json
+++ b/examples/fixtures.invalid/unsupported-node-type.workflow.json
@@ -13,10 +13,11 @@
       "type": "start"
     },
     {
-      "id": "fanout",
-      "type": "parallel",
+      "id": "nested",
+      "type": "subworkflow",
       "config": {
-        "branches": []
+        "workflow_ref": "urn:example:wf:child",
+        "input_mapping": {}
       }
     }
   ],
@@ -27,7 +28,7 @@
     },
     {
       "source": "start",
-      "target": "fanout"
+      "target": "nested"
     }
   ]
 }

--- a/examples/r2-research-parallel.workflow.json
+++ b/examples/r2-research-parallel.workflow.json
@@ -1,0 +1,77 @@
+{
+  "document": {
+    "schema": "https://example.org/agent-workflow/poc/v1/workflow-definition",
+    "name": "r2-research-parallel-demo",
+    "version": "1.0.0"
+  },
+  "state_schema": {
+    "type": "object",
+    "properties": {
+      "topic": { "type": "string" },
+      "findings": {
+        "type": "array",
+        "items": { "type": "string" },
+        "reducer": "append"
+      },
+      "phase": { "type": "string" }
+    }
+  },
+  "nodes": [
+    { "id": "start", "type": "start" },
+    {
+      "id": "plan",
+      "type": "llm_call",
+      "config": { "model": "stub", "prompt": "Plan subtopics" }
+    },
+    {
+      "id": "research",
+      "type": "parallel",
+      "config": {
+        "join": "all",
+        "branches": [
+          { "name": "web", "entry": "web_collect" },
+          { "name": "internal", "entry": "internal_collect" }
+        ]
+      }
+    },
+    {
+      "id": "web_collect",
+      "type": "tool_call",
+      "config": { "server": "demo-mcp", "tool": "web.search", "arguments": {} }
+    },
+    {
+      "id": "internal_collect",
+      "type": "tool_call",
+      "config": { "server": "demo-mcp", "tool": "kb.search", "arguments": {} }
+    },
+    {
+      "id": "tag",
+      "type": "set_state",
+      "config": {
+        "assignments": {
+          "phase": { "literal": "merged" }
+        }
+      }
+    },
+    {
+      "id": "rest",
+      "type": "wait",
+      "config": { "kind": "duration", "duration_ms": 0 }
+    },
+    {
+      "id": "end",
+      "type": "end",
+      "config": { "output_mapping": ".findings" }
+    }
+  ],
+  "edges": [
+    { "source": "__start__", "target": "start" },
+    { "source": "start", "target": "plan" },
+    { "source": "plan", "target": "research" },
+    { "source": "research", "target": "tag" },
+    { "source": "web_collect", "target": "tag" },
+    { "source": "internal_collect", "target": "tag" },
+    { "source": "tag", "target": "rest" },
+    { "source": "rest", "target": "end" }
+  ]
+}

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -1,6 +1,6 @@
 # `@agent-workflow/engine`
 
-Publishable npm package: **definition-time** validation for Agent Workflow Protocol POC workflow documents, an **append-only execution history** port (SQLite or in-memory), a **linear graph runner** (STORY-2-3), and a **general POC walker** (STORY-2-5) with `switch` and `interrupt` / resume.
+Publishable npm package: **definition-time** validation for Agent Workflow Protocol workflow documents (POC profile + **R2** `parallel`, `wait`, `set_state`), an **append-only execution history** port (SQLite or in-memory), a **linear graph runner** (STORY-2-3), and a **general graph walker** with `switch`, `interrupt` / resume, **parallel** join policies (`all` / `any` / `n_of_m`), **wait** (`duration` / `until`; `signal` needs a host), and **set_state**.
 
 ## Entrypoint (CLI)
 

--- a/packages/engine/schemas/workflow-definition-poc.json
+++ b/packages/engine/schemas/workflow-definition-poc.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://example.org/agent-workflow/poc/v1/workflow-definition",
-  "title": "Agent Workflow Protocol — POC workflow definition",
-  "description": "JSON Schema for the POC subset defined in docs/poc-scope.md. Normative semantics: docs/RFC/rfc-03-workflow-definition-schema.md.",
+  "title": "Agent Workflow Protocol — POC workflow definition (R2 core orchestration)",
+  "description": "JSON Schema for the profile defined in docs/poc-scope.md (POC + R2: parallel, wait, set_state). Normative semantics: docs/RFC/rfc-03-workflow-definition-schema.md.",
   "type": "object",
   "additionalProperties": false,
   "required": ["document", "state_schema", "nodes", "edges"],
@@ -94,7 +94,10 @@
         { "$ref": "#/$defs/node_llm_call" },
         { "$ref": "#/$defs/node_tool_call" },
         { "$ref": "#/$defs/node_switch" },
-        { "$ref": "#/$defs/node_interrupt" }
+        { "$ref": "#/$defs/node_interrupt" },
+        { "$ref": "#/$defs/node_parallel" },
+        { "$ref": "#/$defs/node_wait" },
+        { "$ref": "#/$defs/node_set_state" }
       ]
     },
     "node_start": {
@@ -262,6 +265,152 @@
             { "required": ["prompt"] },
             { "required": ["prompt_ref"] }
           ]
+        },
+        "retry": { "$ref": "#/$defs/retry_policy" },
+        "timeout": { "$ref": "#/$defs/node_level_timeout" },
+        "metadata": { "$ref": "#/$defs/node_level_metadata" }
+      }
+    },
+    "node_parallel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "config"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "type": { "const": "parallel" },
+        "config": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["join", "branches"],
+          "properties": {
+            "join": {
+              "type": "string",
+              "enum": ["all", "any", "n_of_m"]
+            },
+            "n": { "type": "integer", "minimum": 1 },
+            "branches": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["name", "entry"],
+                "properties": {
+                  "name": { "type": "string", "minLength": 1 },
+                  "entry": { "type": "string", "minLength": 1 }
+                }
+              }
+            },
+            "timeout": { "$ref": "#/$defs/node_level_timeout" }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": { "join": { "const": "n_of_m" } },
+                "required": ["join"]
+              },
+              "then": { "required": ["n"] }
+            }
+          ]
+        },
+        "retry": { "$ref": "#/$defs/retry_policy" },
+        "timeout": { "$ref": "#/$defs/node_level_timeout" },
+        "metadata": { "$ref": "#/$defs/node_level_metadata" }
+      }
+    },
+    "node_wait": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "config"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "type": { "const": "wait" },
+        "config": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind"],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": ["duration", "until", "signal"]
+            },
+            "duration_ms": { "type": "integer", "minimum": 0 },
+            "duration": { "type": "string", "minLength": 1 },
+            "until": { "type": "string", "minLength": 1 },
+            "signal": { "type": "string", "minLength": 1 }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": { "kind": { "const": "duration" } },
+                "required": ["kind"]
+              },
+              "then": {
+                "anyOf": [{ "required": ["duration_ms"] }, { "required": ["duration"] }]
+              }
+            },
+            {
+              "if": {
+                "properties": { "kind": { "const": "until" } },
+                "required": ["kind"]
+              },
+              "then": { "required": ["until"] }
+            },
+            {
+              "if": {
+                "properties": { "kind": { "const": "signal" } },
+                "required": ["kind"]
+              },
+              "then": { "required": ["signal"] }
+            }
+          ]
+        },
+        "retry": { "$ref": "#/$defs/retry_policy" },
+        "timeout": { "$ref": "#/$defs/node_level_timeout" },
+        "metadata": { "$ref": "#/$defs/node_level_metadata" }
+      }
+    },
+    "node_set_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "config"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "type": { "const": "set_state" },
+        "config": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["assignments"],
+          "properties": {
+            "assignments": {
+              "type": "object",
+              "minProperties": 1,
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["jq"],
+                    "properties": {
+                      "jq": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "jq expression evaluated against current state; result merged per state_schema reducers."
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["literal"],
+                    "properties": {
+                      "literal": true
+                    }
+                  }
+                ]
+              }
+            }
+          }
         },
         "retry": { "$ref": "#/$defs/retry_policy" },
         "timeout": { "$ref": "#/$defs/node_level_timeout" },

--- a/packages/engine/src/orchestrator/poc-runner-r2-parallel.mjs
+++ b/packages/engine/src/orchestrator/poc-runner-r2-parallel.mjs
@@ -1,0 +1,371 @@
+/**
+ * R2 parallel branch walking and join policies (deterministic branch order).
+ * @see docs/RFC/rfc-04-execution-model.md §4.7
+ */
+
+import { applyOutputWithReducers } from "./linear-runner.mjs";
+
+/**
+ * @typedef {'all' | 'any' | 'n_of_m'} ParallelJoin
+ */
+
+/**
+ * @typedef {object} R2WalkHooks
+ * @property {() => Record<string, unknown>} getState
+ * @property {(s: Record<string, unknown>) => void} setState
+ * @property {(name: string, payload: Record<string, unknown>) => { replayed: boolean }} appendCmd
+ * @property {(name: string, payload: Record<string, unknown>) => number} appendEvt
+ * @property {(nodeId: string, stateSnapshot: Record<string, unknown>, lastAppliedEventSeq: number) => void} appendCheckpoint
+ * @property {(node: { id: string; type: string; config?: object }, state: Record<string, unknown>, jq: { json: (data: unknown, query: string) => Promise<unknown> }) => Promise<string>} resolveSwitchTarget
+ * @property {(node: { id: string; type: string; config?: object }, state: Record<string, unknown>, jq: { json: (data: unknown, query: string) => Promise<unknown> }) => Promise<Record<string, unknown>>} buildSetStateOutput
+ * @property {(node: { id: string; type: string; config?: object }, scheduled: { replayed: boolean }, state: Record<string, unknown>) => Promise<{ ok: true; output: Record<string, unknown> } | { ok: false; error: string; code?: string }>} runPlaceholderActivity
+ * @property {(node: { id: string; type: string; config?: object }, scheduled: { replayed: boolean }) => Promise<void>} runWaitNode
+ * @property {(state: Record<string, unknown>, context: string) => void} throwIfStateInvalid
+ * @property {object} stateSchema
+ * @property {{ json: (data: unknown, query: string) => Promise<unknown> }} jq
+ */
+
+/**
+ * @param {object} params
+ * @param {Map<string, { id: string; type: string; config?: object }>} params.byId
+ * @param {Map<string, string[]>} params.outgoing
+ * @param {R2WalkHooks} params.hooks
+ */
+export function createR2ParallelRuntime(params) {
+  const { byId, outgoing, hooks } = params;
+  const PLACEHOLDER_TYPES = new Set(["step", "llm_call", "tool_call"]);
+
+  /**
+   * @param {string} nodeId
+   * @param {string} joinTargetId
+   * @returns {Promise<{ kind: 'ok' } | { kind: 'failed'; error: string } | { kind: 'interrupt'; nodeId: string; state: Record<string, unknown> }>}
+   */
+  async function runBranchToJoin(nodeId, joinTargetId) {
+    let cur = nodeId;
+    while (cur !== joinTargetId) {
+      const node = byId.get(cur);
+      if (!node) {
+        return { kind: "failed", error: `Edge references unknown node id "${cur}".` };
+      }
+
+      const scheduled = hooks.appendCmd("ScheduleNode", { nodeId: cur });
+      hooks.appendEvt("NodeScheduled", { nodeId: cur });
+
+      if (node.type === "switch") {
+        let targetId;
+        try {
+          targetId = await hooks.resolveSwitchTarget(
+            /** @type {{ id: string; type: string; config?: object }} */ (node),
+            hooks.getState(),
+            hooks.jq
+          );
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          hooks.appendCmd("FailNode", { nodeId: cur, reason: "switch_routing_failed", message: msg });
+          hooks.appendEvt("ExecutionFailed", { error: msg });
+          return { kind: "failed", error: msg };
+        }
+        if (!byId.has(targetId)) {
+          const msg = `switch "${node.id}" resolved to unknown target "${targetId}"`;
+          hooks.appendCmd("FailNode", { nodeId: cur, reason: "switch_routing_failed", message: msg });
+          hooks.appendEvt("ExecutionFailed", { error: msg });
+          return { kind: "failed", error: msg };
+        }
+        hooks.appendCmd("CompleteNode", { nodeId: cur, output: {} });
+        const stateUpdatedSeq = hooks.appendEvt("StateUpdated", {
+          nodeId: cur,
+          state: JSON.parse(JSON.stringify(hooks.getState())),
+        });
+        hooks.appendCheckpoint(cur, hooks.getState(), stateUpdatedSeq);
+        try {
+          hooks.throwIfStateInvalid(hooks.getState(), `State invalid after switch "${cur}"`);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          return { kind: "failed", error: msg };
+        }
+        cur = targetId;
+        continue;
+      }
+
+      if (node.type === "interrupt") {
+        const cfg = node.config && typeof node.config === "object" ? /** @type {{ prompt?: string }} */ (node.config) : {};
+        const promptSummary =
+          typeof cfg.prompt === "string" ? (cfg.prompt.length > 200 ? `${cfg.prompt.slice(0, 200)}…` : cfg.prompt) : "";
+        hooks.appendCmd("RaiseInterrupt", { nodeId: cur, prompt: promptSummary });
+        const interruptSeq = hooks.appendEvt("InterruptRaised", { nodeId: cur, prompt: promptSummary });
+        hooks.appendCheckpoint(cur, hooks.getState(), interruptSeq);
+        return {
+          kind: "interrupt",
+          nodeId: cur,
+          state: JSON.parse(JSON.stringify(hooks.getState())),
+        };
+      }
+
+      if (node.type === "parallel") {
+        const outs = outgoing.get(cur) ?? [];
+        if (outs.length !== 1) {
+          return {
+            kind: "failed",
+            error: `parallel "${cur}" must have exactly one outgoing edge (join target); found ${outs.length}.`,
+          };
+        }
+        const nestedJoin = outs[0];
+        const pr = await executeParallelBlock(
+          /** @type {{ id: string; type: string; config?: object }} */ (node),
+          nestedJoin
+        );
+        if (pr.kind !== "ok") return pr;
+        cur = nestedJoin;
+        continue;
+      }
+
+      if (node.type === "wait") {
+        try {
+          await hooks.runWaitNode(
+            /** @type {{ id: string; type: string; config?: object }} */ (node),
+            scheduled
+          );
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          hooks.appendCmd("FailNode", { nodeId: cur, reason: "wait_failed", message: msg });
+          hooks.appendEvt("ExecutionFailed", { error: msg });
+          return { kind: "failed", error: msg };
+        }
+        hooks.appendCmd("CompleteNode", { nodeId: cur, output: {} });
+        const stateUpdatedSeq = hooks.appendEvt("StateUpdated", {
+          nodeId: cur,
+          state: JSON.parse(JSON.stringify(hooks.getState())),
+        });
+        hooks.appendCheckpoint(cur, hooks.getState(), stateUpdatedSeq);
+        try {
+          hooks.throwIfStateInvalid(hooks.getState(), `State invalid after wait "${cur}"`);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          return { kind: "failed", error: msg };
+        }
+        const nextOut = outgoing.get(cur) ?? [];
+        if (nextOut.length !== 1) {
+          return {
+            kind: "failed",
+            error: `Node "${cur}" (wait) must have exactly one outgoing edge; found ${nextOut.length}.`,
+          };
+        }
+        cur = nextOut[0];
+        continue;
+      }
+
+      if (node.type === "set_state") {
+        let output;
+        try {
+          output = await hooks.buildSetStateOutput(
+            /** @type {{ id: string; type: string; config?: object }} */ (node),
+            hooks.getState(),
+            hooks.jq
+          );
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          hooks.appendCmd("FailNode", { nodeId: cur, reason: "set_state_failed", message: msg });
+          hooks.appendEvt("ExecutionFailed", { error: msg });
+          return { kind: "failed", error: msg };
+        }
+        hooks.appendCmd("CompleteNode", { nodeId: cur, output });
+        hooks.setState(
+          /** @type {Record<string, unknown>} */ (applyOutputWithReducers(hooks.getState(), output, hooks.stateSchema))
+        );
+        const stateUpdatedSeq = hooks.appendEvt("StateUpdated", {
+          nodeId: cur,
+          state: JSON.parse(JSON.stringify(hooks.getState())),
+        });
+        hooks.appendCheckpoint(cur, hooks.getState(), stateUpdatedSeq);
+        try {
+          hooks.throwIfStateInvalid(hooks.getState(), `State invalid after set_state "${cur}"`);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          return { kind: "failed", error: msg };
+        }
+        const nextOut = outgoing.get(cur) ?? [];
+        if (nextOut.length !== 1) {
+          return {
+            kind: "failed",
+            error: `Node "${cur}" (set_state) must have exactly one outgoing edge; found ${nextOut.length}.`,
+          };
+        }
+        cur = nextOut[0];
+        continue;
+      }
+
+      if (node.type === "end") {
+        return {
+          kind: "failed",
+          error: `Invalid "end" node "${cur}" reached inside a parallel branch before the join target.`,
+        };
+      }
+
+      /** @type {Record<string, unknown>} */
+      let output = {};
+
+      if (node.type === "start") {
+        output = {};
+      } else if (PLACEHOLDER_TYPES.has(node.type)) {
+        const activityResult = await hooks.runPlaceholderActivity(
+          /** @type {{ id: string; type: string; config?: object }} */ (node),
+          scheduled,
+          hooks.getState()
+        );
+        if (!activityResult.ok) {
+          const { error, code } = activityResult;
+          hooks.appendEvt("ActivityFailed", { nodeId: cur, error, ...(code !== undefined ? { code } : {}) });
+          hooks.appendCmd("FailNode", {
+            nodeId: cur,
+            reason: "activity_failed",
+            message: error,
+            ...(code !== undefined ? { code } : {}),
+          });
+          hooks.appendEvt("ExecutionFailed", { error });
+          return { kind: "failed", error };
+        }
+        output = activityResult.output;
+      } else {
+        return { kind: "failed", error: `Unsupported node type "${node.type}" inside parallel branch.` };
+      }
+
+      hooks.appendCmd("CompleteNode", { nodeId: cur, output });
+
+      if (node.type !== "start") {
+        hooks.setState(
+          /** @type {Record<string, unknown>} */ (applyOutputWithReducers(hooks.getState(), output, hooks.stateSchema))
+        );
+        const stateUpdatedSeq = hooks.appendEvt("StateUpdated", {
+          nodeId: cur,
+          state: JSON.parse(JSON.stringify(hooks.getState())),
+        });
+        hooks.appendCheckpoint(cur, hooks.getState(), stateUpdatedSeq);
+        try {
+          hooks.throwIfStateInvalid(hooks.getState(), `State invalid after node "${cur}"`);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          return { kind: "failed", error: msg };
+        }
+      }
+
+      const outs = outgoing.get(cur) ?? [];
+      if (outs.length !== 1) {
+        return {
+          kind: "failed",
+          error: `Node "${cur}" (type "${node.type}") must have exactly one outgoing edge inside a branch; found ${outs.length}.`,
+        };
+      }
+      cur = outs[0];
+    }
+    return { kind: "ok" };
+  }
+
+  /**
+   * @param {{ id: string; type: string; config?: object }} parallelNode
+   * @param {string} joinTargetId
+   */
+  async function executeParallelBlock(parallelNode, joinTargetId) {
+    const cfg =
+      parallelNode.config && typeof parallelNode.config === "object"
+        ? /** @type {{ join?: string; n?: number; branches?: Array<{ name: string; entry: string }> }} */ (
+            parallelNode.config
+          )
+        : {};
+    const join = /** @type {ParallelJoin} */ (cfg.join);
+    const branches = Array.isArray(cfg.branches) ? cfg.branches : [];
+    const n = cfg.n;
+
+    if (!join || !["all", "any", "n_of_m"].includes(join)) {
+      return { kind: "failed", error: `parallel "${parallelNode.id}": invalid or missing join policy.` };
+    }
+    if (branches.length === 0) {
+      return { kind: "failed", error: `parallel "${parallelNode.id}": branches must be non-empty.` };
+    }
+    if (join === "n_of_m") {
+      if (!Number.isInteger(n) || n < 1 || n > branches.length) {
+        return {
+          kind: "failed",
+          error: `parallel "${parallelNode.id}": n_of_m requires integer n with 1 ≤ n ≤ branch count (${branches.length}).`,
+        };
+      }
+    }
+
+    const branchNames = branches.map((b) => b.name);
+    hooks.appendCmd("StartParallel", {
+      nodeId: parallelNode.id,
+      join,
+      branchNames,
+      ...(join === "n_of_m" && n !== undefined ? { n } : {}),
+    });
+    hooks.appendEvt("ParallelForked", {
+      nodeId: parallelNode.id,
+      join,
+      branchNames,
+    });
+
+    /**
+     * @param {number} fromIndex inclusive
+     */
+    function cancelRemaining(fromIndex) {
+      for (let i = fromIndex; i < branches.length; i++) {
+        const b = branches[i];
+        hooks.appendCmd("CancelParallelBranch", { nodeId: parallelNode.id, branchName: b.name });
+        hooks.appendEvt("ParallelBranchCancelled", { nodeId: parallelNode.id, branchName: b.name });
+      }
+    }
+
+    if (join === "all") {
+      for (const b of branches) {
+        const r = await runBranchToJoin(b.entry, joinTargetId);
+        if (r.kind !== "ok") return r;
+      }
+    } else if (join === "any") {
+      let successIndex = -1;
+      for (let i = 0; i < branches.length; i++) {
+        const r = await runBranchToJoin(branches[i].entry, joinTargetId);
+        if (r.kind === "interrupt") return r;
+        if (r.kind === "ok") {
+          successIndex = i;
+          break;
+        }
+      }
+      if (successIndex < 0) {
+        const msg = `parallel "${parallelNode.id}" (join any): no branch completed successfully.`;
+        hooks.appendCmd("FailNode", { nodeId: parallelNode.id, reason: "parallel_join_failed", message: msg });
+        hooks.appendEvt("ExecutionFailed", { error: msg });
+        return { kind: "failed", error: msg };
+      }
+      cancelRemaining(successIndex + 1);
+    } else {
+      let successes = 0;
+      for (let i = 0; i < branches.length; i++) {
+        const b = branches[i];
+        if (successes >= /** @type {number} */ (n)) {
+          cancelRemaining(i);
+          break;
+        }
+        const r = await runBranchToJoin(b.entry, joinTargetId);
+        if (r.kind === "interrupt") return r;
+        if (r.kind === "ok") {
+          successes += 1;
+          if (successes >= /** @type {number} */ (n)) {
+            cancelRemaining(i + 1);
+            break;
+          }
+        }
+      }
+      if (successes < /** @type {number} */ (n)) {
+        const msg = `parallel "${parallelNode.id}" (join n_of_m): needed ${n} successful branches, got ${successes}.`;
+        hooks.appendCmd("FailNode", { nodeId: parallelNode.id, reason: "parallel_join_failed", message: msg });
+        hooks.appendEvt("ExecutionFailed", { error: msg });
+        return { kind: "failed", error: msg };
+      }
+    }
+
+    hooks.appendCmd("JoinParallel", { nodeId: parallelNode.id, join });
+    hooks.appendEvt("ParallelJoined", { nodeId: parallelNode.id, join });
+    return { kind: "ok" };
+  }
+
+  return { executeParallelBlock, runBranchToJoin };
+}

--- a/packages/engine/src/orchestrator/poc-runner.mjs
+++ b/packages/engine/src/orchestrator/poc-runner.mjs
@@ -1,5 +1,6 @@
 /**
- * General POC graph walker: `start`, `end`, `step`, `llm_call`, `tool_call`, `switch`, `interrupt`.
+ * POC graph walker: `start`, `end`, `step`, `llm_call`, `tool_call`, `switch`, `interrupt`,
+ * plus R2 `parallel`, `wait`, and `set_state`.
  * Switch routing uses only `config.cases` / `config.default` (static edges from the switch id are ignored).
  */
 import Ajv2020 from "ajv/dist/2020.js";
@@ -14,6 +15,7 @@ import {
 } from "./linear-runner.mjs";
 import { assertHistoryReadableByEngine } from "../persistence/history-record-schema-version.mjs";
 import { hydrateReplayContext } from "./replay-loader.mjs";
+import { createR2ParallelRuntime } from "./poc-runner-r2-parallel.mjs";
 
 const require = createRequire(import.meta.url);
 
@@ -69,6 +71,108 @@ function expectedCommandIdentity(name, payload) {
  */
 function jqTruthy(jqResult) {
   return jqResult !== false && jqResult !== null;
+}
+
+/**
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * @param {object} cfg wait node config
+ * @returns {number}
+ */
+function parseWaitDurationMs(cfg) {
+  if (typeof cfg.duration_ms === "number" && cfg.duration_ms >= 0) return cfg.duration_ms;
+  const s = typeof cfg.duration === "string" ? cfg.duration.trim() : "";
+  if (!s) {
+    throw new Error('wait (kind "duration"): expected duration_ms (number) or duration (string)');
+  }
+  const m = /^(\d+)\s*(ms|s|m|h)?$/i.exec(s);
+  if (!m) {
+    throw new Error(`wait (kind "duration"): cannot parse duration string "${s}"`);
+  }
+  const n = Number(m[1]);
+  const u = (m[2] || "ms").toLowerCase();
+  const mult = u === "h" ? 3_600_000 : u === "m" ? 60_000 : u === "s" ? 1000 : 1;
+  return n * mult;
+}
+
+/**
+ * @param {{ config?: object }} node
+ * @param {Record<string, unknown>} state
+ * @param {{ json: (data: unknown, query: string) => Promise<unknown> }} jq
+ * @returns {Promise<Record<string, unknown>>}
+ */
+async function buildSetStateOutput(node, state, jq) {
+  const cfg = node.config && typeof node.config === "object" ? /** @type {{ assignments?: unknown }} */ (node.config) : {};
+  const assignments =
+    cfg.assignments && typeof cfg.assignments === "object" && !Array.isArray(cfg.assignments)
+      ? /** @type {Record<string, unknown>} */ (cfg.assignments)
+      : {};
+  /** @type {Record<string, unknown>} */
+  const out = {};
+  for (const [key, specRaw] of Object.entries(assignments)) {
+    if (!specRaw || typeof specRaw !== "object" || Array.isArray(specRaw)) {
+      throw new Error(`set_state "${node.id}": assignment "${key}" must be an object with "jq" or "literal".`);
+    }
+    const spec = /** @type {Record<string, unknown>} */ (specRaw);
+    if ("jq" in spec) {
+      const q = typeof spec.jq === "string" ? spec.jq : "";
+      if (!q.trim()) throw new Error(`set_state "${node.id}": empty jq for "${key}"`);
+      try {
+        out[key] = await jq.json(state, q);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        throw new Error(`set_state "${node.id}" key "${key}" (jq): ${msg}`);
+      }
+    } else if ("literal" in spec) {
+      out[key] = JSON.parse(JSON.stringify(spec.literal));
+    } else {
+      throw new Error(`set_state "${node.id}": assignment "${key}" must use "jq" or "literal".`);
+    }
+  }
+  return out;
+}
+
+/**
+ * @param {string} nodeId
+ * @param {{ replayed: boolean }} scheduled
+ * @param {(name: string, payload: Record<string, unknown>) => { replayed: boolean }} appendCmd
+ * @param {(name: string, payload: Record<string, unknown>) => number} appendEvt
+ * @param {object | undefined} config
+ */
+async function runWaitNodeExecution(nodeId, scheduled, appendCmd, appendEvt, config) {
+  const wcfg = config && typeof config === "object" ? config : {};
+  const kind = /** @type {{ kind?: string }} */ (wcfg).kind;
+  if (kind === "signal") {
+    throw new Error(
+      'wait kind "signal" requires a host to deliver workflow_signal (not implemented in this engine profile)'
+    );
+  }
+  let waitMs = 0;
+  let untilIso;
+  if (kind === "duration") {
+    waitMs = parseWaitDurationMs(wcfg);
+  } else if (kind === "until") {
+    untilIso = typeof wcfg.until === "string" ? wcfg.until : "";
+    const t = Date.parse(untilIso);
+    if (Number.isNaN(t)) throw new Error('wait kind "until": invalid ISO-8601 timestamp');
+    waitMs = Math.max(0, t - Date.now());
+  } else {
+    throw new Error(`wait: unsupported or missing kind "${kind ?? ""}"`);
+  }
+  appendCmd("StartTimer", {
+    nodeId,
+    kind,
+    ...(untilIso ? { until: untilIso } : { wait_ms: waitMs }),
+  });
+  appendEvt("TimerStarted", { nodeId, kind });
+  if (!scheduled.replayed && waitMs > 0) await delay(waitMs);
+  appendEvt("TimerFired", { nodeId, kind });
 }
 
 /**
@@ -158,6 +262,14 @@ function assertPocGraphEdges(nodes, outgoing) {
       if (outs.length !== 1) {
         throw new Error(
           `Node "${n.id}" (interrupt) must have exactly one outgoing edge; found ${outs.length}.`
+        );
+      }
+      continue;
+    }
+    if (n.type === "parallel" || n.type === "wait" || n.type === "set_state") {
+      if (outs.length !== 1) {
+        throw new Error(
+          `Node "${n.id}" (type "${n.type}") must have exactly one outgoing edge (successor / join target); found ${outs.length}.`
         );
       }
       continue;
@@ -323,6 +435,50 @@ export async function runPocWorkflow(options) {
     });
   }
 
+  const { executeParallelBlock } = createR2ParallelRuntime({
+    byId,
+    outgoing,
+    hooks: {
+      getState: () => state,
+      setState: (s) => {
+        state = s;
+      },
+      appendCmd,
+      appendEvt,
+      appendCheckpoint,
+      throwIfStateInvalid: (st, ctx) => throwIfStateInvalid(validateState, st, ctx),
+      stateSchema: definition.state_schema,
+      jq,
+      resolveSwitchTarget,
+      buildSetStateOutput,
+      runWaitNode: (node, scheduled) =>
+        runWaitNodeExecution(node.id, scheduled, appendCmd, appendEvt, node.config),
+      runPlaceholderActivity: async (node, scheduled, st) => {
+        const replayedOutput = scheduled.replayed ? replay.replayResults.get(node.id) : undefined;
+        if (replayedOutput) {
+          const output = JSON.parse(JSON.stringify(replayedOutput));
+          appendEvt("ActivityCompleted", { nodeId: node.id, result: output, replayed: true });
+          return { ok: /** @type {true} */ (true), output };
+        }
+        appendEvt("ActivityRequested", { nodeId: node.id, nodeType: node.type });
+        const activityResult = await executor.executeActivity({
+          executionId,
+          node: /** @type {{ id: string; type: string; config?: object }} */ (node),
+          state: st,
+        });
+        if (!activityResult.ok) {
+          return {
+            ok: /** @type {false} */ (false),
+            error: activityResult.error,
+            ...(activityResult.code !== undefined ? { code: activityResult.code } : {}),
+          };
+        }
+        appendEvt("ActivityCompleted", { nodeId: node.id, result: activityResult.output });
+        return { ok: /** @type {true} */ (true), output: activityResult.output };
+      },
+    },
+  });
+
   try {
     appendEvt("ExecutionStarted", {
       workflowName: definition.document?.name,
@@ -381,6 +537,83 @@ export async function runPocWorkflow(options) {
           nodeId: current,
           state: JSON.parse(JSON.stringify(state)),
         };
+      }
+
+      if (node.type === "parallel") {
+        const pOuts = outgoing.get(current) ?? [];
+        if (pOuts.length !== 1) {
+          throw new Error(
+            `parallel "${current}" must have exactly one outgoing edge (join target); found ${pOuts.length}.`
+          );
+        }
+        const joinTarget = pOuts[0];
+        const pr = await executeParallelBlock(
+          /** @type {{ id: string; type: string; config?: object }} */ (node),
+          joinTarget
+        );
+        if (pr.kind === "interrupt") {
+          return {
+            status: "interrupted",
+            executionId,
+            nodeId: pr.nodeId,
+            state: pr.state,
+          };
+        }
+        if (pr.kind === "failed") {
+          return { status: "failed", error: pr.error, finalState: state };
+        }
+        appendCmd("CompleteNode", { nodeId: current, output: {} });
+        const pStateSeq = appendEvt("StateUpdated", { nodeId: current, state: JSON.parse(JSON.stringify(state)) });
+        appendCheckpoint(current, state, pStateSeq);
+        throwIfStateInvalid(validateState, state, `State invalid after parallel "${current}"`);
+        current = joinTarget;
+        continue;
+      }
+
+      if (node.type === "wait") {
+        try {
+          await runWaitNodeExecution(current, scheduled, appendCmd, appendEvt, node.config);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          appendCmd("FailNode", { nodeId: current, reason: "wait_failed", message: msg });
+          appendEvt("ExecutionFailed", { error: msg });
+          return { status: "failed", error: msg, finalState: state };
+        }
+        appendCmd("CompleteNode", { nodeId: current, output: {} });
+        const wStateSeq = appendEvt("StateUpdated", { nodeId: current, state: JSON.parse(JSON.stringify(state)) });
+        appendCheckpoint(current, state, wStateSeq);
+        throwIfStateInvalid(validateState, state, `State invalid after wait "${current}"`);
+        const wNext = outgoing.get(current) ?? [];
+        if (wNext.length !== 1) {
+          throw new Error(`Node "${current}" (wait) must have exactly one outgoing edge; found ${wNext.length}.`);
+        }
+        current = wNext[0];
+        continue;
+      }
+
+      if (node.type === "set_state") {
+        let stOutput;
+        try {
+          stOutput = await buildSetStateOutput(node, state, jq);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          appendCmd("FailNode", { nodeId: current, reason: "set_state_failed", message: msg });
+          appendEvt("ExecutionFailed", { error: msg });
+          return { status: "failed", error: msg, finalState: state };
+        }
+        appendCmd("CompleteNode", { nodeId: current, output: stOutput });
+        state = /** @type {Record<string, unknown>} */ (
+          applyOutputWithReducers(state, stOutput, definition.state_schema)
+        );
+        const ssSeq = appendEvt("StateUpdated", { nodeId: current, state: JSON.parse(JSON.stringify(state)) });
+        appendCheckpoint(current, state, ssSeq);
+        throwIfStateInvalid(validateState, state, `State invalid after set_state "${current}"`);
+        const ssNext = outgoing.get(current) ?? [];
+        if (ssNext.length !== 1) {
+          throw new Error(`Node "${current}" (set_state) must have exactly one outgoing edge; found ${ssNext.length}.`);
+        }
+        current = ssNext[0];
+        continue;
       }
 
       /** @type {Record<string, unknown>} */
@@ -684,6 +917,49 @@ export async function resumePocWorkflow(options) {
     });
   }
 
+  function resumeAppendCmd(name, payload) {
+    appendCmd(name, payload);
+    return { replayed: false };
+  }
+
+  const { executeParallelBlock: resumeExecuteParallel } = createR2ParallelRuntime({
+    byId,
+    outgoing,
+    hooks: {
+      getState: () => state,
+      setState: (s) => {
+        state = s;
+      },
+      appendCmd: resumeAppendCmd,
+      appendEvt,
+      appendCheckpoint,
+      throwIfStateInvalid: (st, ctx) => throwIfStateInvalid(validateState, st, ctx),
+      stateSchema: definition.state_schema,
+      jq,
+      resolveSwitchTarget,
+      buildSetStateOutput,
+      runWaitNode: (node, scheduled) =>
+        runWaitNodeExecution(node.id, scheduled, resumeAppendCmd, appendEvt, node.config),
+      runPlaceholderActivity: async (node, _scheduled, st) => {
+        appendEvt("ActivityRequested", { nodeId: node.id, nodeType: node.type });
+        const activityResult = await executor.executeActivity({
+          executionId,
+          node: /** @type {{ id: string; type: string; config?: object }} */ (node),
+          state: st,
+        });
+        if (!activityResult.ok) {
+          return {
+            ok: /** @type {false} */ (false),
+            error: activityResult.error,
+            ...(activityResult.code !== undefined ? { code: activityResult.code } : {}),
+          };
+        }
+        appendEvt("ActivityCompleted", { nodeId: node.id, result: activityResult.output });
+        return { ok: /** @type {true} */ (true), output: activityResult.output };
+      },
+    },
+  });
+
   try {
     throwIfStateInvalid(validateState, state, "State invalid after merging resume payload");
 
@@ -747,6 +1023,83 @@ export async function resumePocWorkflow(options) {
           nodeId: current,
           state: JSON.parse(JSON.stringify(state)),
         };
+      }
+
+      if (node.type === "parallel") {
+        const pOuts = outgoing.get(current) ?? [];
+        if (pOuts.length !== 1) {
+          throw new Error(
+            `parallel "${current}" must have exactly one outgoing edge (join target); found ${pOuts.length}.`
+          );
+        }
+        const joinTarget = pOuts[0];
+        const pr = await resumeExecuteParallel(
+          /** @type {{ id: string; type: string; config?: object }} */ (node),
+          joinTarget
+        );
+        if (pr.kind === "interrupt") {
+          return {
+            status: "interrupted",
+            executionId,
+            nodeId: pr.nodeId,
+            state: pr.state,
+          };
+        }
+        if (pr.kind === "failed") {
+          return { status: "failed", error: pr.error, finalState: state };
+        }
+        appendCmd("CompleteNode", { nodeId: current, output: {} });
+        const pStateSeq = appendEvt("StateUpdated", { nodeId: current, state: JSON.parse(JSON.stringify(state)) });
+        appendCheckpoint(current, state, pStateSeq);
+        throwIfStateInvalid(validateState, state, `State invalid after parallel "${current}"`);
+        current = joinTarget;
+        continue;
+      }
+
+      if (node.type === "wait") {
+        try {
+          await runWaitNodeExecution(current, { replayed: false }, resumeAppendCmd, appendEvt, node.config);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          appendCmd("FailNode", { nodeId: current, reason: "wait_failed", message: msg });
+          appendEvt("ExecutionFailed", { error: msg });
+          return { status: "failed", error: msg, finalState: state };
+        }
+        appendCmd("CompleteNode", { nodeId: current, output: {} });
+        const wStateSeq = appendEvt("StateUpdated", { nodeId: current, state: JSON.parse(JSON.stringify(state)) });
+        appendCheckpoint(current, state, wStateSeq);
+        throwIfStateInvalid(validateState, state, `State invalid after wait "${current}"`);
+        const wNext = outgoing.get(current) ?? [];
+        if (wNext.length !== 1) {
+          throw new Error(`Node "${current}" (wait) must have exactly one outgoing edge; found ${wNext.length}.`);
+        }
+        current = wNext[0];
+        continue;
+      }
+
+      if (node.type === "set_state") {
+        let stOutput;
+        try {
+          stOutput = await buildSetStateOutput(node, state, jq);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          appendCmd("FailNode", { nodeId: current, reason: "set_state_failed", message: msg });
+          appendEvt("ExecutionFailed", { error: msg });
+          return { status: "failed", error: msg, finalState: state };
+        }
+        appendCmd("CompleteNode", { nodeId: current, output: stOutput });
+        state = /** @type {Record<string, unknown>} */ (
+          applyOutputWithReducers(state, stOutput, definition.state_schema)
+        );
+        const ssSeq = appendEvt("StateUpdated", { nodeId: current, state: JSON.parse(JSON.stringify(state)) });
+        appendCheckpoint(current, state, ssSeq);
+        throwIfStateInvalid(validateState, state, `State invalid after set_state "${current}"`);
+        const ssNext = outgoing.get(current) ?? [];
+        if (ssNext.length !== 1) {
+          throw new Error(`Node "${current}" (set_state) must have exactly one outgoing edge; found ${ssNext.length}.`);
+        }
+        current = ssNext[0];
+        continue;
       }
 
       /** @type {Record<string, unknown>} */

--- a/packages/engine/test/poc-runner-r2.test.mjs
+++ b/packages/engine/test/poc-runner-r2.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+import { MemoryExecutionHistoryStore } from "../src/persistence/memory-history-store.mjs";
+import { runPocWorkflow } from "../src/orchestrator/poc-runner.mjs";
+import { findWorkflowRepoRoot, validateWorkflowDefinition } from "../src/validate.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function loadR2ParallelFixture() {
+  const root = findWorkflowRepoRoot(__dirname);
+  const p = path.join(root, "examples", "r2-research-parallel.workflow.json");
+  return JSON.parse(readFileSync(p, "utf8"));
+}
+
+describe("runPocWorkflow (R2 parallel, wait, set_state)", () => {
+  it("runs research-style parallel join all with set_state and zero-duration wait", async () => {
+    const definition = loadR2ParallelFixture();
+    assert.equal(validateWorkflowDefinition(definition).ok, true);
+
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "exec-r2-parallel-demo";
+
+    const out = await runPocWorkflow({
+      definition,
+      input: { topic: "widgets" },
+      executionId,
+      store,
+      stubActivityOutputs: {
+        plan: {},
+        web_collect: { findings: ["web:a"] },
+        internal_collect: { findings: ["internal:b"] },
+      },
+    });
+
+    assert.equal(out.status, "completed");
+    assert.deepEqual(out.result, ["web:a", "internal:b"]);
+    assert.equal(/** @type {{ phase?: string }} */ (out.finalState).phase, "merged");
+
+    const rows = store.listByExecution(executionId);
+    assert.ok(rows.some((r) => r.kind === "command" && r.name === "StartParallel"));
+    assert.ok(rows.some((r) => r.kind === "command" && r.name === "JoinParallel"));
+    assert.ok(rows.some((r) => r.kind === "event" && r.name === "TimerFired"));
+    assert.ok(rows.some((r) => r.kind === "event" && r.name === "ParallelJoined"));
+  });
+});

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -2,7 +2,7 @@
 
 Machine-readable contract for the **POC workflow definition** subset. Human-readable scope and semantics:
 
-- [docs/poc-scope.md](../docs/poc-scope.md) — what is in/out of scope for the first engine milestone
+- [docs/poc-scope.md](../docs/poc-scope.md) — engine profile (POC + R2: `parallel`, `wait`, `set_state`)
 - [docs/RFC/rfc-03-workflow-definition-schema.md](../docs/RFC/rfc-03-workflow-definition-schema.md) — normative protocol text
 
 ## Entry schema
@@ -17,7 +17,7 @@ Machine-readable contract for the **POC workflow definition** subset. Human-read
 
 - Stable **`$id`** on the entry schema for tooling, documentation links, and future registry publication.
 - **`additionalProperties: false`** on the workflow root rejects top-level fields not in the POC surface (including **`extensions`**, which is out of scope per [docs/poc-scope.md](../docs/poc-scope.md)).
-- **`oneOf` node discriminated union** rejects unknown `type` values (e.g. `parallel`, `wait`) until the scope note is expanded.
+- **`oneOf` node discriminated union** rejects unknown `type` values (e.g. `subworkflow`, `agent_delegate` until promoted).
 
 **Limits:** `state_schema` is validated as a non-empty object only; nested `reducer: custom` is called out in the schema description as needing extra checks if you require it. Unique `nodes[].id` values are not expressible in JSON Schema alone—enforce in the engine or a small custom lint.
 

--- a/schemas/workflow-definition-poc.json
+++ b/schemas/workflow-definition-poc.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://example.org/agent-workflow/poc/v1/workflow-definition",
-  "title": "Agent Workflow Protocol — POC workflow definition",
-  "description": "JSON Schema for the POC subset defined in docs/poc-scope.md. Normative semantics: docs/RFC/rfc-03-workflow-definition-schema.md.",
+  "title": "Agent Workflow Protocol — POC workflow definition (R2 core orchestration)",
+  "description": "JSON Schema for the profile defined in docs/poc-scope.md (POC + R2: parallel, wait, set_state). Normative semantics: docs/RFC/rfc-03-workflow-definition-schema.md.",
   "type": "object",
   "additionalProperties": false,
   "required": ["document", "state_schema", "nodes", "edges"],
@@ -94,7 +94,10 @@
         { "$ref": "#/$defs/node_llm_call" },
         { "$ref": "#/$defs/node_tool_call" },
         { "$ref": "#/$defs/node_switch" },
-        { "$ref": "#/$defs/node_interrupt" }
+        { "$ref": "#/$defs/node_interrupt" },
+        { "$ref": "#/$defs/node_parallel" },
+        { "$ref": "#/$defs/node_wait" },
+        { "$ref": "#/$defs/node_set_state" }
       ]
     },
     "node_start": {
@@ -262,6 +265,152 @@
             { "required": ["prompt"] },
             { "required": ["prompt_ref"] }
           ]
+        },
+        "retry": { "$ref": "#/$defs/retry_policy" },
+        "timeout": { "$ref": "#/$defs/node_level_timeout" },
+        "metadata": { "$ref": "#/$defs/node_level_metadata" }
+      }
+    },
+    "node_parallel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "config"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "type": { "const": "parallel" },
+        "config": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["join", "branches"],
+          "properties": {
+            "join": {
+              "type": "string",
+              "enum": ["all", "any", "n_of_m"]
+            },
+            "n": { "type": "integer", "minimum": 1 },
+            "branches": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["name", "entry"],
+                "properties": {
+                  "name": { "type": "string", "minLength": 1 },
+                  "entry": { "type": "string", "minLength": 1 }
+                }
+              }
+            },
+            "timeout": { "$ref": "#/$defs/node_level_timeout" }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": { "join": { "const": "n_of_m" } },
+                "required": ["join"]
+              },
+              "then": { "required": ["n"] }
+            }
+          ]
+        },
+        "retry": { "$ref": "#/$defs/retry_policy" },
+        "timeout": { "$ref": "#/$defs/node_level_timeout" },
+        "metadata": { "$ref": "#/$defs/node_level_metadata" }
+      }
+    },
+    "node_wait": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "config"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "type": { "const": "wait" },
+        "config": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind"],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": ["duration", "until", "signal"]
+            },
+            "duration_ms": { "type": "integer", "minimum": 0 },
+            "duration": { "type": "string", "minLength": 1 },
+            "until": { "type": "string", "minLength": 1 },
+            "signal": { "type": "string", "minLength": 1 }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": { "kind": { "const": "duration" } },
+                "required": ["kind"]
+              },
+              "then": {
+                "anyOf": [{ "required": ["duration_ms"] }, { "required": ["duration"] }]
+              }
+            },
+            {
+              "if": {
+                "properties": { "kind": { "const": "until" } },
+                "required": ["kind"]
+              },
+              "then": { "required": ["until"] }
+            },
+            {
+              "if": {
+                "properties": { "kind": { "const": "signal" } },
+                "required": ["kind"]
+              },
+              "then": { "required": ["signal"] }
+            }
+          ]
+        },
+        "retry": { "$ref": "#/$defs/retry_policy" },
+        "timeout": { "$ref": "#/$defs/node_level_timeout" },
+        "metadata": { "$ref": "#/$defs/node_level_metadata" }
+      }
+    },
+    "node_set_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "config"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "type": { "const": "set_state" },
+        "config": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["assignments"],
+          "properties": {
+            "assignments": {
+              "type": "object",
+              "minProperties": 1,
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["jq"],
+                    "properties": {
+                      "jq": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "jq expression evaluated against current state; result merged per state_schema reducers."
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["literal"],
+                    "properties": {
+                      "literal": true
+                    }
+                  }
+                ]
+              }
+            }
+          }
         },
         "retry": { "$ref": "#/$defs/retry_policy" },
         "timeout": { "$ref": "#/$defs/node_level_timeout" },


### PR DESCRIPTION
## What changed

- Extended \schemas/workflow-definition-poc.json\ (synced to engine package) with \parallel\, \wait\, and \set_state\ node shapes.
- **Parallel:** \config.branches\ = \{ name, entry }\ per branch; exactly one static edge from the parallel node to the **join target**; each branch walks to that target. Join policies \ll\, \ny\, \
_of_m\ (with \
\); branches run in **declaration order**; \ny\ / satisfied \
_of_m\ emit \CancelParallelBranch\ for skipped tails (deterministic cancellation).
- **Wait:** \StartTimer\ + \TimerStarted\ / \TimerFired\; \duration\ (\duration_ms\ or suffixed string); \until\ (ISO-8601); \signal\ errors at runtime (host not implemented).
- **set_state:** \ssignments\ map with \{ jq }\ or \{ literal }\; merges via existing reducers.
- **Resume path** wires the same node types (parallel runtime uses non-replay append helpers).
- **Docs/fixtures:** \docs/poc-scope.md\, \examples/r2-research-parallel.workflow.json\, conformance \schema.valid.r2-research-parallel\; invalid \unsupported-node-type\ fixture now uses \subworkflow\.

## Why

Closes **[#2](https://github.com/benvdbergh/workflows/issues/2)** (R2 feature slice) for epic **[#1](https://github.com/benvdbergh/workflows/issues/1)**.

## Validation

- [x] \
pm run validate-workflows\
- [x] \
pm run conformance\
- [x] \
pm test\

Closes #2

Made with [Cursor](https://cursor.com)