### PR TITLE
feat(engine): MCP stdio activity executor for tool_call (#69)

### DIFF
--- a/packages/engine/src/index.mjs
+++ b/packages/engine/src/index.mjs
@@ -7,6 +7,13 @@
  */
 export * from "./validate.mjs";
 export { StubActivityExecutor } from "./orchestrator/activity-executor.mjs";
+export {
+  callMcpToolStdio,
+  DEFAULT_MCP_ACTIVITY_TOOL_TIMEOUT_MS,
+  mapMcpCallToolResultToActivityResult,
+  mapMcpClientThrownError,
+  McpManifestActivityExecutor,
+} from "./orchestrator/mcp-stdio-activity-executor.mjs";
 export { MemoryExecutionHistoryStore } from "./persistence/memory-history-store.mjs";
 export { SqliteExecutionHistoryStore } from "./persistence/sqlite-history-store.mjs";
 export {

--- a/packages/engine/src/orchestrator/mcp-stdio-activity-executor.mjs
+++ b/packages/engine/src/orchestrator/mcp-stdio-activity-executor.mjs
@@ -1,0 +1,198 @@
+/**
+ * Engine-direct MCP stdio client for `tools/call` against operator manifest server definitions.
+ *
+ * **Transport:** stdio subprocess only (operator manifest `command` / `args` / `env`).
+ * HTTP/SSE `url` servers are out of scope for this module; see `docs/architecture/mcp-operator-manifest.md`.
+ *
+ * **Timeouts:** `callMcpToolStdio` and {@link McpManifestActivityExecutor} use conservative defaults
+ * suitable for CI (`DEFAULT_MCP_ACTIVITY_TOOL_TIMEOUT_MS`). Override per call via `timeoutMs`, or pass
+ * `signal` (`AbortSignal`) for cancellation (connect + `tools/call` honor `RequestOptions.signal` from the MCP SDK).
+ *
+ * @see docs/architecture/adr/ADR-0003-engine-direct-mcp-activity-execution.md
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+
+/** Default for MCP initialize + tools/call (ms). Conservative for automation/CI. */
+export const DEFAULT_MCP_ACTIVITY_TOOL_TIMEOUT_MS = 45_000;
+
+/**
+ * Maps thrown errors from MCP client / stdio transport to ActivityFailed-compatible results.
+ *
+ * @param {unknown} err
+ * @returns {import("./activity-executor.mjs").ActivityExecutorResult}
+ */
+export function mapMcpClientThrownError(err) {
+  if (err instanceof DOMException && err.name === "AbortError") {
+    return { ok: false, error: "MCP tool call aborted", code: "ACTIVITY_CANCELLED" };
+  }
+  if (err instanceof McpError) {
+    if (err.code === ErrorCode.RequestTimeout) {
+      return { ok: false, error: err.message, code: "ACTIVITY_TIMEOUT" };
+    }
+    if (err.code === ErrorCode.ConnectionClosed) {
+      return { ok: false, error: err.message, code: "MCP_CONNECTION_CLOSED" };
+    }
+    return { ok: false, error: err.message, code: "MCP_PROTOCOL_ERROR" };
+  }
+  if (err instanceof Error) {
+    if (err.name === "AbortError") {
+      return { ok: false, error: err.message || "aborted", code: "ACTIVITY_CANCELLED" };
+    }
+    return { ok: false, error: err.message, code: "MCP_CLIENT_ERROR" };
+  }
+  return { ok: false, error: String(err), code: "MCP_CLIENT_ERROR" };
+}
+
+/**
+ * @param {unknown} content
+ * @returns {string}
+ */
+function joinTextToolContent(content) {
+  if (!Array.isArray(content)) return "";
+  const parts = [];
+  for (const block of content) {
+    if (block && typeof block === "object" && block.type === "text" && typeof block.text === "string") {
+      parts.push(block.text);
+    }
+  }
+  return parts.join("\n").trim();
+}
+
+/**
+ * Interprets a successful `client.callTool` return value into an activity result.
+ *
+ * @param {Record<string, unknown>} result
+ * @returns {import("./activity-executor.mjs").ActivityExecutorResult}
+ */
+export function mapMcpCallToolResultToActivityResult(result) {
+  if (result.isError === true) {
+    const msg = joinTextToolContent(result.content) || "MCP tool returned isError";
+    return { ok: false, error: msg, code: "MCP_TOOL_EXECUTION_ERROR" };
+  }
+  if (result.structuredContent && typeof result.structuredContent === "object" && !Array.isArray(result.structuredContent)) {
+    return { ok: true, output: /** @type {Record<string, unknown>} */ ({ ...result.structuredContent }) };
+  }
+  const text = joinTextToolContent(result.content);
+  if (text) {
+    return { ok: true, output: { text } };
+  }
+  return { ok: true, output: { content: result.content ?? [] } };
+}
+
+/**
+ * Spawns an MCP stdio server, completes initialize, invokes `tools/call`, then closes the client.
+ *
+ * @param {import("../config/mcp-operator-manifest.mjs").McpStdioServerDefinition} serverDef
+ * @param {string} toolName
+ * @param {Record<string, unknown>} toolArguments
+ * @param {{
+ *   timeoutMs?: number;
+ *   signal?: AbortSignal;
+ *   clientName?: string;
+ *   clientVersion?: string;
+ * }} [options]
+ * @returns {Promise<import("./activity-executor.mjs").ActivityExecutorResult>}
+ */
+export async function callMcpToolStdio(serverDef, toolName, toolArguments, options = {}) {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_MCP_ACTIVITY_TOOL_TIMEOUT_MS;
+  const client = new Client(
+    {
+      name: options.clientName ?? "@agent-workflow/engine-mcp-activity-client",
+      version: options.clientVersion ?? "0.0.0",
+    },
+    {}
+  );
+  const transport = new StdioClientTransport({
+    command: serverDef.command,
+    args: serverDef.args ?? [],
+    env: serverDef.env && typeof serverDef.env === "object" ? { ...serverDef.env } : {},
+  });
+  try {
+    await client.connect(transport, { timeout: timeoutMs, signal: options.signal });
+    const raw = await client.callTool({ name: toolName, arguments: toolArguments }, undefined, {
+      timeout: timeoutMs,
+      signal: options.signal,
+    });
+    return mapMcpCallToolResultToActivityResult(/** @type {Record<string, unknown>} */ (raw));
+  } catch (err) {
+    return mapMcpClientThrownError(err);
+  } finally {
+    try {
+      await client.close();
+    } catch {
+      // ignore shutdown errors
+    }
+  }
+}
+
+/**
+ * ActivityExecutor that runs `tool_call` nodes via MCP stdio using a normalized operator manifest.
+ * `step` and `llm_call` are rejected (use stub/host-mediated paths for those in R2).
+ *
+ * @implements {import("./activity-executor.mjs").ActivityExecutor}
+ */
+export class McpManifestActivityExecutor {
+  /**
+   * @param {{
+   *   manifest: import("../config/mcp-operator-manifest.mjs").NormalizedMcpOperatorManifest;
+   *   defaultTimeoutMs?: number;
+   *   getAbortSignal?: () => AbortSignal | undefined;
+   *   clientName?: string;
+   *   clientVersion?: string;
+   * }} opts
+   */
+  constructor(opts) {
+    this.manifest = opts.manifest;
+    this.defaultTimeoutMs = opts.defaultTimeoutMs ?? DEFAULT_MCP_ACTIVITY_TOOL_TIMEOUT_MS;
+    this.getAbortSignal = opts.getAbortSignal;
+    this.clientName = opts.clientName;
+    this.clientVersion = opts.clientVersion;
+  }
+
+  /**
+   * @param {import("./activity-executor.mjs").ActivityExecutorContext} ctx
+   * @returns {Promise<import("./activity-executor.mjs").ActivityExecutorResult>}
+   */
+  async executeActivity(ctx) {
+    const { node } = ctx;
+    if (node.type !== "tool_call") {
+      return {
+        ok: false,
+        error: `McpManifestActivityExecutor only supports tool_call nodes (got ${node.type})`,
+        code: "ACTIVITY_EXECUTOR_UNSUPPORTED_NODE",
+      };
+    }
+    const cfg = node.config && typeof node.config === "object" && !Array.isArray(node.config) ? node.config : {};
+    const serverKey = typeof cfg.server === "string" ? cfg.server : "";
+    const toolName = typeof cfg.tool === "string" ? cfg.tool : "";
+    if (!serverKey || !toolName) {
+      return {
+        ok: false,
+        error: "tool_call node requires config.server and config.tool strings",
+        code: "INVALID_TOOL_CALL_CONFIG",
+      };
+    }
+    const serverDef = this.manifest.mcpServers[serverKey];
+    if (!serverDef) {
+      return {
+        ok: false,
+        error: `No MCP server "${serverKey}" in operator manifest`,
+        code: "MCP_SERVER_NOT_CONFIGURED",
+      };
+    }
+    const toolArguments =
+      cfg.arguments && typeof cfg.arguments === "object" && !Array.isArray(cfg.arguments)
+        ? /** @type {Record<string, unknown>} */ ({ ...cfg.arguments })
+        : {};
+    const signal = this.getAbortSignal?.();
+    return callMcpToolStdio(serverDef, toolName, toolArguments, {
+      timeoutMs: this.defaultTimeoutMs,
+      signal,
+      clientName: this.clientName,
+      clientVersion: this.clientVersion,
+    });
+  }
+}

--- a/packages/engine/test/fixtures/mcp-echo-stdio-server.mjs
+++ b/packages/engine/test/fixtures/mcp-echo-stdio-server.mjs
@@ -1,0 +1,37 @@
+/**
+ * Minimal MCP stdio server for engine tests: tools `echo` and `fail_tool`.
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const inputSchema = z.object({}).passthrough();
+
+const server = new McpServer({ name: "workflow-test-echo-mcp", version: "0.0.0" });
+
+server.registerTool(
+  "echo",
+  {
+    title: "Echo",
+    description: "Returns arguments as structuredContent.echoed",
+    inputSchema,
+  },
+  async (args) => ({
+    structuredContent: { echoed: args },
+    content: [],
+  })
+);
+
+server.registerTool(
+  "fail_tool",
+  {
+    title: "Always fails",
+    inputSchema,
+  },
+  async () => ({
+    isError: true,
+    content: [{ type: "text", text: "intentional tool failure" }],
+  })
+);
+
+await server.connect(new StdioServerTransport());

--- a/packages/engine/test/mcp-stdio-activity-executor.test.mjs
+++ b/packages/engine/test/mcp-stdio-activity-executor.test.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { runLinearWorkflow } from "../src/orchestrator/linear-runner.mjs";
+import { MemoryExecutionHistoryStore } from "../src/persistence/memory-history-store.mjs";
+import {
+  callMcpToolStdio,
+  mapMcpCallToolResultToActivityResult,
+  mapMcpClientThrownError,
+  McpManifestActivityExecutor,
+} from "../src/orchestrator/mcp-stdio-activity-executor.mjs";
+
+const echoServerPath = fileURLToPath(new URL("./fixtures/mcp-echo-stdio-server.mjs", import.meta.url));
+const linearFixturePath = fileURLToPath(new URL("./fixtures/linear.workflow.json", import.meta.url));
+
+describe("mapMcpClientThrownError", () => {
+  it("maps McpError RequestTimeout", () => {
+    const r = mapMcpClientThrownError(new McpError(ErrorCode.RequestTimeout, "slow", undefined));
+    assert.equal(r.ok, false);
+    assert.equal(r.code, "ACTIVITY_TIMEOUT");
+  });
+
+  it("maps McpError ConnectionClosed", () => {
+    const r = mapMcpClientThrownError(new McpError(ErrorCode.ConnectionClosed, "closed", undefined));
+    assert.equal(r.ok, false);
+    assert.equal(r.code, "MCP_CONNECTION_CLOSED");
+  });
+
+  it("maps generic Error", () => {
+    const r = mapMcpClientThrownError(new Error("spawn xyz failed"));
+    assert.equal(r.ok, false);
+    assert.equal(r.code, "MCP_CLIENT_ERROR");
+  });
+});
+
+describe("mapMcpCallToolResultToActivityResult", () => {
+  it("maps isError tool results", () => {
+    const r = mapMcpCallToolResultToActivityResult({
+      isError: true,
+      content: [{ type: "text", text: "bad" }],
+    });
+    assert.equal(r.ok, false);
+    assert.match(r.error ?? "", /bad/);
+    assert.equal(r.code, "MCP_TOOL_EXECUTION_ERROR");
+  });
+
+  it("maps structuredContent to output", () => {
+    const r = mapMcpCallToolResultToActivityResult({
+      structuredContent: { a: 1 },
+      content: [],
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) assert.deepEqual(r.output, { a: 1 });
+  });
+});
+
+describe("callMcpToolStdio (integration)", () => {
+  it("invokes echo tool on fixture stdio server", async () => {
+    const serverDef = {
+      command: process.execPath,
+      args: [echoServerPath],
+      env: {},
+    };
+    const r = await callMcpToolStdio(serverDef, "echo", { hello: "mcp" }, { timeoutMs: 20_000 });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.deepEqual(r.output.echoed, { hello: "mcp" });
+    }
+  });
+
+  it("maps tool isError from fixture", async () => {
+    const serverDef = {
+      command: process.execPath,
+      args: [echoServerPath],
+      env: {},
+    };
+    const r = await callMcpToolStdio(serverDef, "fail_tool", {}, { timeoutMs: 20_000 });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.match(r.error, /intentional/);
+      assert.equal(r.code, "MCP_TOOL_EXECUTION_ERROR");
+    }
+  });
+});
+
+describe("McpManifestActivityExecutor", () => {
+  it("rejects non-tool_call nodes", async () => {
+    const ex = new McpManifestActivityExecutor({
+      manifest: { mcpServers: { x: { command: process.execPath, args: [], env: {} } } },
+    });
+    const r = await ex.executeActivity({
+      executionId: "e1",
+      node: { id: "n1", type: "step", config: { handler: "h" } },
+      state: {},
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "ACTIVITY_EXECUTOR_UNSUPPORTED_NODE");
+  });
+
+  it("fails when server label is missing from manifest", async () => {
+    const ex = new McpManifestActivityExecutor({
+      manifest: { mcpServers: {} },
+    });
+    const r = await ex.executeActivity({
+      executionId: "e1",
+      node: { id: "t1", type: "tool_call", config: { server: "missing", tool: "echo", arguments: {} } },
+      state: {},
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "MCP_SERVER_NOT_CONFIGURED");
+  });
+
+  it("runs tool_call via manifest server (integration)", async () => {
+    const manifest = {
+      mcpServers: {
+        echoSrv: {
+          command: process.execPath,
+          args: [echoServerPath],
+          env: {},
+        },
+      },
+    };
+    const definition = JSON.parse(readFileSync(linearFixturePath, "utf8"));
+    const toolNode = definition.nodes.find((n) => n.id === "enrich");
+    assert.ok(toolNode);
+    toolNode.type = "tool_call";
+    toolNode.config = { server: "echoSrv", tool: "echo", arguments: { via: "workflow" } };
+
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "exec-mcp-manifest-executor";
+    const ex = new McpManifestActivityExecutor({ manifest, defaultTimeoutMs: 25_000 });
+    const out = await runLinearWorkflow({
+      definition,
+      input: { ticket_text: "hello" },
+      executionId,
+      store,
+      activityExecutor: ex,
+    });
+    assert.equal(out.status, "completed");
+    const completed = store.listByExecution(executionId).filter((r) => r.name === "ActivityCompleted");
+    assert.ok(completed.length >= 1);
+    const last = completed[completed.length - 1];
+    assert.deepEqual(last.payload.result.echoed, { via: "workflow" });
+  });
+});


### PR DESCRIPTION
## What changed

- Added `packages/engine/src/orchestrator/mcp-stdio-activity-executor.mjs` with `callMcpToolStdio`, `mapMcpClientThrownError`, `mapMcpCallToolResultToActivityResult`, and `McpManifestActivityExecutor` for `tool_call` nodes against operator manifest stdio servers.
- Re-exported the new API from `packages/engine/src/index.mjs`.
- Added `packages/engine/test/fixtures/mcp-echo-stdio-server.mjs` and `packages/engine/test/mcp-stdio-activity-executor.test.mjs` (unit mappers plus stdio integration).

## Why this change

- Delivers the engine-direct MCP `tools/call` bridge for `in_process` / manifest-backed runs as specified in #69 (builds on closed #68 manifest loader).

## Roadmap alignment

- Linked issue: Closes #69
- Target release: `R2`
- Type: `feature`
- RFC trace links:
  - https://github.com/benvdbergh/workflows/blob/master/docs/RFC/rfc-06-interoperability.md

## Spec and architecture traceability

- Spec artifact link (operator manifest contract): https://github.com/benvdbergh/workflows/blob/master/docs/architecture/mcp-operator-manifest.md
- Architecture decision link: https://github.com/benvdbergh/workflows/blob/master/docs/architecture/adr/ADR-0003-engine-direct-mcp-activity-execution.md
- [x] Scope and constraints reviewed against `docs/poc-scope.md` and relevant `docs/RFC/*` — library-only executor; stdio-only per manifest; `step` / `llm_call` remain unsupported on this executor (explicit error code).
- [x] No workflow definition schema or golden fixture contract change in this PR.

## Architecture runway impact

- [x] No runway impact

## Validation

- [x] `npm run validate-workflows`
- [x] `npm run conformance`
- [x] `npm test`
- [x] Docs updated when behavior/contract changed — module-level JSDoc defers HTTP/SSE to manifest doc; no RFC/schema edit required.

## Risk and rollback

- Risk level: `low`
- Rollback/fallback plan: revert the commit; public API change is additive exports only.
