### PR TITLE
feat: R2 replay determinism and checkpoint hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ MCP tools exposed: `workflow_start`, `workflow_status`, `workflow_resume`. Opera
 
 ## Key architectural decisions
 
-**POC scope is intentionally narrow.** `docs/poc-scope.md` freezes the surface the first engine must honor. Supported node types: `start`, `end`, `step`, `llm_call`, `tool_call`, `switch`, `interrupt`. Explicitly out of scope: `parallel`, `agent_delegate`, `subworkflow`, `wait`, `set_state`. The schema enforces this via a `oneOf` discriminated union that rejects unknown `type` values.
+**Engine profile (POC + R2).** `docs/poc-scope.md` freezes the surface the reference engine must honor. Supported node types: `start`, `end`, `step`, `llm_call`, `tool_call`, `switch`, `interrupt`, plus R2 `parallel`, `wait`, and `set_state`. Explicitly out of scope for this profile: `agent_delegate`, `subworkflow`. The schema enforces allowed `type` values via a `oneOf` discriminated union that rejects unknown `type` values.
 
 **JSON Schema `additionalProperties: false`** on the workflow root means adding top-level fields (e.g. `extensions`) will fail validation by design.
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ scripts/           # validate-workflows.mjs (AJV, CI-aligned)
 
 ## POC schema and validation
 
