### PR TITLE
feat(engine): MCP operator manifest loader (#68)

### DIFF
--- a/docs/architecture/mcp-operator-manifest.md
+++ b/docs/architecture/mcp-operator-manifest.md
@@ -1,0 +1,71 @@
+# MCP operator manifest (engine reference)
+
+Last updated: 2026-05-04
+
+## Purpose
+
+Define a **single, documented JSON shape** for operator-supplied MCP **stdio** server definitions so the reference engine can align with common IDE host manifests (Cursor-style `mcp.json` under `mcpServers`) without inventing a parallel undocumented format. Normative security and trust expectations for **engine-direct** execution are in [ADR-0003](adr/ADR-0003-engine-direct-mcp-activity-execution.md).
+
+## Schema
+
+- **JSON Schema (Draft 2020-12):** `packages/engine/schemas/mcp-operator-manifest.json`
+- **Validation API:** `@agent-workflow/engine` exports `validateMcpOperatorManifest`, `readAndValidateMcpOperatorManifestFile`, `resolveMcpOperatorManifestPath`, and `normalizeMcpOperatorManifest` (see package `src/index.mjs`).
+
+The schema accepts **only** this top-level shape:
+
+- Required property: `mcpServers` — object whose keys are server labels and values are **stdio** definitions.
+- Each server **MUST** include `command` (non-empty string).
+- Optional: `args` (array of strings), `env` (object with string values only).
+- **No** additional properties are allowed on the root or on each server entry (unknown keys fail validation with AJV instance paths).
+
+## Resolution order (file path)
+
+When code or tooling needs a manifest path without an explicit caller argument, resolution is:
+
+1. **Explicit path** passed by the caller (for example a future CLI flag or host integration).
+2. Environment variable **`AGENT_WORKFLOW_MCP_MANIFEST`**: path to a JSON file (relative paths are resolved from `process.cwd()` unless absolute).
+3. **Default file:** `<cwd>/.agent-workflow/mcp.json` if that path exists on disk.
+
+If none of the above apply, `resolveMcpOperatorManifestPath` returns `null` (no implicit manifest).
+
+## CLI validation
+
+From the repository root (after `npm install`):
+
+```bash
+npm run engine:validate -- path/to/workflow.json
+node packages/engine/src/cli.mjs mcp-manifest validate path/to/mcp.json
+```
+
+Or with the published bin:
+
+```bash
+workflows-engine mcp-manifest validate path/to/mcp.json
+```
+
+Exit codes mirror workflow validate: `0` valid, `1` schema failure, `2` usage or I/O error.
+
+## Vendor alignment and deliberate divergence
+
+Many hosts use a JSON file with a top-level **`mcpServers`** map; this repository **matches that key** and the common **`command` / `args` / `env`** fields for **stdio** transports.
+
+**Not supported in this manifest schema (validation will reject or ignore at boundary):**
+
+| Vendor / product concept | Notes |
+|--------------------------|--------|
+| **`url` / SSE / HTTP MCP transports** | Omitted from this schema; use stdio `command`/`args` or a separate integration path. |
+| **`disabled`, `alwaysAllow`, tool allowlists** | Host UX and policy; not part of the engine operator manifest contract. Re-introduce only with a versioned schema extension. |
+| **`resource` roots, nested includes, `$ref` between files** | Not implemented; there is **no** include graph—**circular includes do not apply**. One JSON document per validated file. |
+| **Non-string `env` values** | Rejected; normalize to string env for subprocess compatibility. |
+
+Operators should **trim** vendor-only keys when translating a desktop `mcp.json` into a file validated by this schema, or maintain a dedicated engine manifest that lists only the stdio servers the automation profile may invoke.
+
+## Secret handling
+
+Follow [RFC-07](../RFC/rfc-07-security-model.md) and ADR-0003: prefer environment injection by a process supervisor, restrict file permissions on manifest paths, and avoid committing real secrets (use placeholders in examples and tests).
+
+## References
+
+- [ADR-0002](adr/ADR-0002-host-mediated-activity-execution.md), [ADR-0003](adr/ADR-0003-engine-direct-mcp-activity-execution.md)
+- [RFC-06 §6.1](../RFC/rfc-06-interoperability.md#61-composing-mcp)
+- `docs/governance/spec-architecture-governance.md`

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "check-engine-poc-schema-sync": "node scripts/sync-engine-poc-schema.mjs --check",
     "validate-workflows": "node scripts/validate-workflows.mjs",
     "engine:validate": "node packages/engine/src/cli.mjs validate",
+    "engine:mcp-manifest:validate": "node packages/engine/src/cli.mjs mcp-manifest validate",
     "engine:mcp:stdio": "node packages/engine/src/mcp-stdio-server.mjs",
     "conformance": "node conformance/run-conformance.mjs",
     "test": "npm test --workspace=@agent-workflow/engine"

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -16,6 +16,14 @@ Or use the package bin name when linked:
 npx workflows-engine validate path/to/workflow.json
 ```
 
+Validate an operator MCP manifest (Cursor-style `mcpServers` subset for stdio servers):
+
+```bash
+node packages/engine/src/cli.mjs mcp-manifest validate path/to/mcp.json
+```
+
+See `docs/architecture/mcp-operator-manifest.md` and exports `validateMcpOperatorManifest`, `readAndValidateMcpOperatorManifestFile`, `resolveMcpOperatorManifestPath` from the package entrypoint.
+
 ## MCP stdio adapter (STORY-4-1 bootstrap)
 
 Run from repository root:

--- a/packages/engine/schemas/mcp-operator-manifest.json
+++ b/packages/engine/schemas/mcp-operator-manifest.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/benvdbergh/workflows/schemas/mcp-operator-manifest.json",
+  "title": "MCP operator manifest (mcpServers-compatible subset)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["mcpServers"],
+  "properties": {
+    "mcpServers": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": { "$ref": "#/$defs/stdioTransport" }
+    }
+  },
+  "$defs": {
+    "stdioTransport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command"],
+      "properties": {
+        "command": { "type": "string", "minLength": 1 },
+        "args": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/packages/engine/src/cli.mjs
+++ b/packages/engine/src/cli.mjs
@@ -1,18 +1,24 @@
 #!/usr/bin/env node
 /**
- * CLI entrypoint: validate canonical JSON workflow documents against the POC schema.
- * Usage: node packages/engine/src/cli.mjs validate [<file>|-]
- * Omit file or use `-` to read JSON from stdin.
+ * CLI entrypoint: validate workflow JSON and operator MCP manifests.
+ * Usage:
+ *   workflows-engine validate [<file>|-]
+ *   workflows-engine mcp-manifest validate <file>
  */
 import { readFile } from "node:fs/promises";
+import { readAndValidateMcpOperatorManifestFile } from "./config/mcp-operator-manifest.mjs";
 import { validateWorkflowDefinition } from "./validate.mjs";
 
 function usage() {
   process.stderr.write(
-    "Usage: workflows-engine validate [<file>]\n" +
-      "  Validates a workflow JSON document against schemas/workflow-definition-poc.json.\n" +
-      "  If <file> is omitted or `-`, reads JSON from stdin.\n" +
-      "  Exit: 0 valid, 1 validation failed, 2 usage / I/O / JSON parse error.\n"
+    "Usage:\n" +
+      "  workflows-engine validate [<file>]\n" +
+      "    Validates a workflow JSON document against schemas/workflow-definition-poc.json.\n" +
+      "    If <file> is omitted or `-`, reads JSON from stdin.\n" +
+      "  workflows-engine mcp-manifest validate <file>\n" +
+      "    Validates an operator MCP manifest (Cursor-style mcpServers subset).\n" +
+      "    See docs/architecture/mcp-operator-manifest.md.\n" +
+      "Exit: 0 valid, 1 validation failed, 2 usage / I/O / JSON parse error.\n"
   );
 }
 
@@ -52,13 +58,7 @@ function printValidationErrors(errors) {
   }
 }
 
-async function main() {
-  const [, , cmd, ...rest] = process.argv;
-  if (cmd !== "validate") {
-    usage();
-    process.exitCode = 2;
-    return;
-  }
+async function cmdValidateWorkflow(rest) {
   const fileArg = rest[0];
   let data;
   try {
@@ -76,6 +76,37 @@ async function main() {
   process.stderr.write("Validation failed:\n");
   printValidationErrors(result.errors ?? []);
   process.exitCode = 1;
+}
+
+async function cmdValidateMcpManifest(rest) {
+  const fileArg = rest[0];
+  if (!fileArg || fileArg === "-") {
+    process.stderr.write("engine mcp-manifest validate: requires a manifest file path.\n");
+    process.exitCode = 2;
+    return;
+  }
+  const result = await readAndValidateMcpOperatorManifestFile(fileArg);
+  if (result.ok) {
+    process.stdout.write("OK: manifest matches MCP operator manifest schema.\n");
+    return;
+  }
+  process.stderr.write("Validation failed:\n");
+  printValidationErrors(result.errors ?? []);
+  process.exitCode = 1;
+}
+
+async function main() {
+  const [, , cmd, ...rest] = process.argv;
+  if (cmd === "validate") {
+    await cmdValidateWorkflow(rest);
+    return;
+  }
+  if (cmd === "mcp-manifest" && rest[0] === "validate") {
+    await cmdValidateMcpManifest(rest.slice(1));
+    return;
+  }
+  usage();
+  process.exitCode = 2;
 }
 
 main();

--- a/packages/engine/src/config/mcp-operator-manifest.mjs
+++ b/packages/engine/src/config/mcp-operator-manifest.mjs
@@ -1,0 +1,138 @@
+/**
+ * Operator MCP manifest: Cursor-style `mcp.json` subset (stdio command/args/env only).
+ * @see docs/architecture/mcp-operator-manifest.md
+ */
+import Ajv2020 from "ajv/dist/2020.js";
+import { existsSync, readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** @typedef {{ command: string, args: string[], env: Record<string, string> }} McpStdioServerDefinition */
+/** @typedef {{ mcpServers: Record<string, McpStdioServerDefinition> }} NormalizedMcpOperatorManifest */
+
+/**
+ * @returns {string}
+ */
+function bundledManifestSchemaPath() {
+  return path.join(__dirname, "..", "..", "schemas", "mcp-operator-manifest.json");
+}
+
+/**
+ * @returns {import("ajv").AnySchema}
+ */
+function loadMcpOperatorManifestSchema() {
+  const p = bundledManifestSchemaPath();
+  if (!existsSync(p)) {
+    throw new Error(`MCP operator manifest schema not found at ${p}`);
+  }
+  return JSON.parse(readFileSync(p, "utf8"));
+}
+
+/** @type {import("ajv").ValidateFunction | null} */
+let cachedValidate = null;
+
+/**
+ * @returns {(data: unknown) => boolean}
+ */
+function getCompiledValidator() {
+  if (!cachedValidate) {
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    cachedValidate = ajv.compile(loadMcpOperatorManifestSchema());
+  }
+  return cachedValidate;
+}
+
+/**
+ * @param {unknown} data
+ * @returns {{ ok: true, manifest: NormalizedMcpOperatorManifest } | { ok: false, errors: import("ajv").ErrorObject[] }}
+ */
+export function validateMcpOperatorManifest(data) {
+  const validate = getCompiledValidator();
+  const valid = validate(data);
+  if (!valid) {
+    return { ok: false, errors: validate.errors ?? [] };
+  }
+  return { ok: true, manifest: normalizeMcpOperatorManifest(/** @type {Record<string, any>} */ (data)) };
+}
+
+/**
+ * @param {Record<string, any>} data validated root
+ * @returns {NormalizedMcpOperatorManifest}
+ */
+export function normalizeMcpOperatorManifest(data) {
+  const rawServers = data.mcpServers;
+  /** @type {Record<string, McpStdioServerDefinition>} */
+  const mcpServers = {};
+  for (const name of Object.keys(rawServers)) {
+    const s = rawServers[name];
+    mcpServers[name] = {
+      command: s.command,
+      args: Array.isArray(s.args) ? [...s.args] : [],
+      env: s.env && typeof s.env === "object" && !Array.isArray(s.env) ? { ...s.env } : {},
+    };
+  }
+  return { mcpServers };
+}
+
+/**
+ * Resolution order for locating a manifest file (no file read).
+ * 1. `explicitPath` when provided.
+ * 2. `process.env.AGENT_WORKFLOW_MCP_MANIFEST` when set to a non-empty string.
+ * 3. `${cwd}/.agent-workflow/mcp.json` when that path exists.
+ * Otherwise returns `null`.
+ *
+ * @param {{ explicitPath?: string | undefined; cwd?: string | undefined }} [options]
+ * @returns {string | null}
+ */
+export function resolveMcpOperatorManifestPath(options = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  if (options.explicitPath && String(options.explicitPath).trim() !== "") {
+    const p = String(options.explicitPath);
+    return path.isAbsolute(p) ? p : path.resolve(cwd, p);
+  }
+  const fromEnv = process.env.AGENT_WORKFLOW_MCP_MANIFEST;
+  if (fromEnv && String(fromEnv).trim() !== "") {
+    const p = String(fromEnv).trim();
+    return path.isAbsolute(p) ? p : path.resolve(cwd, p);
+  }
+  const defaultPath = path.join(cwd, ".agent-workflow", "mcp.json");
+  if (existsSync(defaultPath)) {
+    return defaultPath;
+  }
+  return null;
+}
+
+/**
+ * Read UTF-8 JSON from disk and validate.
+ * @param {string} filePath absolute or relative path (relative to cwd if not absolute)
+ * @param {{ cwd?: string }} [options]
+ * @returns {Promise<{ ok: true, manifest: NormalizedMcpOperatorManifest } | { ok: false, errors: import("ajv").ErrorObject[] } | { ok: false, errors: { instancePath: string; keyword: string; message: string }[] }>}
+ */
+export async function readAndValidateMcpOperatorManifestFile(filePath, options = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  const resolved = path.isAbsolute(filePath) ? filePath : path.resolve(cwd, filePath);
+  let raw;
+  try {
+    raw = await readFile(resolved, "utf8");
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      ok: false,
+      errors: [{ instancePath: "", keyword: "read", message: `Failed to read manifest: ${msg}` }],
+    };
+  }
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      ok: false,
+      errors: [{ instancePath: "", keyword: "parse", message: `Invalid JSON: ${msg}` }],
+    };
+  }
+  return validateMcpOperatorManifest(data);
+}

--- a/packages/engine/src/index.mjs
+++ b/packages/engine/src/index.mjs
@@ -27,3 +27,9 @@ export { createWorkflowApplicationPort } from "./application/workflow-applicatio
 export { createMcpWorkflowStdioServer } from "./adapters/mcp/stdio-server.mjs";
 export { createMcpWorkflowToolHandlers } from "./adapters/mcp/workflow-tools.mjs";
 export { MCP_ADAPTER_ERROR, McpAdapterError } from "./adapters/mcp/errors.mjs";
+export {
+  normalizeMcpOperatorManifest,
+  readAndValidateMcpOperatorManifestFile,
+  resolveMcpOperatorManifestPath,
+  validateMcpOperatorManifest,
+} from "./config/mcp-operator-manifest.mjs";

--- a/packages/engine/test/fixtures/mcp-manifest/missing-command.json
+++ b/packages/engine/test/fixtures/mcp-manifest/missing-command.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "broken": {
+      "args": ["-e", "0"]
+    }
+  }
+}

--- a/packages/engine/test/fixtures/mcp-manifest/unknown-server-field.json
+++ b/packages/engine/test/fixtures/mcp-manifest/unknown-server-field.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "remote": {
+      "url": "https://example.invalid/mcp",
+      "command": "node"
+    }
+  }
+}

--- a/packages/engine/test/fixtures/mcp-manifest/unknown-top-level.json
+++ b/packages/engine/test/fixtures/mcp-manifest/unknown-top-level.json
@@ -1,0 +1,6 @@
+{
+  "mcpServers": {
+    "a": { "command": "node" }
+  },
+  "alwaysAllow": []
+}

--- a/packages/engine/test/fixtures/mcp-manifest/valid.json
+++ b/packages/engine/test/fixtures/mcp-manifest/valid.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "demo-tool": {
+      "command": "npx",
+      "args": ["-y", "@example/mcp-server@1.0.0"],
+      "env": {
+        "EXAMPLE_TOKEN": "REDACTED_PLACEHOLDER"
+      }
+    },
+    "minimal": {
+      "command": "node"
+    }
+  }
+}

--- a/packages/engine/test/mcp-operator-manifest.test.mjs
+++ b/packages/engine/test/mcp-operator-manifest.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  normalizeMcpOperatorManifest,
+  readAndValidateMcpOperatorManifestFile,
+  resolveMcpOperatorManifestPath,
+  validateMcpOperatorManifest,
+} from "../src/config/mcp-operator-manifest.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturesDir = path.join(__dirname, "fixtures", "mcp-manifest");
+
+describe("validateMcpOperatorManifest", () => {
+  it("accepts valid fixture and normalizes defaults", () => {
+    const data = JSON.parse(readFileSync(path.join(fixturesDir, "valid.json"), "utf8"));
+    const result = validateMcpOperatorManifest(data);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.manifest.mcpServers.minimal.command, "node");
+    assert.deepEqual(result.manifest.mcpServers.minimal.args, []);
+    assert.deepEqual(result.manifest.mcpServers.minimal.env, {});
+    assert.ok(Array.isArray(result.manifest.mcpServers["demo-tool"].args));
+    assert.equal(result.manifest.mcpServers["demo-tool"].env.EXAMPLE_TOKEN, "REDACTED_PLACEHOLDER");
+  });
+
+  it("rejects unknown top-level keys with actionable errors", () => {
+    const data = JSON.parse(readFileSync(path.join(fixturesDir, "unknown-top-level.json"), "utf8"));
+    const result = validateMcpOperatorManifest(data);
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    const msg = JSON.stringify(result.errors ?? []);
+    assert.ok(msg.includes("alwaysAllow") || msg.includes("additional properties"), msg);
+  });
+
+  it("rejects unknown server fields (e.g. url alongside strict schema)", () => {
+    const data = JSON.parse(readFileSync(path.join(fixturesDir, "unknown-server-field.json"), "utf8"));
+    const result = validateMcpOperatorManifest(data);
+    assert.equal(result.ok, false);
+  });
+
+  it("rejects missing command", () => {
+    const data = JSON.parse(readFileSync(path.join(fixturesDir, "missing-command.json"), "utf8"));
+    const result = validateMcpOperatorManifest(data);
+    assert.equal(result.ok, false);
+  });
+
+  it("rejects empty mcpServers", () => {
+    const result = validateMcpOperatorManifest({ mcpServers: {} });
+    assert.equal(result.ok, false);
+  });
+});
+
+describe("normalizeMcpOperatorManifest", () => {
+  it("copies args and env defensively", () => {
+    const raw = {
+      mcpServers: {
+        x: { command: "sh", args: ["-c", "true"], env: { A: "1" } },
+      },
+    };
+    const n = normalizeMcpOperatorManifest(raw);
+    n.mcpServers.x.args.push("mutated");
+    raw.mcpServers.x.args.push("raw-mutated");
+    assert.deepEqual(n.mcpServers.x.args, ["-c", "true", "mutated"]);
+  });
+});
+
+describe("readAndValidateMcpOperatorManifestFile", () => {
+  it("returns parse error for invalid JSON", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "mcp-manifest-"));
+    const bad = path.join(dir, "bad.json");
+    writeFileSync(bad, "{ not json", "utf8");
+    const result = await readAndValidateMcpOperatorManifestFile(bad);
+    rmSync(dir, { recursive: true, force: true });
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.ok(result.errors?.some((e) => e.keyword === "parse"));
+  });
+});
+
+describe("resolveMcpOperatorManifestPath", () => {
+  it("prefers explicitPath over env and default file", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "mcp-resolve-"));
+    const explicit = path.join(dir, "explicit.json");
+    const hidden = path.join(dir, ".agent-workflow", "mcp.json");
+    mkdirSync(path.dirname(hidden), { recursive: true });
+    writeFileSync(hidden, '{"mcpServers":{"h":{"command":"x"}}}', "utf8");
+    writeFileSync(explicit, '{"mcpServers":{"e":{"command":"y"}}}', "utf8");
+    const prev = process.env.AGENT_WORKFLOW_MCP_MANIFEST;
+    process.env.AGENT_WORKFLOW_MCP_MANIFEST = hidden;
+    try {
+      const got = resolveMcpOperatorManifestPath({ cwd: dir, explicitPath: explicit });
+      assert.equal(got, path.resolve(explicit));
+    } finally {
+      if (prev === undefined) delete process.env.AGENT_WORKFLOW_MCP_MANIFEST;
+      else process.env.AGENT_WORKFLOW_MCP_MANIFEST = prev;
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("uses AGENT_WORKFLOW_MCP_MANIFEST when set and no explicit path", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "mcp-env-"));
+    const p = path.join(dir, "from-env.json");
+    writeFileSync(p, '{"mcpServers":{"a":{"command":"z"}}}', "utf8");
+    const prev = process.env.AGENT_WORKFLOW_MCP_MANIFEST;
+    process.env.AGENT_WORKFLOW_MCP_MANIFEST = p;
+    try {
+      const got = resolveMcpOperatorManifestPath({ cwd: dir });
+      assert.equal(got, path.resolve(p));
+    } finally {
+      if (prev === undefined) delete process.env.AGENT_WORKFLOW_MCP_MANIFEST;
+      else process.env.AGENT_WORKFLOW_MCP_MANIFEST = prev;
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("falls back to .agent-workflow/mcp.json when present", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "mcp-default-"));
+    const defaultPath = path.join(dir, ".agent-workflow", "mcp.json");
+    mkdirSync(path.dirname(defaultPath), { recursive: true });
+    writeFileSync(defaultPath, '{"mcpServers":{"d":{"command":"w"}}}', "utf8");
+    try {
+      const got = resolveMcpOperatorManifestPath({ cwd: dir });
+      assert.equal(got, defaultPath);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null when nothing matches", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "mcp-none-"));
+    const prev = process.env.AGENT_WORKFLOW_MCP_MANIFEST;
+    delete process.env.AGENT_WORKFLOW_MCP_MANIFEST;
+    try {
+      assert.equal(resolveMcpOperatorManifestPath({ cwd: dir }), null);
+    } finally {
+      if (prev !== undefined) process.env.AGENT_WORKFLOW_MCP_MANIFEST = prev;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #68

## Summary
Implements operator MCP manifest loading contract: Cursor-style \mcpServers\ map with stdio \command\ / \rgs\ / \env\, strict JSON Schema validation, path resolution, and CLI validation.

## Spec / architecture traceability
- **ADR:** [ADR-0003](docs/architecture/adr/ADR-0003-engine-direct-mcp-activity-execution.md) (manifest alignment, secrets); dependency #67 runway satisfied on \main\.
- **RFC:** [RFC-06 §6.1](docs/RFC/rfc-06-interoperability.md#61-composing-mcp), [RFC-07](docs/RFC/rfc-07-security-model.md) cited in \docs/architecture/mcp-operator-manifest.md\.
- **Schema:** \packages/engine/schemas/mcp-operator-manifest.json\ (Draft 2020-12, \dditionalProperties: false\).

## Acceptance criteria (#68)
- [x] Documented schema + resolution order — architecture doc + schema path; resolution in \esolveMcpOperatorManifestPath\; validate via \workflows-engine mcp-manifest validate <file>\ (and \
pm run engine:mcp-manifest:validate -- <file>\).
- [x] Unknown keys / missing command — AJV errors with \instancePath\; empty \mcpServers\ rejected. No include directives — circular includes N/A (documented).
- [x] Unit tests + redacted fixtures under \packages/engine/test/fixtures/mcp-manifest/\.
- [x] Vendor divergence table in architecture doc.

## Testing
\
pm test\, \
pm run validate-workflows\, \
pm run conformance\.

Made with [Cursor](https://cursor.com)