### PR TITLE
feat(conformance): engine-direct replay invariants for tool_call (#71)

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -34,7 +34,7 @@ Current domain coverage:
 
 - `vectors/schema/valid/*.vector.json`
 - `vectors/schema/invalid/*.vector.json`
-- `vectors/replay/**/*.vector.json` (includes `replay/host-activity/` for host-mediated activity replay and submit error codes)
+- `vectors/replay/**/*.vector.json` (includes `replay/host-activity/` for host-mediated activity replay and submit error codes; `replay/engine-direct-activity/` for in-process / engine-direct replay invariants)
 
 Future domains (replay, reducers, interrupts) should follow the same layout and runner contract.
 
@@ -96,7 +96,8 @@ Replay fields:
 - `expect.status`: expected terminal status (`completed`, `failed`, `interrupted`, or `awaiting_activity` when no successful continuation ran).
 - `expect.tailCommands` (optional): exact post-prefix command tail (type/order + stable identity fields like `nodeId`).
 - `expect.mismatch` (optional): expected deterministic mismatch diagnostics (message fragment and expected/actual command identity).
-- `activityExecutionMode` (optional): `"in_process"` (default) or `"host_mediated"` for `runPocWorkflow` after prefix injection.
+- `activityExecutionMode` (optional): `"in_process"` (default) or `"host_mediated"` for `runPocWorkflow` after prefix injection. **In-process** is the same activity port the engine uses for engine-direct execution (MCP or other `ActivityExecutor`); **host_mediated** yields at `ActivityRequested` until a submit.
+- `assertNoActivityExecutorInvocation` (optional): when `true`, the harness wires a `RejectingActivityExecutor` that fails any `executeActivity` call. Use with `activityExecutionMode: "in_process"` and a `historyPrefix` that already records `ActivityRequested` / `ActivityCompleted` for every `tool_call` the tail will revisit, so the run proves **tail replay does not re-invoke the activity port** (no duplicate “external” calls; deterministic stub). Ordering is still asserted via `expect.tailCommands` (command stream), matching host-mediated replay vectors that omit this flag.
 - `activitySubmissions` (optional): ordered `submitActivityOutcome` steps after the initial run. Each entry has `nodeId`, `outcome`, optional `expectedParallelSpan` when the pending `ActivityRequested` carries `parallelSpan`, and optional `expectFailure: { code }` to assert a failed submit without continuing (e.g. `ACTIVITY_SUBMIT_NODE_MISMATCH`, `ACTIVITY_SUBMIT_PARALLEL_MISMATCH`, `ACTIVITY_SUBMIT_NOT_AWAITING`).
 
 ## Discovery contract
@@ -134,6 +135,7 @@ The matrix below maps RFC-08 section `8.2 Conformance tests` areas to the curren
 | Interrupt resume (validation failure vs success) | Partial | Replay vectors exercise resume cursor behavior; lighthouse happy-path coverage is active, while dedicated interrupt resume conformance vectors are still deferred |
 | MCP tool mapping roundtrip (mock server) | Deferred | MCP adapter conformance vectors not yet implemented in harness |
 | Host-mediated activity replay / submit | Implemented | `vectors/replay/host-activity/` (linear + parallel branch correlation, replay-safe `ActivityCompleted` in prefix, duplicate and mismatch submits) |
+| Engine-direct (in-process) activity replay — no duplicate activity port calls | Implemented | `vectors/replay/engine-direct-activity/` (`assertNoActivityExecutorInvocation` + `ActivityCompleted` in prefix; linear + parallel `tool_call`) |
 
 ## Deferral register (out-of-scope or pending)
 

--- a/conformance/runner.mjs
+++ b/conformance/runner.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { validateWorkflowDefinition } from "../packages/engine/src/validate.mjs";
 import {
   MemoryExecutionHistoryStore,
+  RejectingActivityExecutor,
   runPocWorkflow,
   submitActivityOutcome,
 } from "../packages/engine/src/index.mjs";
@@ -25,6 +26,7 @@ const vectorsRoot = path.join(__dirname, "vectors");
  *     payload?: Record<string, unknown>;
  *   }>;
  *   activityExecutionMode?: "in_process" | "host_mediated";