-The [`schemas/`](schemas/) directory contains the **POC JSON Schema bundle** (Draft 2020-12) covering the first engine milestone subset. See [`docs/poc-scope.md`](docs/poc-scope.md) for exactly which node types, commands, events, and reducers are in scope for this milestone — notably, `parallel`, `agent_delegate`, `subworkflow`, `wait`, and `set_state` are deferred.
+The [`schemas/`](schemas/) directory contains the **workflow JSON Schema bundle** (Draft 2020-12) for the profile in [`docs/poc-scope.md`](docs/poc-scope.md) (POC nodes plus R2 `parallel`, `wait`, and `set_state`). `agent_delegate` and `subworkflow` remain out of scope until R3.
 
 Validate all golden fixtures locally (Node.js 20+). **CI** uses Node.js **24** with `actions/checkout@v5` and `actions/setup-node@v5` per [GitHub’s Node 20 deprecation on runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -126,9 +126,9 @@ The matrix below maps RFC-08 section `8.2 Conformance tests` areas to the curren
 | RFC-08 conformance area | Status | Evidence |
 |---|---|---|
 | Schema validation (valid/invalid fixtures) | Implemented | `conformance/vectors/schema/valid/*.vector.json`, `conformance/vectors/schema/invalid/*.vector.json` |
-| Replay (inject history, deterministic tail stream) | Implemented | `conformance/vectors/replay/prefix-tail/*.vector.json`, including lighthouse happy path `conformance/vectors/replay/prefix-tail/lighthouse-prefix-tail-technical.vector.json`; mismatch diagnostics in `conformance/vectors/replay/mismatch/*.vector.json` |
-| Reducers (append/merge/overwrite matrices) | Deferred | Out of active POC execution scope; no reducer matrix vectors yet |
-| Parallel joins (`all`, `any`, `n_of_m`) | Deferred | `parallel` execution is out of active POC scope |
+| Replay (inject history, deterministic tail stream) | Implemented | Prefix/tail vectors under `conformance/vectors/replay/prefix-tail/` (lighthouse, R2 `join all` / `any` / `n_of_m`); mismatch diagnostics in `conformance/vectors/replay/mismatch/` (lighthouse route + R2 parallel branch order) |
+| Reducers (append/merge/overwrite matrices) | Deferred | No dedicated reducer matrix vectors yet (behavior covered indirectly by fixtures) |
+| Parallel joins (`all`, `any`, `n_of_m`) | Partial | R2 reference engine implements join policies; harness covers deterministic replay through a parallel fork/join tail (`r2-research-prefix-after-plan`); dedicated join-policy matrix vectors still deferred |
 | Interrupt resume (validation failure vs success) | Partial | Replay vectors exercise resume cursor behavior; lighthouse happy-path coverage is active, while dedicated interrupt resume conformance vectors are still deferred |
 | MCP tool mapping roundtrip (mock server) | Deferred | MCP adapter conformance vectors not yet implemented in harness |
 
@@ -137,7 +137,7 @@ The matrix below maps RFC-08 section `8.2 Conformance tests` areas to the curren
 | Area | Current decision | Rationale | Re-entry trigger |
 |---|---|---|---|
 | Reducer conformance matrix | Deferred | Active POC profile prioritizes schema + replay coverage and does not include reducer behavior conformance vectors yet | EPIC/story that introduces reducer semantics into active execution profile (`append`, `merge`, `overwrite`) |
-| Parallel join conformance | Deferred | `parallel` node execution is explicitly outside active POC scope | Scope update that enables `parallel` in `docs/poc-scope.md` plus engine support |
+| Parallel join conformance (full matrix) | Deferred | Join policies are implemented in-engine; harness lacks explicit `all` / `any` / `n_of_m` matrix vectors | Story adds replay/schema vectors per join policy and failure modes |
 | Interrupt resume conformance (dedicated vectors) | Deferred (currently partial) | Existing replay vectors validate deterministic continuation mechanics and protect lighthouse happy path, but not explicit interrupt-resume success/failure matrix cases | Story adds interrupt pause/resume fixture set with both schema-valid and schema-invalid resume payload cases |
 | MCP tool mapping roundtrip conformance | Deferred | Harness currently runs in-process vectors and does not yet include MCP mock-server roundtrip assertions | EPIC-4 MCP stdio integration reaches testable parity and adds stable mock-server test harness |
 

--- a/conformance/vectors/replay/mismatch/r2-parallel-branch-order-mismatch.vector.json
+++ b/conformance/vectors/replay/mismatch/r2-parallel-branch-order-mismatch.vector.json
@@ -1,0 +1,114 @@
+{
+  "id": "replay.mismatch.r2.parallel.branch_order",
+  "description": "Adversarial prefix schedules the second parallel branch first; deterministic replay expects the first branch per branch array order.",
+  "kind": "replay",
+  "definition": "examples/r2-research-parallel.workflow.json",
+  "input": { "topic": "t" },
+  "historyPrefix": [
+    {
+      "kind": "event",
+      "name": "ExecutionStarted",
+      "payload": {
+        "workflowName": "r2-research-parallel-demo",
+        "workflowVersion": "1.0.0",
+        "inputKeys": ["topic"]
+      }
+    },
+    {
+      "kind": "command",
+      "name": "ScheduleNode",
+      "payload": { "nodeId": "start" }
+    },
+    {
+      "kind": "event",
+      "name": "NodeScheduled",
+      "payload": { "nodeId": "start" }
+    },
+    {
+      "kind": "command",
+      "name": "CompleteNode",
+      "payload": { "nodeId": "start", "output": {} }
+    },
+    {
+      "kind": "event",
+      "name": "StateUpdated",
+      "payload": { "nodeId": "start", "state": { "topic": "t" } }
+    },
+    {
+      "kind": "command",
+      "name": "ScheduleNode",
+      "payload": { "nodeId": "plan" }
+    },
+    {
+      "kind": "event",
+      "name": "NodeScheduled",
+      "payload": { "nodeId": "plan" }
+    },
+    {
+      "kind": "event",
+      "name": "ActivityRequested",
+      "payload": { "nodeId": "plan", "nodeType": "llm_call" }
+    },
+    {
+      "kind": "event",
+      "name": "ActivityCompleted",
+      "payload": { "nodeId": "plan", "result": {} }
+    },
+    {
+      "kind": "command",
+      "name": "CompleteNode",
+      "payload": { "nodeId": "plan", "output": {} }
+    },
+    {
+      "kind": "event",
+      "name": "StateUpdated",
+      "payload": { "nodeId": "plan", "state": { "topic": "t" } }
+    },
+    {
+      "kind": "command",
+      "name": "ScheduleNode",
+      "payload": { "nodeId": "research" }
+    },
+    {
+      "kind": "event",
+      "name": "NodeScheduled",
+      "payload": { "nodeId": "research" }
+    },
+    {
+      "kind": "command",
+      "name": "StartParallel",
+      "payload": {
+        "nodeId": "research",
+        "join": "all",
+        "branchNames": ["web", "internal"]
+      }
+    },
+    {
+      "kind": "event",
+      "name": "ParallelForked",
+      "payload": {
+        "nodeId": "research",
+        "join": "all",
+        "branchNames": ["web", "internal"]
+      }
+    },
+    {
+      "kind": "command",
+      "name": "ScheduleNode",
+      "payload": { "nodeId": "internal_collect" }
+    },
+    {
+      "kind": "event",
+      "name": "NodeScheduled",
+      "payload": { "nodeId": "internal_collect" }
+    }
+  ],
+  "expect": {
+    "status": "failed",
+    "mismatch": {
+      "messageIncludes": "command index 7",
+      "expected": { "name": "ScheduleNode", "nodeId": "internal_collect" },
+      "actual": { "name": "ScheduleNode", "nodeId": "web_collect" }
+    }
+  }
+}

--- a/conformance/vectors/replay/prefix-tail/r2-parallel-any-prefix-after-plan.vector.json
+++ b/conformance/vectors/replay/prefix-tail/r2-parallel-any-prefix-after-plan.vector.json
@@ -1,0 +1,85 @@
+{
+  "id": "replay.prefix.tail.r2.parallel.any.after_plan",
+  "description": "join=any: prefix through plan, tail includes CancelParallelBranch after first successful branch.",
+  "kind": "replay",
+  "definition": "examples/r2-parallel-join-any.workflow.json",
+  "input": { "topic": "t" },
+  "historyPrefix": [
+    {
+      "kind": "event",
+      "name": "ExecutionStarted",
+      "payload": {
+        "workflowName": "r2-parallel-join-any",
+        "workflowVersion": "1.0.0",
+        "inputKeys": ["topic"]
+      }
+    },
+    {
+      "kind": "command",
+      "name": "ScheduleNode",
+      "payload": { "nodeId": "start" }
+    },
+    {
+      "kind": "event",
+      "name": "NodeScheduled",
+      "payload": { "nodeId": "start" }
+    },
+    {
+      "kind": "command",
+      "name": "CompleteNode",
+      "payload": { "nodeId": "start", "output": {} }
+    },
+    {
+      "kind": "event",
+      "name": "StateUpdated",
+      "payload": { "nodeId": "start", "state": { "topic": "t" } }
+    },
+    {
+      "kind": "command",
+      "name": "ScheduleNode",
+      "payload": { "nodeId": "plan" }
+    },
+    {
+      "kind": "event",
+      "name": "NodeScheduled",
+      "payload": { "nodeId": "plan" }
+    },
+    {
+      "kind": "event",
+      "name": "ActivityRequested",
+      "payload": { "nodeId": "plan", "nodeType": "llm_call" }
+    },
+    {
+      "kind": "event",
+      "name": "ActivityCompleted",
+      "payload": { "nodeId": "plan", "result": {} }
+    },
+    {
+      "kind": "command",
+      "name": "CompleteNode",
+      "payload": { "nodeId": "plan", "output": {} }
+    },
+    {
+      "kind": "event",
+      "name": "StateUpdated",
+      "payload": { "nodeId": "plan", "state": { "topic": "t" } }
+    }
+  ],
+  "expect": {
+    "status": "completed",
+    "tailCommands": [
+      { "name": "ScheduleNode", "nodeId": "research" },
+      { "name": "StartParallel", "nodeId": "research" },
+      { "name": "ScheduleNode", "nodeId": "web_collect" },
+      { "name": "CompleteNode", "nodeId": "web_collect" },
+      { "name": "CancelParallelBranch", "nodeId": "research" },
+      { "name": "JoinParallel", "nodeId": "research" },
+      { "name": "CompleteNode", "nodeId": "research" },
+      { "name": "ScheduleNode", "nodeId": "rest" },
+      { "name": "StartTimer", "nodeId": "rest" },
+      { "name": "CompleteNode", "nodeId": "rest" },
+      { "name": "ScheduleNode", "nodeId": "end" },
+      { "name": "CompleteNode", "nodeId": "end" }
+    ]
+  }
+}

--- a/conformance/vectors/replay/prefix-tail/r2-parallel-n2-prefix-after-start.vector.json
+++ b/conformance/vectors/replay/prefix-tail/r2-parallel-n2-prefix-after-start.vector.json
@@ -1,0 +1,57 @@
+{
+  "id": "replay.prefix.tail.r2.parallel.n2.after_start",
+  "description": "join=n_of_m (n=2) with 3 branches: only two branches run before cancel + join.",
+  "kind": "replay",
+  "definition": "examples/r2-parallel-join-n2-of-3.workflow.json",
+  "input": {},
+  "historyPrefix": [
+    {
+      "kind": "event",
+      "name": "ExecutionStarted",
+      "payload": {
+        "workflowName": "r2-parallel-join-n2-of-3",
+        "workflowVersion": "1.0.0",
+        "inputKeys": []
+      }
+    },
+    {
+      "kind": "command",
+      "name": "ScheduleNode",
+      "payload": { "nodeId": "start" }
+    },
+    {
+      "kind": "event",
+      "name": "NodeScheduled",
+      "payload": { "nodeId": "start" }
+    },
+    {
+      "kind": "command",
+      "name": "CompleteNode",
+      "payload": { "nodeId": "start", "output": {} }
+    },
+    {
+      "kind": "event",
+      "name": "StateUpdated",
+      "payload": { "nodeId": "start", "state": {} }
+    }
+  ],
+  "expect": {
+    "status": "completed",
+    "tailCommands": [
+      { "name": "ScheduleNode", "nodeId": "fanout" },
+      { "name": "StartParallel", "nodeId": "fanout" },
+      { "name": "ScheduleNode", "nodeId": "collect_a" },
+      { "name": "CompleteNode", "nodeId": "collect_a" },
+      { "name": "ScheduleNode", "nodeId": "collect_b" },
+      { "name": "CompleteNode", "nodeId": "collect_b" },
+      { "name": "CancelParallelBranch", "nodeId": "fanout" },
+      { "name": "JoinParallel", "nodeId": "fanout" },
+      { "name": "CompleteNode", "nodeId": "fanout" },
+      { "name": "ScheduleNode", "nodeId": "rest" },
+      { "name": "StartTimer", "nodeId": "rest" },
+      { "name": "CompleteNode", "nodeId": "rest" },
+      { "name": "ScheduleNode", "nodeId": "end" },
+      { "name": "CompleteNode", "nodeId": "end" }
+    ]
+  }
+}

--- a/conformance/vectors/replay/prefix-tail/r2-research-prefix-after-plan.vector.json
+++ b/conformance/vectors/replay/prefix-tail/r2-research-prefix-after-plan.vector.json
@@ -1,0 +1,120 @@
+{
+  "id": "replay.prefix.tail.r2.research.after_plan",
+  "description": "R2 parallel fixture: replay prefix through plan completion, then fork/join, set_state, wait, and end.",
+  "kind": "replay",
+  "definition": "examples/r2-research-parallel.workflow.json",
+  "input": {
+    "topic": "t"
+  },
+  "historyPrefix": [
+    {
+      "kind": "event",
+      "name": "ExecutionStarted",
+      "payload": {
+        "workflowName": "r2-research-parallel-demo",
+        "workflowVersion": "1.0.0",
+        "inputKeys": ["topic"]
+      }
+    },
+    {
+      "kind": "command",
+      "name": "ScheduleNode",
+      "payload": {
+        "nodeId": "start"
+      }
+    },
+    {
+      "kind": "event",
+      "name": "NodeScheduled",
+      "payload": {
+        "nodeId": "start"
+      }
+    },
+    {
+      "kind": "command",
+      "name": "CompleteNode",
+      "payload": {
+        "nodeId": "start",
+        "output": {}
+      }
+    },
+    {
+      "kind": "event",
+      "name": "StateUpdated",
+      "payload": {
+        "nodeId": "start",
+        "state": {
+          "topic": "t"
+        }
+      }
+    },
+    {
+      "kind": "command",
+      "name": "ScheduleNode",
+      "payload": {
+        "nodeId": "plan"
+      }
+    },
+    {
+      "kind": "event",
+      "name": "NodeScheduled",
+      "payload": {
+        "nodeId": "plan"
+      }
+    },
+    {
+      "kind": "event",
+      "name": "ActivityRequested",
+      "payload": {
+        "nodeId": "plan",
+        "nodeType": "llm_call"
+      }
+    },
+    {
+      "kind": "event",
+      "name": "ActivityCompleted",
+      "payload": {
+        "nodeId": "plan",
+        "result": {}
+      }
+    },
+    {
+      "kind": "command",
+      "name": "CompleteNode",
+      "payload": {
+        "nodeId": "plan",
+        "output": {}
+      }
+    },
+    {
+      "kind": "event",
+      "name": "StateUpdated",
+      "payload": {
+        "nodeId": "plan",
+        "state": {
+          "topic": "t"
+        }
+      }
+    }
+  ],
+  "expect": {
+    "status": "completed",
+    "tailCommands": [
+      { "name": "ScheduleNode", "nodeId": "research" },
+      { "name": "StartParallel", "nodeId": "research" },
+      { "name": "ScheduleNode", "nodeId": "web_collect" },
+      { "name": "CompleteNode", "nodeId": "web_collect" },
+      { "name": "ScheduleNode", "nodeId": "internal_collect" },
+      { "name": "CompleteNode", "nodeId": "internal_collect" },
+      { "name": "JoinParallel", "nodeId": "research" },
+      { "name": "CompleteNode", "nodeId": "research" },
+      { "name": "ScheduleNode", "nodeId": "tag" },
+      { "name": "CompleteNode", "nodeId": "tag" },
+      { "name": "ScheduleNode", "nodeId": "rest" },
+      { "name": "StartTimer", "nodeId": "rest" },
+      { "name": "CompleteNode", "nodeId": "rest" },
+      { "name": "ScheduleNode", "nodeId": "end" },
+      { "name": "CompleteNode", "nodeId": "end" }
+    ]
+  }
+}

--- a/conformance/vectors/schema/valid/r2-parallel-join-any.vector.json
+++ b/conformance/vectors/schema/valid/r2-parallel-join-any.vector.json
@@ -1,0 +1,7 @@
+{
+  "id": "schema.valid.r2-parallel-join-any",
+  "description": "R2 profile: parallel join any validates.",
+  "kind": "schema",
+  "definition": "examples/r2-parallel-join-any.workflow.json",
+  "expect": { "ok": true }
+}

--- a/conformance/vectors/schema/valid/r2-parallel-join-n2-of-3.vector.json
+++ b/conformance/vectors/schema/valid/r2-parallel-join-n2-of-3.vector.json
@@ -1,0 +1,7 @@
+{
+  "id": "schema.valid.r2-parallel-join-n2-of-3",
+  "description": "R2 profile: parallel n_of_m validates.",
+  "kind": "schema",
+  "definition": "examples/r2-parallel-join-n2-of-3.workflow.json",
+  "expect": { "ok": true }
+}

--- a/docs/architecture/as-is-system-overview.md
+++ b/docs/architecture/as-is-system-overview.md
@@ -182,10 +182,11 @@ Physical/runtime perspectives shown:
 - Stable adapter boundary (`createWorkflowApplicationPort`) reducing coupling.
 - Explicit conformance harness as part of the delivery contract.
 - Practical local/operator split for MCP deployment model.
+- Checkpoints after R2 parallel branch steps carry a **`parallelSpan`** correlation object (parallel node id, join target, branch name, branch entry) alongside inline state snapshots.
 
 ## Known gaps and intentional limitations
 
-- Active runtime does not yet implement deferred node families (`parallel`, `wait`, `set_state`, delegation/subworkflow).
+- Active runtime implements R2 core nodes (`parallel`, `wait`, `set_state`) in the reference engine; `agent_delegate` and `subworkflow` remain deferred (R3+).
 - Conformance coverage is not yet full RFC-08 breadth.
 - Security hardening posture is intentionally POC-level for local stdio scenarios.
 - Multi-surface parity (REST/SDK breadth) is roadmap scope, not as-is baseline.
@@ -203,7 +204,7 @@ Use this as-is baseline to derive versioned viewpoints:
 
 Start ADRs from real tension points observed in this baseline:
 
-- Node coverage expansion strategy (`parallel`/`wait`/`set_state`) without replay regressions.
+- Node coverage expansion strategy (R3 delegation/subworkflow, richer join/timer matrices) without replay regressions.
 - Checkpointing and replay guarantees versus performance/cost.
 - Adapter surface parity strategy (MCP first, REST/SDK sequencing).
 - Contract versioning and compatibility gates for GA stabilization.

--- a/docs/poc-scope.md
+++ b/docs/poc-scope.md
@@ -106,7 +106,9 @@ After reducer application, engines **SHOULD** validate state against `state_sche
 ## 5. Retry, timeout, checkpointing
 
 - **Retry and timeout** on nodes follow [RFC-03 §3.8](rfc-03-workflow-definition-schema.md#38-retry-and-timeout); POC **MUST** accept at least `retry.max_attempts` (≥ 1) and common duration forms the engine documents.
-- **Checkpointing** ([RFC-03 §3.9](rfc-03-workflow-definition-schema.md#39-checkpointing-block), [RFC-04 §4.10](rfc-04-execution-model.md#410-checkpointing)) — optional for the earliest runnable milestone; when not implemented, engines **MUST** document that limitation while still accepting definitions that include `checkpointing` if listed as allowed above.
+- **Checkpointing** ([RFC-03 §3.9](rfc-03-workflow-definition-schema.md#39-checkpointing-block), [RFC-04 §4.10](rfc-04-execution-model.md#410-checkpointing)) — the reference engine emits `CheckpointWritten` after selected node boundaries (switch completion, interrupt raised, parallel join, wait, `set_state`, and post-resume steps). The optional top-level `checkpointing` object **MAY** set execution policy:
+  - `strategy` (or alias `policy`): `after_each_node` (default when omitted or when `checkpointing` is absent), `every_n_nodes` (requires integer `n` ≥ 1), or `disabled` (no checkpoints).
+  - For `every_n_nodes`, checkpoint emission uses the same boundary points as `after_each_node`, but only every *n*th opportunity (deterministic ordering of boundaries as implemented by the engine).
 
 ---
 
@@ -138,7 +140,7 @@ The full taxonomies are [RFC-04 §4.4](rfc-04-execution-model.md#44-command-taxo
 
 **Events — optional / phased**
 
-- `CheckpointWritten` — required once checkpointing is claimed as supported ([RFC-04 §4.10](rfc-04-execution-model.md#410-checkpointing)).
+- `CheckpointWritten` — emitted when checkpointing is not `disabled`; payload `policy` is `after_each_node` or `every_n_nodes` (with `intervalNodes` when interval policy is used). Checkpoints taken **inside a parallel branch** (per-branch walk before the join target) include **`parallelSpan`**: `{ parallelNodeId, joinTargetId, branchName, branchEntryNodeId }` so readers can correlate inline `stateRef` with fork/join context ([RFC-04 §4.10](rfc-04-execution-model.md#410-checkpointing)).
 
 **Out of scope (deferred)**
 

--- a/examples/r2-parallel-join-any.workflow.json
+++ b/examples/r2-parallel-join-any.workflow.json
@@ -1,0 +1,66 @@
+{
+  "document": {
+    "schema": "https://example.org/agent-workflow/poc/v1/workflow-definition",
+    "name": "r2-parallel-join-any",
+    "version": "1.0.0"
+  },
+  "state_schema": {
+    "type": "object",
+    "properties": {
+      "topic": { "type": "string" },
+      "findings": {
+        "type": "array",
+        "items": { "type": "string" },
+        "reducer": "append"
+      }
+    }
+  },
+  "nodes": [
+    { "id": "start", "type": "start" },
+    {
+      "id": "plan",
+      "type": "llm_call",
+      "config": { "model": "stub", "prompt": "Plan" }
+    },
+    {
+      "id": "research",
+      "type": "parallel",
+      "config": {
+        "join": "any",
+        "branches": [
+          { "name": "web", "entry": "web_collect" },
+          { "name": "internal", "entry": "internal_collect" }
+        ]
+      }
+    },
+    {
+      "id": "web_collect",
+      "type": "tool_call",
+      "config": { "server": "demo-mcp", "tool": "web.search", "arguments": {} }
+    },
+    {
+      "id": "internal_collect",
+      "type": "tool_call",
+      "config": { "server": "demo-mcp", "tool": "kb.search", "arguments": {} }
+    },
+    {
+      "id": "rest",
+      "type": "wait",
+      "config": { "kind": "duration", "duration_ms": 0 }
+    },
+    {
+      "id": "end",
+      "type": "end",
+      "config": { "output_mapping": ".findings" }
+    }
+  ],
+  "edges": [
+    { "source": "__start__", "target": "start" },
+    { "source": "start", "target": "plan" },
+    { "source": "plan", "target": "research" },
+    { "source": "research", "target": "rest" },
+    { "source": "web_collect", "target": "rest" },
+    { "source": "internal_collect", "target": "rest" },
+    { "source": "rest", "target": "end" }
+  ]
+}

--- a/examples/r2-parallel-join-n2-of-3.workflow.json
+++ b/examples/r2-parallel-join-n2-of-3.workflow.json
@@ -1,0 +1,67 @@
+{
+  "document": {
+    "schema": "https://example.org/agent-workflow/poc/v1/workflow-definition",
+    "name": "r2-parallel-join-n2-of-3",
+    "version": "1.0.0"
+  },
+  "state_schema": {
+    "type": "object",
+    "properties": {
+      "findings": {
+        "type": "array",
+        "items": { "type": "string" },
+        "reducer": "append"
+      }
+    }
+  },
+  "nodes": [
+    { "id": "start", "type": "start" },
+    {
+      "id": "fanout",
+      "type": "parallel",
+      "config": {
+        "join": "n_of_m",
+        "n": 2,
+        "branches": [
+          { "name": "a", "entry": "collect_a" },
+          { "name": "b", "entry": "collect_b" },
+          { "name": "c", "entry": "collect_c" }
+        ]
+      }
+    },
+    {
+      "id": "collect_a",
+      "type": "tool_call",
+      "config": { "server": "demo-mcp", "tool": "a", "arguments": {} }
+    },
+    {
+      "id": "collect_b",
+      "type": "tool_call",
+      "config": { "server": "demo-mcp", "tool": "b", "arguments": {} }
+    },
+    {
+      "id": "collect_c",
+      "type": "tool_call",
+      "config": { "server": "demo-mcp", "tool": "c", "arguments": {} }
+    },
+    {
+      "id": "rest",
+      "type": "wait",
+      "config": { "kind": "duration", "duration_ms": 0 }
+    },
+    {
+      "id": "end",
+      "type": "end",
+      "config": { "output_mapping": ".findings" }
+    }
+  ],
+  "edges": [
+    { "source": "__start__", "target": "start" },
+    { "source": "start", "target": "fanout" },
+    { "source": "fanout", "target": "rest" },
+    { "source": "collect_a", "target": "rest" },
+    { "source": "collect_b", "target": "rest" },
+    { "source": "collect_c", "target": "rest" },
+    { "source": "rest", "target": "end" }
+  ]
+}

--- a/packages/engine/schemas/workflow-definition-poc.json
+++ b/packages/engine/schemas/workflow-definition-poc.json
@@ -20,8 +20,28 @@
     },
     "checkpointing": {
       "type": "object",
-      "description": "Optional checkpoint policy per RFC-03 §3.9; engines may implement later.",
-      "additionalProperties": true
+      "description": "Optional checkpoint policy per RFC-03 §3.9; reference engine honors strategy/n (see docs/poc-scope.md §5).",
+      "additionalProperties": true,
+      "properties": {
+        "strategy": {
+          "type": "string",
+          "description": "after_each_node (default), every_n_nodes, or disabled."
+        },
+        "policy": {
+          "type": "string",
+          "description": "Alias of strategy for document authors."
+        },
+        "n": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Required when strategy/policy is every_n_nodes."
+        },
+        "interval": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Alias of n for every_n_nodes."
+        }
+      }
     }
   },
   "$defs": {

--- a/packages/engine/src/orchestrator/poc-runner-r2-parallel.mjs
+++ b/packages/engine/src/orchestrator/poc-runner-r2-parallel.mjs
@@ -15,7 +15,7 @@ import { applyOutputWithReducers } from "./linear-runner.mjs";
  * @property {(s: Record<string, unknown>) => void} setState
  * @property {(name: string, payload: Record<string, unknown>) => { replayed: boolean }} appendCmd
  * @property {(name: string, payload: Record<string, unknown>) => number} appendEvt
- * @property {(nodeId: string, stateSnapshot: Record<string, unknown>, lastAppliedEventSeq: number) => void} appendCheckpoint
+ * @property {(nodeId: string, stateSnapshot: Record<string, unknown>, lastAppliedEventSeq: number, parallelSpan?: Record<string, unknown>) => void} appendCheckpoint
  * @property {(node: { id: string; type: string; config?: object }, state: Record<string, unknown>, jq: { json: (data: unknown, query: string) => Promise<unknown> }) => Promise<string>} resolveSwitchTarget
  * @property {(node: { id: string; type: string; config?: object }, state: Record<string, unknown>, jq: { json: (data: unknown, query: string) => Promise<unknown> }) => Promise<Record<string, unknown>>} buildSetStateOutput
  * @property {(node: { id: string; type: string; config?: object }, scheduled: { replayed: boolean }, state: Record<string, unknown>) => Promise<{ ok: true; output: Record<string, unknown> } | { ok: false; error: string; code?: string }>} runPlaceholderActivity
@@ -38,9 +38,16 @@ export function createR2ParallelRuntime(params) {
   /**
    * @param {string} nodeId
    * @param {string} joinTargetId
+   * @param {{ parallelNodeId: string; joinTargetId: string; branchName: string; branchEntryNodeId: string }} branchCtx
    * @returns {Promise<{ kind: 'ok' } | { kind: 'failed'; error: string } | { kind: 'interrupt'; nodeId: string; state: Record<string, unknown> }>}
    */
-  async function runBranchToJoin(nodeId, joinTargetId) {
+  async function runBranchToJoin(nodeId, joinTargetId, branchCtx) {
+    const parallelSpan = {
+      parallelNodeId: branchCtx.parallelNodeId,
+      joinTargetId: branchCtx.joinTargetId,
+      branchName: branchCtx.branchName,
+      branchEntryNodeId: branchCtx.branchEntryNodeId,
+    };
     let cur = nodeId;
     while (cur !== joinTargetId) {
       const node = byId.get(cur);
@@ -76,7 +83,7 @@ export function createR2ParallelRuntime(params) {
           nodeId: cur,
           state: JSON.parse(JSON.stringify(hooks.getState())),
         });
-        hooks.appendCheckpoint(cur, hooks.getState(), stateUpdatedSeq);
+        hooks.appendCheckpoint(cur, hooks.getState(), stateUpdatedSeq, parallelSpan);
         try {
           hooks.throwIfStateInvalid(hooks.getState(), `State invalid after switch "${cur}"`);
         } catch (e) {
@@ -93,7 +100,7 @@ export function createR2ParallelRuntime(params) {
           typeof cfg.prompt === "string" ? (cfg.prompt.length > 200 ? `${cfg.prompt.slice(0, 200)}…` : cfg.prompt) : "";
         hooks.appendCmd("RaiseInterrupt", { nodeId: cur, prompt: promptSummary });
         const interruptSeq = hooks.appendEvt("InterruptRaised", { nodeId: cur, prompt: promptSummary });
-        hooks.appendCheckpoint(cur, hooks.getState(), interruptSeq);
+        hooks.appendCheckpoint(cur, hooks.getState(), interruptSeq, parallelSpan);
         return {
           kind: "interrupt",
           nodeId: cur,
@@ -136,7 +143,7 @@ export function createR2ParallelRuntime(params) {
           nodeId: cur,
           state: JSON.parse(JSON.stringify(hooks.getState())),
         });
-        hooks.appendCheckpoint(cur, hooks.getState(), stateUpdatedSeq);
+        hooks.appendCheckpoint(cur, hooks.getState(), stateUpdatedSeq, parallelSpan);
         try {
           hooks.throwIfStateInvalid(hooks.getState(), `State invalid after wait "${cur}"`);
         } catch (e) {
@@ -176,7 +183,7 @@ export function createR2ParallelRuntime(params) {
           nodeId: cur,
           state: JSON.parse(JSON.stringify(hooks.getState())),
         });
-        hooks.appendCheckpoint(cur, hooks.getState(), stateUpdatedSeq);
+        hooks.appendCheckpoint(cur, hooks.getState(), stateUpdatedSeq, parallelSpan);
         try {
           hooks.throwIfStateInvalid(hooks.getState(), `State invalid after set_state "${cur}"`);
         } catch (e) {
@@ -239,7 +246,7 @@ export function createR2ParallelRuntime(params) {
           nodeId: cur,
           state: JSON.parse(JSON.stringify(hooks.getState())),
         });
-        hooks.appendCheckpoint(cur, hooks.getState(), stateUpdatedSeq);
+        hooks.appendCheckpoint(cur, hooks.getState(), stateUpdatedSeq, parallelSpan);
         try {
           hooks.throwIfStateInvalid(hooks.getState(), `State invalid after node "${cur}"`);
         } catch (e) {
@@ -316,13 +323,24 @@ export function createR2ParallelRuntime(params) {
 
     if (join === "all") {
       for (const b of branches) {
-        const r = await runBranchToJoin(b.entry, joinTargetId);
+        const r = await runBranchToJoin(b.entry, joinTargetId, {
+          parallelNodeId: parallelNode.id,
+          joinTargetId,
+          branchName: b.name,
+          branchEntryNodeId: b.entry,
+        });
         if (r.kind !== "ok") return r;
       }
     } else if (join === "any") {
       let successIndex = -1;
       for (let i = 0; i < branches.length; i++) {
-        const r = await runBranchToJoin(branches[i].entry, joinTargetId);
+        const b = branches[i];
+        const r = await runBranchToJoin(b.entry, joinTargetId, {
+          parallelNodeId: parallelNode.id,
+          joinTargetId,
+          branchName: b.name,
+          branchEntryNodeId: b.entry,
+        });
         if (r.kind === "interrupt") return r;
         if (r.kind === "ok") {
           successIndex = i;
@@ -344,7 +362,12 @@ export function createR2ParallelRuntime(params) {
           cancelRemaining(i);
           break;
         }
-        const r = await runBranchToJoin(b.entry, joinTargetId);
+        const r = await runBranchToJoin(b.entry, joinTargetId, {
+          parallelNodeId: parallelNode.id,
+          joinTargetId,
+          branchName: b.name,
+          branchEntryNodeId: b.entry,
+        });
         if (r.kind === "interrupt") return r;
         if (r.kind === "ok") {
           successes += 1;

--- a/packages/engine/src/orchestrator/poc-runner.mjs
+++ b/packages/engine/src/orchestrator/poc-runner.mjs
@@ -26,7 +26,43 @@ function loadJq() {
 
 const PLACEHOLDER_TYPES = new Set(["step", "llm_call", "tool_call"]);
 const NONDETERMINISM_ERROR_CODE = "NONDETERMINISM_DETECTED";
-const CHECKPOINT_POLICY = "after_each_node";
+
+/**
+ * @param {object} definition
+ * @returns {{ enabled: boolean; mode: "each" | "interval"; intervalN?: number }}
+ */
+function resolveCheckpointConfig(definition) {
+  const cp = definition?.checkpointing;
+  if (!cp || typeof cp !== "object") {
+    return { enabled: true, mode: "each" };
+  }
+  const raw =
+    typeof cp.strategy === "string"
+      ? cp.strategy
+      : typeof cp.policy === "string"
+        ? cp.policy
+        : "after_each_node";
+  const strategy = raw.trim();
+  if (strategy === "disabled" || strategy === "off" || strategy === "none") {
+    return { enabled: false, mode: "each" };
+  }
+  if (strategy === "every_n_nodes" || strategy === "interval") {
+    const n =
+      typeof cp.n === "number" && Number.isInteger(cp.n) && cp.n >= 1
+        ? cp.n
+        : typeof cp.interval === "number" && Number.isInteger(cp.interval) && cp.interval >= 1
+          ? cp.interval
+          : null;
+    if (n == null) {
+      throw new Error('checkpointing: strategy "every_n_nodes" requires integer n ≥ 1');
+    }
+    return { enabled: true, mode: "interval", intervalN: n };
+  }
+  if (strategy === "after_each_node" || strategy === "") {
+    return { enabled: true, mode: "each" };
+  }
+  throw new Error(`checkpointing: unknown strategy "${strategy}"`);
+}
 
 class NondeterminismError extends Error {
   /**
@@ -368,6 +404,16 @@ export async function runPocWorkflow(options) {
     return { status: "failed", error: msg };
   }
 
+  /** @type {{ enabled: boolean; mode: "each" | "interval"; intervalN?: number }} */
+  let checkpointConfig;
+  try {
+    checkpointConfig = resolveCheckpointConfig(definition);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { status: "failed", error: msg };
+  }
+  let checkpointIntervalCounter = 0;
+
   const nodes = /** @type {{ nodes: Array<{ id: string; type: string; config?: object }>; edges: Array<{ source: string; target: string }>; state_schema: object; document: { name?: string; version?: string } }} */ (
     definition
   ).nodes;
@@ -421,9 +467,25 @@ export async function runPocWorkflow(options) {
   function appendEvt(name, payload) {
     return store.append(executionId, { kind: "event", name, payload: { executionId, ...payload } });
   }
-  function appendCheckpoint(nodeId, stateSnapshot, lastAppliedEventSeq) {
-    appendEvt("CheckpointWritten", {
-      policy: CHECKPOINT_POLICY,
+  /**
+   * @param {string} nodeId
+   * @param {Record<string, unknown>} stateSnapshot
+   * @param {number} lastAppliedEventSeq
+   * @param {{ parallelNodeId: string; joinTargetId: string; branchName: string; branchEntryNodeId: string }} [parallelSpan]
+   */
+  function appendCheckpoint(nodeId, stateSnapshot, lastAppliedEventSeq, parallelSpan) {
+    if (!checkpointConfig.enabled) return;
+    if (checkpointConfig.mode === "interval") {
+      checkpointIntervalCounter += 1;
+      if (checkpointIntervalCounter % /** @type {number} */ (checkpointConfig.intervalN) !== 0) return;
+    }
+    const policyPayload =
+      checkpointConfig.mode === "interval"
+        ? { policy: "every_n_nodes", intervalNodes: checkpointConfig.intervalN }
+        : { policy: "after_each_node" };
+    /** @type {Record<string, unknown>} */
+    const cpPayload = {
+      ...policyPayload,
       workflowVersion: definitionMeta.workflowVersion,
       definitionHash: definitionMeta.definitionHash,
       lastAppliedEventSeq,
@@ -432,7 +494,22 @@ export async function runPocWorkflow(options) {
         kind: "inline_state",
         state: JSON.parse(JSON.stringify(stateSnapshot)),
       },
-    });
+    };
+    if (
+      parallelSpan &&
+      typeof parallelSpan.parallelNodeId === "string" &&
+      typeof parallelSpan.joinTargetId === "string" &&
+      typeof parallelSpan.branchName === "string" &&
+      typeof parallelSpan.branchEntryNodeId === "string"
+    ) {
+      cpPayload.parallelSpan = {
+        parallelNodeId: parallelSpan.parallelNodeId,
+        joinTargetId: parallelSpan.joinTargetId,
+        branchName: parallelSpan.branchName,
+        branchEntryNodeId: parallelSpan.branchEntryNodeId,
+      };
+    }
+    appendEvt("CheckpointWritten", cpPayload);
   }
 
   const { executeParallelBlock } = createR2ParallelRuntime({
@@ -785,6 +862,16 @@ export async function resumePocWorkflow(options) {
     return { status: "failed", error: msg };
   }
 
+  /** @type {{ enabled: boolean; mode: "each" | "interval"; intervalN?: number }} */
+  let resumeCheckpointConfig;
+  try {
+    resumeCheckpointConfig = resolveCheckpointConfig(definition);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { status: "failed", error: msg };
+  }
+  let resumeCheckpointIntervalCounter = 0;
+
   const rows = store.listByExecution(executionId);
   assertHistoryReadableByEngine(rows);
   const lastRow = latestPrimaryEvent(rows);
@@ -903,9 +990,25 @@ export async function resumePocWorkflow(options) {
   function appendEvt(name, payload) {
     return store.append(executionId, { kind: "event", name, payload: { executionId, ...payload } });
   }
-  function appendCheckpoint(nodeId, stateSnapshot, lastAppliedEventSeq) {
-    appendEvt("CheckpointWritten", {
-      policy: CHECKPOINT_POLICY,
+  /**
+   * @param {string} nodeId
+   * @param {Record<string, unknown>} stateSnapshot
+   * @param {number} lastAppliedEventSeq
+   * @param {{ parallelNodeId: string; joinTargetId: string; branchName: string; branchEntryNodeId: string }} [parallelSpan]
+   */
+  function appendCheckpoint(nodeId, stateSnapshot, lastAppliedEventSeq, parallelSpan) {
+    if (!resumeCheckpointConfig.enabled) return;
+    if (resumeCheckpointConfig.mode === "interval") {
+      resumeCheckpointIntervalCounter += 1;
+      if (resumeCheckpointIntervalCounter % /** @type {number} */ (resumeCheckpointConfig.intervalN) !== 0) return;
+    }
+    const policyPayload =
+      resumeCheckpointConfig.mode === "interval"
+        ? { policy: "every_n_nodes", intervalNodes: resumeCheckpointConfig.intervalN }
+        : { policy: "after_each_node" };
+    /** @type {Record<string, unknown>} */
+    const cpPayload = {
+      ...policyPayload,
       workflowVersion: definitionMeta.workflowVersion,
       definitionHash: definitionMeta.definitionHash,
       lastAppliedEventSeq,
@@ -914,7 +1017,22 @@ export async function resumePocWorkflow(options) {
         kind: "inline_state",
         state: JSON.parse(JSON.stringify(stateSnapshot)),
       },
-    });
+    };
+    if (
+      parallelSpan &&
+      typeof parallelSpan.parallelNodeId === "string" &&
+      typeof parallelSpan.joinTargetId === "string" &&
+      typeof parallelSpan.branchName === "string" &&
+      typeof parallelSpan.branchEntryNodeId === "string"
+    ) {
+      cpPayload.parallelSpan = {
+        parallelNodeId: parallelSpan.parallelNodeId,
+        joinTargetId: parallelSpan.joinTargetId,
+        branchName: parallelSpan.branchName,
+        branchEntryNodeId: parallelSpan.branchEntryNodeId,
+      };
+    }
+    appendEvt("CheckpointWritten", cpPayload);
   }
 
   function resumeAppendCmd(name, payload) {

--- a/packages/engine/test/poc-runner-r2.test.mjs
+++ b/packages/engine/test/poc-runner-r2.test.mjs
@@ -44,5 +44,18 @@ describe("runPocWorkflow (R2 parallel, wait, set_state)", () => {
     assert.ok(rows.some((r) => r.kind === "command" && r.name === "JoinParallel"));
     assert.ok(rows.some((r) => r.kind === "event" && r.name === "TimerFired"));
     assert.ok(rows.some((r) => r.kind === "event" && r.name === "ParallelJoined"));
+
+    const branchCp = rows.find(
+      (r) =>
+        r.kind === "event" &&
+        r.name === "CheckpointWritten" &&
+        r.payload?.nodeId === "web_collect" &&
+        r.payload?.parallelSpan
+    );
+    assert.ok(branchCp);
+    assert.equal(branchCp.payload.parallelSpan.parallelNodeId, "research");
+    assert.equal(branchCp.payload.parallelSpan.joinTargetId, "tag");
+    assert.equal(branchCp.payload.parallelSpan.branchName, "web");
+    assert.equal(branchCp.payload.parallelSpan.branchEntryNodeId, "web_collect");
   });
 });

--- a/packages/engine/test/poc-runner.test.mjs
+++ b/packages/engine/test/poc-runner.test.mjs
@@ -368,6 +368,91 @@ describe("runPocWorkflow (deterministic replay matching)", () => {
 });
 
 describe("runPocWorkflow (checkpoint policy)", () => {
+  it("omits CheckpointWritten when checkpointing.strategy is disabled", async () => {
+    const definition = structuredClone(loadLighthouse());
+    definition.checkpointing = { strategy: "disabled" };
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "exec-checkpoint-disabled";
+
+    const out = await runPocWorkflow({
+      definition,
+      input: { ticket_text: "My API returns 500" },
+      executionId,
+      store,
+      stubActivityOutputs: {
+        classify: { intent: "technical", confidence: 0.9 },
+        search_kb: { snippets: [] },
+      },
+    });
+    assert.equal(out.status, "completed");
+    const checkpoints = store.listByExecution(executionId).filter((r) => r.name === "CheckpointWritten");
+    assert.equal(checkpoints.length, 0);
+  });
+
+  it("every_n_nodes emits fewer checkpoints than after_each_node on the R2 parallel fixture", async () => {
+    const root = findWorkflowRepoRoot(__dirname);
+    const base = JSON.parse(
+      readFileSync(path.join(root, "examples", "r2-research-parallel.workflow.json"), "utf8")
+    );
+    const intervalDef = structuredClone(base);
+    intervalDef.checkpointing = { strategy: "every_n_nodes", n: 2 };
+
+    async function countCheckpoints(def) {
+      const store = new MemoryExecutionHistoryStore();
+      const id = `exec-r2-cp-${def.checkpointing ? "i" : "d"}`;
+      const r = await runPocWorkflow({
+        definition: def,
+        input: { topic: "t" },
+        executionId: id,
+        store,
+        stubActivityOutputs: {
+          plan: {},
+          web_collect: { findings: ["a"] },
+          internal_collect: { findings: ["b"] },
+        },
+      });
+      assert.equal(r.status, "completed");
+      return store.listByExecution(id).filter((row) => row.name === "CheckpointWritten").length;
+    }
+
+    const eachCount = await countCheckpoints(base);
+    const intervalCount = await countCheckpoints(intervalDef);
+    assert.ok(eachCount >= 4);
+    assert.ok(intervalCount > 0);
+    assert.ok(intervalCount < eachCount);
+
+    const policyStore = new MemoryExecutionHistoryStore();
+    await runPocWorkflow({
+      definition: intervalDef,
+      input: { topic: "t" },
+      executionId: "exec-r2-cp-interval-policy",
+      store: policyStore,
+      stubActivityOutputs: {
+        plan: {},
+        web_collect: { findings: ["a"] },
+        internal_collect: { findings: ["b"] },
+      },
+    });
+    assert.ok(
+      policyStore.listByExecution("exec-r2-cp-interval-policy").some((r) => r.payload?.policy === "every_n_nodes")
+    );
+  });
+
+  it("returns failed when every_n_nodes is missing n", async () => {
+    const definition = structuredClone(loadLighthouse());
+    definition.checkpointing = { strategy: "every_n_nodes" };
+    const store = new MemoryExecutionHistoryStore();
+    const out = await runPocWorkflow({
+      definition,
+      input: { ticket_text: "x" },
+      executionId: "exec-bad-cp",
+      store,
+      stubActivityOutputs: { classify: { intent: "technical", confidence: 0.9 }, search_kb: { snippets: [] } },
+    });
+    assert.equal(out.status, "failed");
+    assert.match(out.error ?? "", /checkpointing/);
+  });
+
   it("writes after_each_node checkpoints with recovery metadata linked to history boundaries", async () => {
     const definition = loadLighthouse();
     const store = new MemoryExecutionHistoryStore();

--- a/schemas/workflow-definition-poc.json
+++ b/schemas/workflow-definition-poc.json
@@ -20,8 +20,28 @@
     },
     "checkpointing": {
       "type": "object",
-      "description": "Optional checkpoint policy per RFC-03 §3.9; engines may implement later.",
-      "additionalProperties": true
+      "description": "Optional checkpoint policy per RFC-03 §3.9; reference engine honors strategy/n (see docs/poc-scope.md §5).",
+      "additionalProperties": true,
+      "properties": {
+        "strategy": {
+          "type": "string",
+          "description": "after_each_node (default), every_n_nodes, or disabled."
+        },
+        "policy": {
+          "type": "string",
+          "description": "Alias of strategy for document authors."
+        },
+        "n": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Required when strategy/policy is every_n_nodes."
+        },
+        "interval": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Alias of n for every_n_nodes."
+        }
+      }
     }
   },
   "$defs": {


### PR DESCRIPTION
## What changed

- **Replay / conformance:** New history-prefix replay vectors for R2 workflows (`join: all` research path, `join: any`, `join: n_of_m` with cancel tail), plus an **adversarial mismatch** vector proving deterministic **command-order** divergence detection when a forged prefix schedules the wrong parallel branch first.
- **Checkpoints:** Optional top-level `checkpointing` strategies — `after_each_node` (default), `every_n_nodes` (`n` or `interval`), and `disabled`; `CheckpointWritten` carries `every_n_nodes` + `intervalNodes` when applicable.
- **Parallel correlation:** `CheckpointWritten` events emitted **inside parallel branches** now include **`parallelSpan`** (`parallelNodeId`, `joinTargetId`, `branchName`, `branchEntryNodeId`) alongside `stateRef`, matching the issue design handoff for fork/join-aware readers.
- **Fixtures:** `examples/r2-parallel-join-any.workflow.json`, `examples/r2-parallel-join-n2-of-3.workflow.json`.
- **Docs:** `docs/poc-scope.md`, `docs/architecture/as-is-system-overview.md`, root `README.md`, `CLAUDE.md`, `conformance/README.md`; JSON Schema `checkpointing` property hints.

## Why this change

Closes the acceptance criteria for **replay determinism**, **divergence diagnostics**, **checkpoint policy** beyond a single fixed policy, and **CI-visible conformance** for parallel/timer paths described in the linked issue.

## Roadmap alignment

- Linked issue: Closes #3
- Target release: `R2`
- Type: `feature`
- RFC trace links:
  - [RFC-04 — Deterministic replay, parallelism, checkpointing](https://github.com/benvdbergh/workflows/blob/master/docs/RFC/rfc-04-execution-model.md)
  - [RFC-03 — Checkpointing block](https://github.com/benvdbergh/workflows/blob/master/docs/RFC/rfc-03-workflow-definition-schema.md)

## Spec and architecture traceability

- Spec artifact link (required for feature/runway PRs):
  - [docs/poc-scope.md](https://github.com/benvdbergh/workflows/blob/master/docs/poc-scope.md)
- Architecture decision link (ADR/design note, if applicable):
  - **ADR deferred** — backward-compatible checkpoint payload extension (`parallelSpan` additive); no on-disk format break for stores that treat event payloads as opaque JSON.
- [x] Scope and constraints reviewed against `docs/poc-scope.md` and relevant `docs/RFC/*`
- [x] If behavior/contract changed, corresponding spec/design docs were updated first or in this PR

## Architecture runway impact

- [x] No runway impact
- [ ] Adds/updates runway enabler
- [ ] Depends on runway enabler (link issue)

## Validation

- [x] `npm run validate-workflows`
- [x] `npm run conformance`
- [x] `npm test`
- [x] Docs updated when behavior/contract changed
- [x] `npm run check-engine-poc-schema-sync`

## Risk and rollback

- Risk level: `low`
- Rollback/fallback plan: Revert PR; checkpoint `parallelSpan` and new strategies are additive; existing consumers ignoring unknown JSON fields remain safe.
