### PR TITLE
docs(adr): ADR-0003 engine-direct MCP security posture

### DIFF
--- a/docs/architecture/adr/ADR-0002-host-mediated-activity-execution.md
+++ b/docs/architecture/adr/ADR-0002-host-mediated-activity-execution.md
@@ -34,13 +34,13 @@ Activity nodes (`step`, `llm_call`, `tool_call`) require non-deterministic I/O (
 
 For **operator and automation** scenarios, the repository **target** includes an **engine-direct** activity path: the reference engine **invokes** MCP servers (stdio or other supported transports) and **MAY** invoke bounded local commands where the deployment profile allows, without a conversational MCP host mediating every `tool_call`. **Configuration** for MCP servers **SHOULD** be reusable or translatable from **host manifest** shapes (for example Cursor-style `mcp.json` or equivalent desktop MCP config) so credentials and server lists are not maintained twice when both an IDE host and an engine worker need the same tools—subject to explicit policy when secrets must remain host-only.
 
-That posture extends **Option C (hybrid)** and optional **Option A**-style surfaces; it does **not** revise the **default assistant-class decision** above. When engine-direct execution becomes a supported reference profile, a **follow-on ADR** should record normative security, isolation, and provenance expectations.
+That posture extends **Option C (hybrid)** and optional **Option A**-style surfaces; it does **not** revise the **default assistant-class decision** above. Normative security, isolation, configuration, and audit expectations for engine-direct execution are recorded in **[ADR-0003](ADR-0003-engine-direct-mcp-activity-execution.md)**.
 
 ## Follow-up (implementation and validation)
 
 - Reference MCP stdio exposes `workflow_submit_activity` and status projection for `awaiting_activity`; extend conformance and governance naming as needed.
 - Conformance vectors for pause, submit result, replay idempotency.
-- Engine-direct MCP/cmd execution and manifest-aligned operator configuration (see Evolution).
+- Engine-direct MCP/cmd execution and manifest-aligned operator configuration (see [ADR-0003](ADR-0003-engine-direct-mcp-activity-execution.md)).
 - Update `docs/architecture/as-is-system-overview.md` and as-built diagrams as profiles mature.
 
 ## References
@@ -48,5 +48,6 @@ That posture extends **Option C (hybrid)** and optional **Option A**-style surfa
 - `docs/architecture/as-is-system-overview.md`
 - `docs/poc-scope.md`
 - `docs/RFC/rfc-04-execution-model.md`, `docs/RFC/rfc-05-integration-interfaces.md`, `docs/RFC/rfc-06-interoperability.md`
+- `docs/architecture/adr/ADR-0003-engine-direct-mcp-activity-execution.md`
 - `ROADMAP.md`
 - `docs/governance/spec-architecture-governance.md`

--- a/docs/architecture/adr/ADR-0003-engine-direct-mcp-activity-execution.md
+++ b/docs/architecture/adr/ADR-0003-engine-direct-mcp-activity-execution.md
@@ -1,0 +1,76 @@
+# ADR-0003: Engine-direct MCP activity execution (security and configuration posture)
+
+**Status:** Accepted  
+**Date:** 2026-05-04  
+**Tags:** integration, MCP, execution-model, trust-boundary, security, engine-direct
+
+## Context
+
+[ADR-0002](ADR-0002-host-mediated-activity-execution.md) establishes **host-mediated** activity execution as the default for assistant-class deployments and describes an **engine-direct** evolution for operator and automation scenarios. [RFC-06 §6.1](../../RFC/rfc-06-interoperability.md#61-composing-mcp) distinguishes **host-mediated** and **engine-direct** profiles at the protocol level.
+
+Without normative repository rules, engine-direct execution risks duplicating host trust assumptions: secrets in the engine process, unbounded child processes, and non-replay-safe side effects. This ADR closes that gap so dependent R2 implementation issues can assume explicit boundaries.
+
+## Decision
+
+1. **Engine-direct is an optional deployment profile** of the reference engine. It **does not** change the default assistant-class posture in ADR-0002. Operators **MUST** enable it only where policy, threat model, and operating procedures explicitly allow the engine process to perform MCP **tools/call** (and any bounded local handlers) on behalf of workflows.
+2. **Trust boundaries** (normative for this repository’s reference engine when engine-direct is enabled):
+   - **Workflow document and graph state** remain untrusted input; validation and deterministic replay rules apply unchanged.
+   - **Engine process** becomes part of the **credential and side-effect trust zone** for configured MCP servers and allowed local handlers—the same practical zone as a long-lived automation worker, not an ephemeral IDE session.
+   - **MCP server processes** (stdio children or remote peers) are **separate trust domains** from the engine: compromised or malicious servers can attack the engine via protocol surfaces, resource exhaustion, or malicious tool results; the engine **MUST** treat tool payloads as untrusted input to reducers and host-facing projections.
+3. **Secret and credential storage** (reference expectations):
+   - **Preferred:** OS/user secret stores, environment injection by a supervisor, or short-lived tokens obtained out-of-band—configured so workflow JSON **never** embeds long-lived secrets when avoidable.
+   - **Acceptable for R2:** Filesystem-backed manifest shapes compatible with common MCP host configs (for example `mcp.json`-class), with **explicit operator responsibility** for file permissions, rotation, and exclusion from version control; the engine **SHOULD** read credentials only from configured paths or env vars named in operator docs, not from arbitrary workflow fields.
+   - **Forbidden as a normative pattern:** silently persisting tool outputs that contain secrets into durable history without policy; see audit/redaction below.
+4. **Process isolation for stdio MCP children:**
+   - Each stdio MCP server **SHOULD** run as a **separate child process** with minimal inherited environment; operators **SHOULD** use dedicated OS users or containers where available.
+   - The engine **MUST NOT** assume stdio children are benign; enforce timeouts, output size limits, and connection lifecycle consistent with implementation issues and RFC security guidance ([RFC-07](../../RFC/rfc-07-security-model.md)).
+   - **Restart and health** behavior is implementation-defined but **MUST** preserve append-only history and deterministic replay (completed activities are not re-invoked on replay—see conformance/replay work).
+5. **Audit and redaction:**
+   - Command/event history remains the **audit trail** for orchestration; operators **SHOULD** configure logging and retention to match policy.
+   - Implementations **SHOULD** support redaction or omission of sensitive fragments in persisted events and tool error surfaces where feasible; full enterprise DLP is **out of scope** for R2 (see non-goals).
+6. **When engine-direct is forbidden vs host-mediated** (decision guide):
+   - **Require host-mediated** when the deployment cannot accept the engine process holding MCP credentials, when regulatory context requires human-in-the-loop hosts for external access, when untrusted third parties supply workflow definitions to a shared engine, or when child-process or network egress from the engine is disallowed.
+   - **Engine-direct may be used** when a dedicated automation worker owns the same trust as the tools it calls, workflows and definitions are operator-controlled, and blast radius is accepted and monitored.
+
+## Considered options
+
+| Option | Summary | Why not primary |
+|--------|---------|-----------------|
+| A — Document only in RFC | Keep norms exclusively in RFC-06/RFC-07 | Insufficient for repo-specific manifest alignment, replay, and CI/governance gates |
+| B — Large addendum to ADR-0002 | Single ADR for both profiles | Blurs default-assistant vs automation narrative; harder to review |
+| C — Standalone ADR (chosen) | This ADR-0003 | Extra file; clearer ownership for engine-direct security |
+
+## Consequences
+
+- **Positive:** Implementers of MCP bridges and MCP stdio modes have explicit security and configuration rules; conformance can cite replay/non-reinvoke expectations.
+- **Negative:** Operators must read and apply profile guidance; engine-direct is not “zero config secure.”
+- **Specification:** [RFC-06 §6.1](../../RFC/rfc-06-interoperability.md#61-composing-mcp) remains normative for protocol wording; this ADR adds **repository reference-engine** obligations and deployment guidance.
+
+## Non-goals (R2)
+
+- A full **multi-tenant secret service**, HSM integration, or organization-wide policy DSL.
+- **Network zero-trust** enforcement inside the engine beyond reasonable timeouts, TLS where applicable, and operator-supplied allowlists (may be incremental post-R2).
+- **Formal verification** of MCP servers or tool implementations.
+- **Universal** redaction/DLP guarantees across all tool payloads and logs.
+
+## Governance alignment (`docs/governance/spec-architecture-governance.md`)
+
+| Gate | Engine-direct–related evidence |
+|------|----------------------------------|
+| **Gate A (Intake)** | Use case for automation/engine-owned tools; explicit pointer to [RFC-06 §6.1](../../RFC/rfc-06-interoperability.md#61-composing-mcp); initial risk note (credentials, child processes, egress). |
+| **Gate B (Build ready)** | This ADR linked; affected surfaces listed (MCP adapter, executor port, manifest loader, conformance); runway dependencies (for example parent ADR-0002) linked on the issue graph. |
+| **Gate C (Merge ready)** | PR traceability section complete; behavior or contract changes accompanied by docs/tests/conformance per the implementing issue; material topology changes reflected in `as-is-system-overview.md` and as-built diagrams when applicable. |
+
+## Follow-up
+
+- Implementation: MCP manifest alignment, `ActivityExecutor` bridge, engine-direct MCP stdio profile, conformance replay invariants (tracked as child issues under the R2 epic).
+- Review after first engine-direct default path ships: revisit timeouts, size limits, and redaction hooks against operational feedback.
+
+## References
+
+- [ADR-0002 — Host-mediated activity execution](ADR-0002-host-mediated-activity-execution.md) (default posture and hybrid context)
+- [RFC-06 — Interoperability, §6.1](../../RFC/rfc-06-interoperability.md#61-composing-mcp)
+- [RFC-07 — Security model](../../RFC/rfc-07-security-model.md)
+- `docs/architecture/as-is-system-overview.md`
+- `docs/poc-scope.md`, `ROADMAP.md`
+- `docs/governance/spec-architecture-governance.md`

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -54,3 +54,4 @@ Each ADR should include:
 
 - `ADR-0001-poc-foundation-decisions.md`
 - `ADR-0002-host-mediated-activity-execution.md`
+- `ADR-0003-engine-direct-mcp-activity-execution.md`

--- a/docs/architecture/as-is-system-overview.md
+++ b/docs/architecture/as-is-system-overview.md
@@ -1,7 +1,7 @@
 # As-Is System Overview (POC Alpha Baseline)
 
 Last updated: 2026-05-03
-Status: Current implementation baseline (not a target architecture). **Assistant-class target posture** (host-mediated activities; graph-driven orchestration) is documented in [ADR-0002](adr/ADR-0002-host-mediated-activity-execution.md). **Reference-engine target** for automation and unattended runs additionally includes **engine-direct** activity execution (MCP transports and bounded local commands) with operator configuration that can **reuse or translate** common MCP host manifest shapes; see the evolution note in ADR-0002 and R2 architectural runway in `ROADMAP.md`.
+Status: Current implementation baseline (not a target architecture). **Assistant-class target posture** (host-mediated activities; graph-driven orchestration) is documented in [ADR-0002](adr/ADR-0002-host-mediated-activity-execution.md). **Reference-engine target** for automation and unattended runs additionally includes **engine-direct** activity execution (MCP transports and bounded local commands) with operator configuration that can **reuse or translate** common MCP host manifest shapes; normative security and configuration rules for that profile are in [ADR-0003](adr/ADR-0003-engine-direct-mcp-activity-execution.md). See the evolution note in ADR-0002 and R2 architectural runway in `ROADMAP.md`.
 
 ## Purpose
 

--- a/docs/governance/spec-architecture-governance.md
+++ b/docs/governance/spec-architecture-governance.md
@@ -54,6 +54,8 @@ Primary constraints and anchors:
   - Doc updates exist in same PR when behavior or contract changed.
   - Validation checks pass (`validate-workflows`, `conformance`, tests).
 
+**Engine-direct profile (R2 reference engine):** Issues that add or materially change **engine-direct** MCP execution (engine-owned MCP clients, manifest-aligned operator config, or bounded local handlers) **SHOULD** link [RFC-06 §6.1](../RFC/rfc-06-interoperability.md#61-composing-mcp) and [ADR-0003](../architecture/adr/ADR-0003-engine-direct-mcp-activity-execution.md) at Gate B, and cite concrete conformance or replay evidence at Gate C when behavior affects history or resumption. Gate mapping table: see ADR-0003 “Governance alignment.”
+
 ### Architecture view artifacts governance
 
 Canonical diagram artifacts:


### PR DESCRIPTION
Closes #67

## Summary
Delivers runway issue **#67** with **ADR-0003** (engine-direct MCP activity execution: security and configuration posture).

## Spec / architecture traceability
- **RFC:** [RFC-06 §6.1](docs/RFC/rfc-06-interoperability.md#61-composing-mcp) — cited in ADR-0003 and governance.
- **ADR:** ADR-0002 updated to reference ADR-0003; new ADR-0003 is the normative follow-on promised in ADR-0002 Evolution.
- **Governance:** [spec-architecture-governance.md](docs/governance/spec-architecture-governance.md) — engine-direct Gate A/B/C pointer.
- **As-is:** [as-is-system-overview.md](docs/architecture/as-is-system-overview.md) — activity boundary links ADR-0003.

## Acceptance criteria (issue #67)
- [x] Trust boundaries, secret storage options, stdio MCP isolation, audit/redaction, forbidden vs host-mediated — ADR-0003 Decision + sections.
- [x] RFC-06 6.1 + governance gate mapping — ADR-0003 + governance paragraph/table.
- [x] R2 non-goals — ADR-0003 Non-goals (R2).

## Testing
Documentation-only; \
pm test\ not required for merge gate of this change (no code).

Made with [Cursor](https://cursor.com)