+ *   assertNoActivityExecutorInvocation?: boolean;
  *   activitySubmissions?: Array<{
  *     nodeId: string;
  *     outcome:
@@ -169,6 +171,8 @@ async function runReplayVector(vector) {
 
   const activityExecutionMode = vector.activityExecutionMode ?? "in_process";
   const activitySubmissions = Array.isArray(vector.activitySubmissions) ? vector.activitySubmissions : [];
+  const assertNoActivityExecutorInvocation = vector.assertNoActivityExecutorInvocation === true;
+  const activityExecutor = assertNoActivityExecutorInvocation ? new RejectingActivityExecutor() : undefined;
 
   let run = await runPocWorkflow({
     definition,
@@ -176,6 +180,7 @@ async function runReplayVector(vector) {
     executionId,
     store,
     activityExecutionMode,
+    ...(activityExecutor ? { activityExecutor } : {}),
   });
 
   for (const step of activitySubmissions) {
@@ -188,6 +193,7 @@ async function runReplayVector(vector) {
       outcome: step.outcome,
       ...(step.expectedParallelSpan ? { expectedParallelSpan: step.expectedParallelSpan } : {}),
       activityExecutionMode,
+      ...(activityExecutor ? { activityExecutor } : {}),
     });
     if (step.expectFailure) {
       if (sub.status !== "failed" || sub.code !== step.expectFailure.code) {

--- a/conformance/vectors/replay/engine-direct-activity/linear-in-process-replay-completed-no-invoke.vector.json
+++ b/conformance/vectors/replay/engine-direct-activity/linear-in-process-replay-completed-no-invoke.vector.json
@@ -1,0 +1,71 @@
+{
+  "id": "replay.engine_direct_activity.linear.in_process_replay_completed_no_invoke",
+  "description": "in_process (engine-direct) mode with a rejecting activity port: history already has ActivityCompleted for the tool_call; tail replay must not invoke executeActivity (parity with host-mediated replay safety).",
+  "kind": "replay",
+  "definition": "examples/conformance-host-activity-linear.workflow.json",
+  "input": {},
+  "activityExecutionMode": "in_process",
+  "assertNoActivityExecutorInvocation": true,
+  "historyPrefix": [
+    {
+      "kind": "event",
+      "name": "ExecutionStarted",
+      "payload": {
+        "workflowName": "conformance-host-linear",
+        "workflowVersion": "1.0.0",
+        "inputKeys": []
+      }
+    },
+    {
+      "kind": "command",
+      "name": "ScheduleNode",
+      "payload": { "nodeId": "start" }
+    },
+    {
+      "kind": "event",
+      "name": "NodeScheduled",
+      "payload": { "nodeId": "start" }
+    },
+    {
+      "kind": "command",
+      "name": "CompleteNode",
+      "payload": { "nodeId": "start", "output": {} }
+    },
+    {
+      "kind": "event",
+      "name": "StateUpdated",
+      "payload": { "nodeId": "start", "state": {} }
+    },
+    {
+      "kind": "command",
+      "name": "ScheduleNode",
+      "payload": { "nodeId": "work" }
+    },
+    {
+      "kind": "event",
+      "name": "NodeScheduled",
+      "payload": { "nodeId": "work" }
+    },
+    {
+      "kind": "event",
+      "name": "ActivityRequested",
+      "payload": { "nodeId": "work", "nodeType": "tool_call" }
+    },
+    {
+      "kind": "event",
+      "name": "ActivityCompleted",
+      "payload": {
+        "nodeId": "work",
+        "result": { "out": "replay" }
+      }
+    }
+  ],
+  "expect": {
+    "status": "completed",
+    "tailCommands": [
+      { "name": "CompleteNode", "nodeId": "work" },
+      { "name": "ScheduleNode", "nodeId": "end" },
+      { "name": "CompleteNode", "nodeId": "end" }
+    ]
+  }
+}

--- a/conformance/vectors/replay/engine-direct-activity/parallel-in-process-replay-completed-no-invoke.vector.json
+++ b/conformance/vectors/replay/engine-direct-activity/parallel-in-process-replay-completed-no-invoke.vector.json
@@ -1,0 +1,112 @@
+{
+  "id": "replay.engine_direct_activity.parallel.in_process_replay_completed_no_invoke",
+  "description": "Parallel branch tool_call: in_process + rejecting activity port; prefix includes ActivityRequested (with parallelSpan) and ActivityCompleted; tail replay must not invoke executeActivity for a1.",
+  "kind": "replay",
+  "definition": "examples/conformance-host-activity-parallel.workflow.json",
+  "input": {},
+  "activityExecutionMode": "in_process",
+  "assertNoActivityExecutorInvocation": true,
+  "historyPrefix": [
+    {
+      "kind": "event",
+      "name": "ExecutionStarted",
+      "payload": {
+        "workflowName": "conformance-host-par",
+        "workflowVersion": "1.0.0",
+        "inputKeys": []
+      }
+    },
+    {
+      "kind": "command",
+      "name": "ScheduleNode",
+      "payload": { "nodeId": "start" }
+    },
+    {
+      "kind": "event",
+      "name": "NodeScheduled",
+      "payload": { "nodeId": "start" }
+    },
+    {
+      "kind": "command",
+      "name": "CompleteNode",
+      "payload": { "nodeId": "start", "output": {} }
+    },
+    {
+      "kind": "event",
+      "name": "StateUpdated",
+      "payload": { "nodeId": "start", "state": {} }
+    },
+    {
+      "kind": "command",
+      "name": "ScheduleNode",
+      "payload": { "nodeId": "fork" }
+    },
+    {
+      "kind": "event",
+      "name": "NodeScheduled",
+      "payload": { "nodeId": "fork" }
+    },
+    {
+      "kind": "command",
+      "name": "StartParallel",
+      "payload": {
+        "nodeId": "fork",
+        "join": "all",
+        "branchNames": ["only"]
+      }
+    },
+    {
+      "kind": "event",
+      "name": "ParallelForked",
+      "payload": {
+        "nodeId": "fork",
+        "join": "all",
+        "branchNames": ["only"]
+      }
+    },
+    {
+      "kind": "command",
+      "name": "ScheduleNode",
+      "payload": { "nodeId": "a1" }
+    },
+    {
+      "kind": "event",
+      "name": "NodeScheduled",
+      "payload": { "nodeId": "a1" }
+    },
+    {
+      "kind": "event",
+      "name": "ActivityRequested",
+      "payload": {
+        "nodeId": "a1",
+        "nodeType": "tool_call",
+        "parallelSpan": {
+          "parallelNodeId": "fork",
+          "joinTargetId": "join",
+          "branchName": "only",
+          "branchEntryNodeId": "a1"
+        }
+      }
+    },
+    {
+      "kind": "event",
+      "name": "ActivityCompleted",
+      "payload": {
+        "nodeId": "a1",
+        "result": { "y": "branch" }
+      }
+    }
+  ],
+  "expect": {
+    "status": "completed",
+    "tailCommands": [
+      { "name": "CompleteNode", "nodeId": "a1" },
+      { "name": "JoinParallel", "nodeId": "fork" },
+      { "name": "CompleteNode", "nodeId": "fork" },
+      { "name": "ScheduleNode", "nodeId": "join" },
+      { "name": "CompleteNode", "nodeId": "join" },
+      { "name": "ScheduleNode", "nodeId": "end" },
+      { "name": "CompleteNode", "nodeId": "end" }
+    ]
+  }
+}

--- a/packages/engine/src/index.mjs
+++ b/packages/engine/src/index.mjs
@@ -6,7 +6,7 @@
  * @typedef {import("./orchestrator/activity-executor.mjs").ActivityExecutor} ActivityExecutor
  */
 export * from "./validate.mjs";
-export { StubActivityExecutor } from "./orchestrator/activity-executor.mjs";
+export { RejectingActivityExecutor, StubActivityExecutor } from "./orchestrator/activity-executor.mjs";
 export {
   callMcpToolStdio,
   DEFAULT_MCP_ACTIVITY_TOOL_TIMEOUT_MS,

--- a/packages/engine/src/orchestrator/activity-executor.mjs
+++ b/packages/engine/src/orchestrator/activity-executor.mjs
@@ -45,3 +45,23 @@ export class StubActivityExecutor {
     return { ok: true, output };
   }
 }
+
+/**
+ * Fails any `executeActivity` call. Use in conformance and tests to prove replay does not
+ * re-invoke the engine activity port (e.g. engine-direct MCP) when results are already in history.
+ *
+ * @implements {ActivityExecutor}
+ */
+export class RejectingActivityExecutor {
+  /**
+   * @param {ActivityExecutorContext} ctx
+   * @returns {Promise<ActivityExecutorResult>}
+   */
+  async executeActivity(ctx) {
+    return {
+      ok: false,
+      error: `CONFORMANCE_ACTIVITY_PORT_INVOKED: executeActivity was called for node ${ctx.node.id} (expected replay to use recorded ActivityCompleted only).`,
+      code: "CONFORMANCE_ACTIVITY_PORT_INVOKED",
+    };
+  }
+}


### PR DESCRIPTION
## What changed

- Added `RejectingActivityExecutor` (exported from `@agent-workflow/engine`) so conformance can prove the activity port is not invoked during replay when history already records `ActivityCompleted`.
- Extended `conformance/runner.mjs` with optional `assertNoActivityExecutorInvocation` on replay vectors.
- New replay vectors under `conformance/vectors/replay/engine-direct-activity/`: linear and parallel `tool_call` with `activityExecutionMode: "in_process"`, prefix including `ActivityRequested`/`ActivityCompleted`, and deterministic `expect.tailCommands`.
- Updated `conformance/README.md` (field docs + RFC-08 matrix row).

## Why this change

- Closes the acceptance criteria for **Conformance: replay invariants for engine-direct activities** (issue #71): parity with host-mediated replay safety using a deterministic harness stub (per issue, does not require #70).

## Roadmap alignment

- Linked issue: Closes #71
- Target release: `R2`
- Type: `feature`
- RFC trace links:
  - `docs/RFC/rfc-04-execution-model.md` (activity invocation + replay)

## Spec and architecture traceability

- Spec artifact link (required for feature/runway PRs):
  - `conformance/README.md`, `conformance/vectors/replay/engine-direct-activity/*.vector.json`
- Architecture decision link (ADR/design note, if applicable):
  - `docs/architecture/adr/ADR-0003-engine-direct-mcp-activity-execution.md` (engine-direct activity execution; replay invariants referenced in governance)
- [x] Scope and constraints reviewed against `docs/poc-scope.md` and relevant `docs/RFC/*`
- [x] If behavior/contract changed, corresponding spec/design docs were updated first or in this PR (harness + matrix only; no workflow schema change)

## Architecture runway impact

- [x] No runway impact
- [ ] Adds/updates runway enabler
- [ ] Depends on runway enabler (link issue)

## Validation

- [x] `npm run validate-workflows`
- [x] `npm run conformance`
- [x] `npm test`
- [x] Docs updated when behavior/contract changed (`conformance/README.md`)

## Risk and rollback

- Risk level: `low`
- Rollback/fallback plan: Revert this PR; no migration or published contract change beyond new optional export and harness field.
