### PR TITLE
feat(mcp): enable engine-direct executor in workflows-engine-mcp

### DIFF
--- a/docs/architecture/mcp-stdio-host-smoke.md
+++ b/docs/architecture/mcp-stdio-host-smoke.md
@@ -33,6 +33,17 @@ Expected behavior:
 - Process stays running and waits on stdio for MCP requests.
 - No startup banner is required; absence of immediate crash is success.
 
+### Optional: engine-direct MCP `tool_call` (R2)
+
+To exercise **real** MCP `tools/call` for `tool_call` workflow nodes (instead of stubs), start the server with an operator manifest path:
+
+- **Environment:** set `WORKFLOW_ENGINE_MCP_CONFIG` to a manifest JSON path (same shape as `workflows-engine mcp-manifest validate` — see [`mcp-operator-manifest.md`](mcp-operator-manifest.md)).
+- **CLI:** append `--mcp-config /absolute/or/relative/path.json` after the `workflows-engine-mcp` bin; this wins over the env var when both are set.
+
+If the manifest cannot be read or fails schema validation, the process **exits with code 1** before listening on stdio (diagnostics on stderr). This path is **opt-in**; omit both to keep Story-4-3 default stub behavior.
+
+Trust boundaries, secrets, and when to prefer host-mediated execution: [ADR-0003](adr/ADR-0003-engine-direct-mcp-activity-execution.md). The host-mediated smoke steps below are unchanged; engine-direct does not replace `workflow_submit_activity` for `activity_execution_mode: host_mediated`.
+
 ## 2) Connect from an MCP-capable host (copy/paste)
 
 ### Operator setup (published package)

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -67,6 +67,19 @@ This starts a dedicated MCP stdio adapter layer with tools `workflow_start`, `wo
 
 Operator smoke runbook (Story-4-3): `docs/architecture/mcp-stdio-host-smoke.md`.
 
+### Engine-direct `tool_call` execution (optional)
+
+By default, `workflows-engine-mcp` uses the **in-process stub** executor for activity placeholders (same backward-compatible demo behavior as before).
+
+To run **`tool_call` nodes against real MCP stdio servers**, enable engine-direct configuration:
+
+- **Environment:** set `WORKFLOW_ENGINE_MCP_CONFIG` to the absolute or relative path of an operator MCP manifest JSON file.
+- **CLI:** pass `--mcp-config <path>` after the bin name (overrides `WORKFLOW_ENGINE_MCP_CONFIG` when both are set).
+
+The manifest matches the schema validated by `workflows-engine mcp-manifest validate` (Cursor-style `mcpServers` with stdio `command` / `args` / `env`). Workflow nodes use `tool_call` with `config.server` (manifest key) and `config.tool` (MCP tool name). If the file is missing or invalid JSON/schema, the process **exits with code 1** before accepting MCP traffic; errors are written to **stderr**.
+
+Security, credentials, and trust boundaries for this profile are documented in [ADR-0003: Engine-direct MCP activity execution](../../docs/architecture/adr/ADR-0003-engine-direct-mcp-activity-execution.md). Host-mediated completion via `workflow_submit_activity` is unchanged when you use `activity_execution_mode: host_mediated`; after a submit, continuations still use the same port-level executor when engine-direct is enabled.
+
 ### Host compatibility constraints for no-install use
 
 - **Node runtime:** Node.js `>=22.5.0` is required (uses `node:sqlite`).

--- a/packages/engine/src/adapters/mcp/stdio-server-config.mjs
+++ b/packages/engine/src/adapters/mcp/stdio-server-config.mjs
@@ -1,0 +1,80 @@
+/**
+ * Resolves engine-direct (MCP manifest) config for `workflows-engine-mcp` only.
+ * Does not use `AGENT_WORKFLOW_MCP_MANIFEST` or the default `.agent-workflow/mcp.json` path
+ * so the stdio server default remains stub in-process unless explicitly opted in.
+ *
+ * @see docs/architecture/adr/ADR-0003-engine-direct-mcp-activity-execution.md
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { readAndValidateMcpOperatorManifestFile } from "../../config/mcp-operator-manifest.mjs";
+import { McpManifestActivityExecutor } from "../../orchestrator/mcp-stdio-activity-executor.mjs";
+
+const enginePackageJsonPath = fileURLToPath(new URL("../../../package.json", import.meta.url));
+const enginePackageVersion = JSON.parse(readFileSync(enginePackageJsonPath, "utf8")).version;
+
+/**
+ * @param {string[]} argv process.argv
+ * @param {string} [cwd]
+ * @returns {string | null} Absolute path to manifest JSON, or null when engine-direct is not configured.
+ */
+export function resolveWorkflowEngineMcpConfigPath(argv, cwd = process.cwd()) {
+  const sliced = argv.slice(2);
+  for (let i = 0; i < sliced.length; i++) {
+    if (sliced[i] === "--mcp-config" && i + 1 < sliced.length) {
+      const p = sliced[i + 1];
+      return path.isAbsolute(p) ? p : path.resolve(cwd, p);
+    }
+  }
+  const env = process.env.WORKFLOW_ENGINE_MCP_CONFIG;
+  if (env && String(env).trim() !== "") {
+    const p = String(env).trim();
+    return path.isAbsolute(p) ? p : path.resolve(cwd, p);
+  }
+  return null;
+}
+
+/**
+ * @param {ReadonlyArray<{ instancePath?: string; keyword: string; message?: string }>} errors
+ * @returns {string}
+ */
+export function formatMcpManifestValidationErrors(errors) {
+  const lines = [];
+  for (const err of errors) {
+    const line = [
+      err.instancePath !== undefined && err.instancePath !== ""
+        ? `instancePath: ${err.instancePath}`
+        : "instancePath: (root)",
+      `keyword: ${err.keyword}`,
+      err.message ? `message: ${err.message}` : null,
+    ]
+      .filter(Boolean)
+      .join(" | ");
+    lines.push(line);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * @param {string} manifestPath
+ * @param {{ cwd?: string }} [options]
+ * @returns {Promise<
+ *   | { ok: true; executor: import("../../orchestrator/mcp-stdio-activity-executor.mjs").McpManifestActivityExecutor }
+ *   | { ok: false; errors: ReadonlyArray<{ instancePath?: string; keyword: string; message?: string }> }
+ * >}
+ */
+export async function loadEngineDirectActivityExecutor(manifestPath, options = {}) {
+  const result = await readAndValidateMcpOperatorManifestFile(manifestPath, options);
+  if (!result.ok) {
+    return { ok: false, errors: result.errors };
+  }
+  const executor = new McpManifestActivityExecutor({
+    manifest: result.manifest,
+    clientName: "@agent-workflow/workflows-engine-mcp",
+    clientVersion: enginePackageVersion,
+  });
+  return { ok: true, executor };
+}
+
+export { enginePackageVersion };

--- a/packages/engine/src/application/workflow-application-port.mjs
+++ b/packages/engine/src/application/workflow-application-port.mjs
@@ -145,10 +145,14 @@ function findLatestNonCheckpointEvent(rows) {
 /**
  * Stable application-facing port for workflow control operations used by interface adapters.
  *
- * @param {{ store: import("../persistence/types.mjs").ExecutionHistoryStore }} deps
+ * @param {{
+ *   store: import("../persistence/types.mjs").ExecutionHistoryStore;
+ *   activityExecutor?: import("../orchestrator/activity-executor.mjs").ActivityExecutor;
+ * }} deps
+ * Optional `activityExecutor` runs `tool_call` nodes in-process (e.g. MCP manifest executor); omit to use the stub executor.
  */
 export function createWorkflowApplicationPort(deps) {
-  const { store } = deps;
+  const { store, activityExecutor } = deps;
 
   return {
     /**
@@ -166,6 +170,7 @@ export function createWorkflowApplicationPort(deps) {
         input: request.input,
         executionId,
         store,
+        ...(activityExecutor ? { activityExecutor } : {}),
         ...(request.activityExecutionMode ? { activityExecutionMode: request.activityExecutionMode } : {}),
       });
 
@@ -250,6 +255,7 @@ export function createWorkflowApplicationPort(deps) {
         executionId: request.executionId,
         resumePayload: request.resumePayload,
         store,
+        ...(activityExecutor ? { activityExecutor } : {}),
         ...(request.activityExecutionMode ? { activityExecutionMode: request.activityExecutionMode } : {}),
       });
 
@@ -288,6 +294,7 @@ export function createWorkflowApplicationPort(deps) {
         ...(request.activityExecutionMode ? { activityExecutionMode: request.activityExecutionMode } : {}),
         ...(request.stubActivityOutputs ? { stubActivityOutputs: request.stubActivityOutputs } : {}),
         ...(request.activityExecutor ? { activityExecutor: request.activityExecutor } : {}),
+        ...(!request.activityExecutor && activityExecutor ? { activityExecutor } : {}),
       });
 
       return {

--- a/packages/engine/src/mcp-stdio-server.mjs
+++ b/packages/engine/src/mcp-stdio-server.mjs
@@ -1,20 +1,47 @@
 #!/usr/bin/env node
 import { createWorkflowApplicationPort } from "./application/workflow-application-port.mjs";
 import { createMcpWorkflowStdioServer } from "./adapters/mcp/stdio-server.mjs";
+import {
+  formatMcpManifestValidationErrors,
+  loadEngineDirectActivityExecutor,
+  resolveWorkflowEngineMcpConfigPath,
+} from "./adapters/mcp/stdio-server-config.mjs";
 import { MemoryExecutionHistoryStore } from "./persistence/memory-history-store.mjs";
 
 async function main() {
-  const args = new Set(process.argv.slice(2));
-  if (args.has("--help") || args.has("-h")) {
+  const args = process.argv.slice(2);
+  if (args.includes("--help") || args.includes("-h")) {
     process.stdout.write(
-      "Usage: node packages/engine/src/mcp-stdio-server.mjs\n" +
-        "Starts MCP stdio adapter with workflow_start/workflow_status/workflow_resume/workflow_submit_activity tools.\n"
+      "Usage: workflows-engine-mcp [--mcp-config <path>]\n" +
+        "Starts MCP stdio adapter with workflow_start/workflow_status/workflow_resume/workflow_submit_activity tools.\n" +
+        "\n" +
+        "Engine-direct activity execution (real MCP tool_call via operator manifest):\n" +
+        "  Set WORKFLOW_ENGINE_MCP_CONFIG to a JSON file path, or pass --mcp-config <path>.\n" +
+        "  When unset, tool_call nodes use the in-process stub (backward-compatible default).\n" +
+        "  Manifest schema: same as `workflows-engine mcp-manifest validate` (mcpServers stdio subset).\n"
     );
     return;
   }
 
+  const manifestPath = resolveWorkflowEngineMcpConfigPath(process.argv);
+  let activityExecutor = undefined;
+  if (manifestPath) {
+    const loaded = await loadEngineDirectActivityExecutor(manifestPath);
+    if (!loaded.ok) {
+      process.stderr.write(
+        `[engine-mcp-stdio] Invalid operator manifest at ${manifestPath}:\n${formatMcpManifestValidationErrors(loaded.errors)}\n`
+      );
+      process.exitCode = 1;
+      return;
+    }
+    activityExecutor = loaded.executor;
+  }
+
   const store = new MemoryExecutionHistoryStore();
-  const workflowPort = createWorkflowApplicationPort({ store });
+  const workflowPort = createWorkflowApplicationPort({
+    store,
+    ...(activityExecutor ? { activityExecutor } : {}),
+  });
   const server = createMcpWorkflowStdioServer(workflowPort);
 
   process.on("uncaughtException", (error) => {

--- a/packages/engine/test/mcp-stdio-server-config.test.mjs
+++ b/packages/engine/test/mcp-stdio-server-config.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+import {
+  formatMcpManifestValidationErrors,
+  loadEngineDirectActivityExecutor,
+  resolveWorkflowEngineMcpConfigPath,
+} from "../src/adapters/mcp/stdio-server-config.mjs";
+import { createWorkflowApplicationPort } from "../src/application/workflow-application-port.mjs";
+import { MemoryExecutionHistoryStore } from "../src/persistence/memory-history-store.mjs";
+
+const echoServerPath = fileURLToPath(new URL("./fixtures/mcp-echo-stdio-server.mjs", import.meta.url));
+const linearFixturePath = fileURLToPath(new URL("./fixtures/linear.workflow.json", import.meta.url));
+
+describe("resolveWorkflowEngineMcpConfigPath", () => {
+  it("prefers --mcp-config over env", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-mcp-"));
+    const a = path.join(dir, "a.json");
+    const b = path.join(dir, "b.json");
+    writeFileSync(a, "{}");
+    writeFileSync(b, "{}");
+    const prev = process.env.WORKFLOW_ENGINE_MCP_CONFIG;
+    process.env.WORKFLOW_ENGINE_MCP_CONFIG = b;
+    try {
+      const argv = ["node", "mcp.mjs", "--mcp-config", a];
+      assert.equal(resolveWorkflowEngineMcpConfigPath(argv, dir), a);
+    } finally {
+      if (prev === undefined) delete process.env.WORKFLOW_ENGINE_MCP_CONFIG;
+      else process.env.WORKFLOW_ENGINE_MCP_CONFIG = prev;
+    }
+  });
+
+  it("uses WORKFLOW_ENGINE_MCP_CONFIG when flag absent", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-mcp-"));
+    const p = path.join(dir, "mcp.json");
+    writeFileSync(p, "{}");
+    const prev = process.env.WORKFLOW_ENGINE_MCP_CONFIG;
+    process.env.WORKFLOW_ENGINE_MCP_CONFIG = "mcp.json";
+    try {
+      assert.equal(resolveWorkflowEngineMcpConfigPath(["node", "mcp.mjs"], dir), p);
+    } finally {
+      if (prev === undefined) delete process.env.WORKFLOW_ENGINE_MCP_CONFIG;
+      else process.env.WORKFLOW_ENGINE_MCP_CONFIG = prev;
+    }
+  });
+
+  it("returns null when not configured", () => {
+    const prev = process.env.WORKFLOW_ENGINE_MCP_CONFIG;
+    delete process.env.WORKFLOW_ENGINE_MCP_CONFIG;
+    try {
+      assert.equal(resolveWorkflowEngineMcpConfigPath(["node", "mcp.mjs"], process.cwd()), null);
+    } finally {
+      if (prev !== undefined) process.env.WORKFLOW_ENGINE_MCP_CONFIG = prev;
+    }
+  });
+});
+
+describe("loadEngineDirectActivityExecutor", () => {
+  it("returns ok false for invalid manifest", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-mcp-"));
+    const bad = path.join(dir, "bad.json");
+    writeFileSync(bad, "{");
+    const r = await loadEngineDirectActivityExecutor(bad);
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.ok(r.errors.length >= 1);
+  });
+
+  it("loads executor for valid manifest", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-mcp-"));
+    const manifestPath = path.join(dir, "mcp.json");
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        mcpServers: {
+          echoSrv: {
+            command: process.execPath,
+            args: [echoServerPath],
+            env: {},
+          },
+        },
+      })
+    );
+    const r = await loadEngineDirectActivityExecutor(manifestPath);
+    assert.equal(r.ok, true);
+    if (r.ok) assert.ok(r.executor);
+  });
+});
+
+describe("createWorkflowApplicationPort + engine-direct executor", () => {
+  it("workflow_start runs tool_call via MCP when executor is configured", async () => {
+    const definition = JSON.parse(readFileSync(linearFixturePath, "utf8"));
+    const toolNode = definition.nodes.find((n) => n.id === "enrich");
+    assert.ok(toolNode);
+    toolNode.type = "tool_call";
+    toolNode.config = { server: "echoSrv", tool: "echo", arguments: { via: "port" } };
+
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-mcp-"));
+    const manifestPath = path.join(dir, "manifest.json");
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        mcpServers: {
+          echoSrv: {
+            command: process.execPath,
+            args: [echoServerPath],
+            env: {},
+          },
+        },
+      })
+    );
+
+    const loaded = await loadEngineDirectActivityExecutor(manifestPath);
+    assert.equal(loaded.ok, true);
+    if (!loaded.ok) return;
+
+    const store = new MemoryExecutionHistoryStore();
+    const port = createWorkflowApplicationPort({ store, activityExecutor: loaded.executor });
+    const out = await port.startWorkflow({
+      executionId: "port-engine-direct-1",
+      definition,
+      input: { ticket_text: "hello" },
+    });
+
+    assert.equal(out.status, "completed");
+    const rows = store.listByExecution("port-engine-direct-1");
+    const completed = rows.filter((r) => r.name === "ActivityCompleted");
+    assert.ok(completed.length >= 1);
+    const last = completed[completed.length - 1];
+    assert.deepEqual(last.payload.result.echoed, { via: "port" });
+  });
+});
+
+describe("formatMcpManifestValidationErrors", () => {
+  it("formats rows", () => {
+    const s = formatMcpManifestValidationErrors([
+      { instancePath: "/x", keyword: "type", message: "must be object" },
+    ]);
+    assert.match(s, /instancePath: \/x/);
+    assert.match(s, /must be object/);
+  });
+});


### PR DESCRIPTION
## What changed

- `workflows-engine-mcp` optionally loads an operator MCP manifest via **`WORKFLOW_ENGINE_MCP_CONFIG`** or **`--mcp-config <path>`**, constructs **`McpManifestActivityExecutor`**, and wires it through **`createWorkflowApplicationPort`** so default **`activity_execution_mode` `in_process`** runs real **`tool_call`** nodes when the workflow references configured servers/tools.
- **`createWorkflowApplicationPort`** accepts optional **`activityExecutor`** for **`startWorkflow`**, **`resumeWorkflow`**, and **`submitWorkflowActivity`** (submit keeps per-request executor override; otherwise uses port-level executor so host-mediated submit + continuation stays correct).
- New module **`adapters/mcp/stdio-server-config.mjs`**: path resolution, manifest load, stderr formatting on validation failure (process exits before stdio when invalid).
- Tests: config resolution, load, **`workflow_start`** integration with echo MCP fixture.
- Docs: **`packages/engine/README.md`**, **`docs/architecture/mcp-stdio-host-smoke.md`** (ADR-0003, operator examples).

## Why this change

- Closes the R2 interop story to enable **engine-direct** execution from the published MCP stdio entrypoint while keeping **stub** default for backward-compatible demos (issue #70).

## Roadmap alignment

- Linked issue: Closes #70
- Target release: `R2`
- Type: `feature`
- RFC trace links:
  - Interop / MCP execution model (host-mediated vs engine-direct) per RFC-06; operator manifest: `docs/architecture/mcp-operator-manifest.md`

## Spec and architecture traceability

- Spec artifact link (required for feature/runway PRs):
  - `docs/poc-scope.md` (POC + R2 profile); workflow definition schema unchanged
- Architecture decision link (ADR/design note, if applicable):
  - `docs/architecture/adr/ADR-0003-engine-direct-mcp-activity-execution.md` (trust boundaries, opt-in engine-direct)
- [x] Scope and constraints reviewed against `docs/poc-scope.md` and relevant `docs/RFC/*`
- [x] If behavior/contract changed, corresponding spec/design docs were updated first or in this PR (README + runbook; no schema change)

## Architecture runway impact

- [x] No runway impact
- [ ] Adds/updates runway enabler
- [ ] Depends on runway enabler (link issue)

## Validation

- [x] `npm run validate-workflows`
- [x] `npm run conformance`
- [x] `npm test`
- [x] Docs updated when behavior/contract changed

## Risk and rollback

- Risk level: `medium` (new subprocess MCP calls when opt-in manifest is set; default path unchanged)
- Rollback/fallback plan: Revert PR; operators unset `WORKFLOW_ENGINE_MCP_CONFIG` / remove `--mcp-config` to restore stub-only behavior.
