### PR TITLE
chore: rename POC terminology to engine profile

### DIFF
--- a/.claude/skills/wf-execute/SKILL.md
+++ b/.claude/skills/wf-execute/SKILL.md
@@ -58,7 +58,7 @@ Use `references/skill-escalation.md` for escalation criteria.
 ### Build-ready preconditions (before setting in-progress)
 
 - Design evidence is present and aligned with `docs/governance/spec-architecture-governance.md` Gate B.
-- Scope trace is explicit to relevant RFC and `docs/poc-scope.md` boundaries.
+- Scope trace is explicit to relevant RFC and `docs/engine-profile.md` boundaries.
 - ADR posture is explicit: link existing ADR(s) or state "ADR deferred" with rationale and follow-up owner.
 - Architecture diagram evidence is current in `docs/architecture/arc42-assets/diagrams/as-built-views.drawio`; if target alignment is discussed, also reference `docs/architecture/arc42-assets/archive/target-state/rfc-target-views.drawio`.
 

--- a/.claude/skills/wf-plan/references/workflows-linear-backlog-override.md
+++ b/.claude/skills/wf-plan/references/workflows-linear-backlog-override.md
@@ -9,11 +9,11 @@ Do **not** draft long planning narratives as untracked files under the repositor
 | Artifact | Canonical location | Notes |
 |----------|-------------------|--------|
 | **Epics** (release umbrellas, runway themes) | **Linear project milestones** on [workflows](https://linear.app/ben-van-den-bergh/project/workflows-a5eb475ff80e/overview) | Milestone description holds outcome, scope, runway, exit criteria, planning posture. |
-| **Stories** (feature slices, executable work) | **Linear issues** on that project | Issue description holds acceptance criteria, technical notes, links to `docs/RFC/`, `docs/poc-scope.md`, ADRs. |
+| **Stories** (feature slices, executable work) | **Linear issues** on that project | Issue description holds acceptance criteria, technical notes, links to `docs/RFC/`, `docs/engine-profile.md`, ADRs. |
 | **Optional tasks** | **Linear sub-issues** | Under the parent story issue when needed. |
 | **Sequencing blockers** | Issue relations (`blocks` / `blocked by`) | Keep the graph sparse—real blockers only. |
 | **Release / horizon / commitment** | Milestone assignment + issue labels / project fields | See `docs/releases/linear-project-operating-model.md`. |
-| **Protocol, POC contract, architecture** | **`docs/`** (RFC, `poc-scope`, arc42, ADRs) | Unchanged; Linear items **link** here—they do not duplicate the contract. |
+| **Protocol, engine profile contract, architecture** | **`docs/`** (RFC, `engine-profile`, arc42, ADRs) | Unchanged; Linear items **link** here—they do not duplicate the contract. |
 | **Community bugs / security / small intake** | **GitHub issues** on `benvdbergh/workflows` | Not the planning backlog; see `CONTRIBUTING.md` / `SUPPORT.md`. |
 
 ### Traceability from GitHub migration
@@ -32,7 +32,7 @@ When an agent escalates to or follows **`project-planning`** for decomposition, 
 
 1. Apply the **same process** (dependencies, sizing, acceptance clarity).
 2. Emit results as **Linear milestones and issues** (MCP `plugin-linear-linear` per `references/linear-tooling-guide.md` and the global `project-planning` skill’s `references/linear-adoption.md`)—not as markdown under `docs` and not as new GitHub planning issues.
-3. For traceability, include in the issue description explicit links to RFC sections, `docs/poc-scope.md` anchors, ADRs, and `ROADMAP.md` release intent as needed.
+3. For traceability, include in the issue description explicit links to RFC sections, `docs/engine-profile.md` anchors, ADRs, and `ROADMAP.md` release intent as needed.
 
 ## `wf-plan`, `wf-design`, `wf-execute`
 

--- a/.claude/skills/workflow-engine-mcp/assets/workflow-definition-schema.json
+++ b/.claude/skills/workflow-engine-mcp/assets/workflow-definition-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://example.org/agent-workflow/v1/workflow-definition",
+  "$id": "https://agent-workflow.dev/schemas/workflow-definition.json/workflow-definition",
   "title": "Agent Workflow Protocol — workflow definition",
   "description": "JSON Schema for Agent Workflow Protocol workflow documents (includes parallel, wait, set_state orchestration nodes). Normative semantics follow RFC-03 workflow definition schema.",
   "type": "object",

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # Protocol and scope docs
 /docs/RFC/ @benvdbergh
-/docs/poc-scope.md @benvdbergh
+/docs/engine-profile.md @benvdbergh
 /ROADMAP.md @benvdbergh
 
 # Engine and schema

--- a/.github/ISSUE_TEMPLATE/02-feature-slice.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-slice.yml
@@ -43,7 +43,7 @@ body:
       description: Link the relevant RFC sections, scope notes, and design/ADR docs that define this slice.
       placeholder: |
         RFC trace:
-        POC scope impact:
+        engine profile impact:
         Design/ADR link:
     validations:
       required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@
   - 
 - Architecture decision link (ADR/design note, if applicable):
   - 
-- [ ] Scope and constraints reviewed against `docs/poc-scope.md` and relevant `docs/RFC/*`
+- [ ] Scope and constraints reviewed against `docs/engine-profile.md` and relevant `docs/RFC/*`
 - [ ] If behavior/contract changed, corresponding spec/design docs were updated first or in this PR
 
 ## Architecture runway impact

--- a/.github/workflows/reusable-validate-and-test.yml
+++ b/.github/workflows/reusable-validate-and-test.yml
@@ -58,7 +58,7 @@ jobs:
             git fetch --no-tags origin master || git fetch --no-tags origin main
           fi
 
-      - name: Check POC schema breaking changes
+      - name: Check workflow schema breaking changes
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             npm run check-schema-breaking-change -- --base-ref "origin/${{ github.base_ref }}"
@@ -74,10 +74,10 @@ jobs:
             npm run check-threat-model-touch -- --base-ref origin/master
           fi
 
-      - name: Verify engine bundled POC schema matches canonical
-        run: npm run check-engine-poc-schema-sync
+      - name: Verify engine bundled workflow schema matches canonical
+        run: npm run check-engine-schema-sync
 
-      - name: Validate POC workflow JSON against schema
+      - name: Validate workflow JSON against schema
         run: npm run validate-workflows
 
       - name: Run conformance harness

--- a/.project-planning.yaml
+++ b/.project-planning.yaml
@@ -17,7 +17,7 @@ linear:
   team_key: BEN
   mcp_server: plugin-linear-linear
 
-# Requirements and contract docs stay in-repo (RFC, poc-scope, ADRs).
+# Requirements and contract docs stay in-repo (RFC, engine-profile, ADRs).
 source_globs:
   - ROADMAP.md
   - "docs/**/*.md"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,16 +4,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repository is
 
-A specification, contract, and **POC engine** repository for the **Agent Workflow Protocol** — a vendor-neutral declarative workflow protocol for AI agent systems. The alpha line is `@agent-workflow/engine@0.1.2` (prior publish: `0.1.1` on `latest` / `alpha`). Publish via the manual **Release npm publish** workflow after tagging `v0.1.2`.
+A specification, contract, and **reference engine** repository for the **Agent Workflow Protocol** — a vendor-neutral declarative workflow protocol for AI agent systems. The alpha line is `@agent-workflow/engine@0.1.2` (prior publish: `0.1.1` on `latest` / `alpha`). Publish via the manual **Release npm publish** workflow after tagging `v0.1.2`.
 
 - `docs/RFC/` — nine-section RFC defining the protocol (workflow definition schema, execution model, MCP/REST/SDK integration, security, governance)
-- `docs/poc-scope.md` — **authoritative engine profile**: which node types, commands/events, and reducers the reference engine must support (read this before implementing anything)
-- `schemas/workflow-definition-poc.json` — JSON Schema Draft 2020-12 entry schema; validates POC workflow documents
+- `docs/engine-profile.md` — **authoritative engine profile**: which node types, commands/events, and reducers the reference engine must support (read this before implementing anything)
+- `schemas/workflow-definition.json` — JSON Schema Draft 2020-12 entry schema; validates workflow documents
 - `examples/` — golden fixtures (workflow + happy-path and failure/retry trace companions) for the lighthouse demo, plus a prompt-improver fixture
 - `conformance/` — conformance harness (`run-conformance.mjs`) with deterministic vector discovery under `conformance/vectors/` (`schema/` and `replay/` subtrees)
-- `packages/engine/` — **`@agent-workflow/engine`** (npm org scope `@agent-workflow`): POC validation (CLI + library), append-only command/event history (SQLite or in-memory), linear runner, full POC walker with `switch` and `interrupt` / resume, and MCP stdio adapter (see `packages/engine/README.md`)
+- `packages/engine/` — **`@agent-workflow/engine`** (npm org scope `@agent-workflow`): definition validation (CLI + library), append-only command/event history (SQLite or in-memory), linear runner, graph walker with `switch` and `interrupt` / resume, and MCP stdio adapter (see `packages/engine/README.md`)
 - `scripts/validate-workflows.mjs` — repo-wide AJV validation used by CI and aligned with the engine's schema options
-- `scripts/sync-engine-poc-schema.mjs` — syncs the root `schemas/workflow-definition-poc.json` into `packages/engine/schemas/` (run automatically on `prepack`)
+- `scripts/sync-engine-schema.mjs` — syncs the root `schemas/workflow-definition.json` into `packages/engine/schemas/` (run automatically on `prepack`)
 - **Linear** [workflows project](https://linear.app/ben-van-den-bergh/project/workflows-a5eb475ff80e/overview) — canonical epics/stories (milestones/issues), acceptance criteria, and planning narrative (see `.project-planning.yaml` and `.claude/skills/wf-plan/references/workflows-linear-backlog-override.md`). **GitHub issues** on `benvdbergh/workflows` remain for community intake (bugs, security, questions), not the planning backlog.
 - `docs/releases/` — release notes and versioning/CI governance docs for the alpha
 - `docs/architecture/` — arc42 baseline (`docs/architecture/arc42/`), linked assets under `docs/architecture/arc42-assets/` (diagrams, demos, operator runbooks); ADRs in `docs/architecture/adr/`
@@ -29,19 +29,19 @@ From the repository root (after `npm install`):
 | `npm run conformance` | Run deterministic conformance harness vectors; emits JSON summary on stdout and readable diagnostics on stderr |
 | `npm run engine:validate -- path/to/workflow.json` | Validate a single file with the engine CLI (stderr lists AJV errors) |
 | `npm run engine:mcp:stdio` | Start the MCP stdio adapter (in-memory store; for development/testing) |
-| `npm run check-engine-poc-schema-sync` | Verify the bundled engine schema is in sync with the root schema (run in CI) |
+| `npm run check-engine-schema-sync` | Verify the bundled engine schema is in sync with the root schema (run in CI) |
 | `npm test` | Run engine package tests |
 
 One-off validation with **ajv-cli** (no `npm install` required):
 
 ```bash
-npx --yes ajv-cli@5 validate -s schemas/workflow-definition-poc.json -d path/to/workflow.json --spec=draft2020
+npx --yes ajv-cli@5 validate -s schemas/workflow-definition.json -d path/to/workflow.json --spec=draft2020
 ```
 
 Lighthouse fixture:
 
 ```bash
-npx --yes ajv-cli@5 validate -s schemas/workflow-definition-poc.json -d examples/lighthouse-customer-routing.workflow.json --spec=draft2020
+npx --yes ajv-cli@5 validate -s schemas/workflow-definition.json -d examples/lighthouse-customer-routing.workflow.json --spec=draft2020
 ```
 
 **CI:** `.github/workflows/validate-workflows.yml` runs the reusable `reusable-validate-and-test.yml` workflow (validate + conformance + test) on pushes and pull requests to `main` and `master`. Manual `release-packaging.yml` and `release-npm-publish.yml` workflows gate release artifacts and trusted npm publishes behind the same quality-gate reusable. All workflows run Node.js 24.
@@ -73,7 +73,7 @@ MCP tools exposed: `workflow_start`, `workflow_status`, `workflow_resume`, `work
 
 ## Key architectural decisions
 
-**Engine profile.** `docs/poc-scope.md` freezes the surface the reference engine must honor. Supported node types: `start`, `end`, `step`, `llm_call`, `tool_call`, `switch`, `interrupt`, `parallel`, `wait`, `set_state`, `agent_delegate`, and `subworkflow`. The schema enforces allowed `type` values via a `oneOf` discriminated union that rejects unknown `type` values.
+**Engine profile.** `docs/engine-profile.md` freezes the surface the reference engine must honor. Supported node types: `start`, `end`, `step`, `llm_call`, `tool_call`, `switch`, `interrupt`, `parallel`, `wait`, `set_state`, `agent_delegate`, and `subworkflow`. The schema enforces allowed `type` values via a `oneOf` discriminated union that rejects unknown `type` values.
 
 **JSON Schema `additionalProperties: false`** on the workflow root means adding top-level fields (e.g. `extensions`) will fail validation by design.
 
@@ -81,7 +81,7 @@ MCP tools exposed: `workflow_start`, `workflow_status`, `workflow_resume`, `work
 
 **Workflow documents are canonical JSON** (YAML for human authoring is fine, but must be normalized to JSON before validation per RFC-03 §3.1).
 
-**Schema sync is enforced at pack time.** `scripts/sync-engine-poc-schema.mjs` runs as `prepack` to copy the root schema into `packages/engine/schemas/`. Use `npm run check-engine-poc-schema-sync` to verify they are in sync without modifying files.
+**Schema sync is enforced at pack time.** `scripts/sync-engine-schema.mjs` runs as `prepack` to copy the root schema into `packages/engine/schemas/`. Use `npm run check-engine-schema-sync` to verify they are in sync without modifying files.
 
 **MCP adapter is layered over a stable application port.** `createWorkflowApplicationPort` is the internal boundary. The MCP stdio server (`mcp-stdio-server.mjs`) maps MCP request DTOs to that port and translates engine failures into structured tool errors with stable error codes (`VALIDATION_ERROR`, `EXECUTION_NOT_FOUND`, `INVALID_RESUME_PAYLOAD`, activity-submit codes `ACTIVITY_SUBMIT_NOT_AWAITING`, `ACTIVITY_SUBMIT_NODE_MISMATCH`, `ACTIVITY_SUBMIT_PARALLEL_MISMATCH`, `SUBMIT_VALIDATION_ERROR`, `ENGINE_FAILURE`, `INTERNAL_ERROR`).
 
@@ -89,11 +89,11 @@ MCP tools exposed: `workflow_start`, `workflow_status`, `workflow_resume`, `work
 
 ## Work item conventions
 
-**Canonical backlog:** Linear milestones and issues on the workflows project hold epic/story intent, acceptance criteria, status, and links to RFC/`docs/poc-scope.md`/ADRs. Use the `wf-plan`, `wf-design`, and `wf-execute` skills and `.project-planning.yaml` (`delivery_tracker: linear`) for Linear MCP conventions. The global `project-planning` skill still applies to **process** (decomposition, dependencies, readiness); this repository **overrides the artifact location** to Linear per `workflows-linear-backlog-override.md`.
+**Canonical backlog:** Linear milestones and issues on the workflows project hold epic/story intent, acceptance criteria, status, and links to RFC/`docs/engine-profile.md`/ADRs. Use the `wf-plan`, `wf-design`, and `wf-execute` skills and `.project-planning.yaml` (`delivery_tracker: linear`) for Linear MCP conventions. The global `project-planning` skill still applies to **process** (decomposition, dependencies, readiness); this repository **overrides the artifact location** to Linear per `workflows-linear-backlog-override.md`.
 
 **Legacy:** Historical per-epic and per-story markdown under `docs` was removed after earlier backlog migrations; GitHub Project #4 is legacy for planning. Do not recreate planning markdown or duplicate backlog in GitHub issues.
 
-When changing the POC contract (scope note, schema, or fixtures), update all three together and bump `document.schema` in workflow instances.
+When changing the engine profile contract (scope note, schema, or fixtures), update all three together and bump `document.schema` in workflow instances.
 
 ## Post-alpha roadmap
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for helping improve the Agent Workflow Protocol project.
 ## Before you open an issue or PR
 
 - Read `README.md` for project scope and quickstart.
-- Check `docs/poc-scope.md` to confirm if a request is in or out of current POC scope.
+- Check `docs/engine-profile.md` to confirm if a request is in or out of current engine profile.
 - Search existing issues/PRs first to avoid duplicates.
 
 ## Contributor intake path
@@ -50,7 +50,7 @@ Escalation for critical findings is defined in `docs/community-launch-playbook.m
 During alpha, maintainers prioritize:
 
 - Protocol/specification correctness
-- POC schema and engine behavior
+- workflow schema and engine behavior
 - Documentation clarity and onboarding quality
 
 Maintainers may defer:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This protocol fills that gap — sitting **between** atomic MCP tool calls and m
 
 ```yaml
 document:
-  schema: "https://example.org/agent-workflow/v1"
+  schema: "https://agent-workflow.dev/schemas/workflow-definition.json"
   name: "customer-support"
   version: "1.0.0"
 
@@ -141,7 +141,7 @@ Workflow definitions must be normalized to canonical JSON before validation or e
 
 ```
 docs/RFC/          # Full protocol specification (9 sections)
-docs/poc-scope.md  # Engine profile — normative subset for the reference engine + schema bundle
+docs/engine-profile.md  # Engine profile — normative subset for the reference engine + schema bundle
 schemas/           # JSON Schema Draft 2020-12 bundle for that profile
 examples/          # Golden fixtures: workflow + RFC-04 trace companions
 conformance/       # Conformance harness vectors + deterministic runner entrypoint
@@ -171,7 +171,7 @@ scripts/           # validate-workflows.mjs (AJV, CI-aligned)
 
 ## Workflow schema and validation
 
-The [`schemas/`](schemas/) directory contains the **workflow JSON Schema bundle** (Draft 2020-12) for the profile in [`docs/poc-scope.md`](docs/poc-scope.md), including `parallel`, `wait`, and `set_state`. `agent_delegate` and `subworkflow` are not in that profile yet; see [`ROADMAP.md`](ROADMAP.md).
+The [`schemas/`](schemas/) directory contains the **workflow JSON Schema bundle** (Draft 2020-12) for the profile in [`docs/engine-profile.md`](docs/engine-profile.md), including `parallel`, `wait`, and `set_state`. `agent_delegate` and `subworkflow` are not in that profile yet; see [`ROADMAP.md`](ROADMAP.md).
 
 Validate locally with Node.js **≥ 22.5.0** (see root `package.json` `engines`). **CI** uses Node.js **24** with `actions/checkout@v5` and `actions/setup-node@v5` per [GitHub’s Node 20 deprecation on runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).
 
@@ -208,7 +208,7 @@ The [`examples/`](examples/) directory contains the canonical lighthouse fixture
 
 ## Reference implementation
 
-**In this repository (Node.js):** [`packages/engine/`](packages/engine/README.md) (`@agent-workflow/engine`) implements definition validation for the profile in [`docs/poc-scope.md`](docs/poc-scope.md), an append-only command/event history (`SqliteExecutionHistoryStore` via `node:sqlite` or in-memory), orchestration including `parallel` / `wait` / `set_state`, `switch`, `interrupt` / resume, host-mediated and engine-direct `tool_call` activity paths, checkpoint policies, and the MCP stdio adapter. The [`conformance/`](conformance/) harness exercises schema and replay vectors in CI. Requires Node.js **≥ 22.5.0** (see root `package.json` `engines`).
+**In this repository (Node.js):** [`packages/engine/`](packages/engine/README.md) (`@agent-workflow/engine`) implements definition validation for the profile in [`docs/engine-profile.md`](docs/engine-profile.md), an append-only command/event history (`SqliteExecutionHistoryStore` via `node:sqlite` or in-memory), orchestration including `parallel` / `wait` / `set_state`, `switch`, `interrupt` / resume, host-mediated and engine-direct `tool_call` activity paths, checkpoint policies, and the MCP stdio adapter. The [`conformance/`](conformance/) harness exercises schema and replay vectors in CI. Requires Node.js **≥ 22.5.0** (see root `package.json` `engines`).
 
 **Longer term (RFC-08):** [RFC-08](docs/RFC/rfc-08-reference-implementation.md) describes a production-style program (multi-language core, Python SDK, REST/SDK parity). The monorepo already ships a Node reference engine; see the as-built note in RFC-08. Delegation and sub-workflows are on the roadmap; see [`ROADMAP.md`](ROADMAP.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,7 +18,7 @@ Linear currently holds **R4–R5 only** (migrated from GitHub); R2/R3 completion
 
 ## Planning assumptions
 
-- **Current baseline:** [`@agent-workflow/engine@0.1.2`](https://www.npmjs.com/package/@agent-workflow/engine) implements the profile in [`docs/poc-scope.md`](docs/poc-scope.md): POC core nodes, **R2** orchestration (`parallel`, `wait`, `set_state`), and **R3** native delegation/composition (`agent_delegate`, `subworkflow`) with in-process mock A2A. Host-mediated and engine-direct activity execution per [ADR-0003](docs/architecture/adr/ADR-0003-engine-direct-mcp-activity-execution.md). Schema validation and conformance harness (`npm run conformance`) are green on `main`.
+- **Current baseline:** [`@agent-workflow/engine@0.1.2`](https://www.npmjs.com/package/@agent-workflow/engine) implements the profile in [`docs/engine-profile.md`](docs/engine-profile.md): POC core nodes, **R2** orchestration (`parallel`, `wait`, `set_state`), and **R3** native delegation/composition (`agent_delegate`, `subworkflow`) with in-process mock A2A. Host-mediated and engine-direct activity execution per [ADR-0003](docs/architecture/adr/ADR-0003-engine-direct-mcp-activity-execution.md). Schema validation and conformance harness (`npm run conformance`) are green on `main`.
 - **Next planning focus:** **R4 GA 1.0** (v1 contract freeze, security baseline, adoption bar). Finish remaining **R3 RC** interop surfaces (REST/SDK, real A2A, integration guides) as runway or explicit R3 carryover before treating R4 items as implementation-ready.
 - This roadmap prioritizes vertical value slices while maintaining architectural runway for durability, interoperability, and governance.
 - Release names are planning labels; semantic versions are assigned during release planning.

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -132,7 +132,7 @@ Output behavior:
 
 ## RFC-08 conformance coverage matrix (POC profile)
 
-The matrix below maps RFC-08 section `8.2 Conformance tests` areas to the current POC harness status.
+The matrix below maps RFC-08 section `8.2 Conformance tests` areas to the current conformance harness status.
 
 | RFC-08 conformance area | Status | Evidence |
 |---|---|---|

--- a/conformance/vectors/replay/integrity/resume-definition-tamper.vector.json
+++ b/conformance/vectors/replay/integrity/resume-definition-tamper.vector.json
@@ -6,7 +6,7 @@
   "resumePayload": { "intent": "billing" },
   "resumeDefinitionTamper": {
     "document": {
-      "schema": "https://agent-workflow.dev/schemas/workflow-definition/v1.json",
+      "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
       "name": "lighthouse-customer-routing",
       "version": "9.9.9"
     }

--- a/conformance/vectors/replay/integrity/submit-definition-tamper.vector.json
+++ b/conformance/vectors/replay/integrity/submit-definition-tamper.vector.json
@@ -26,7 +26,7 @@
       "name": "CheckpointWritten",
       "payload": {
         "policy": "after_each_node",
-        "definitionHash": "9d836701a9074d3bacc69af2282e8c45438b501802d9fa84279d7cd977b8ff58",
+        "definitionHash": "5f97ff9cd98775195180a7e4615ab721ba72813fa14f5b025e5ed149cb2bb873",
         "lastAppliedEventSeq": 2,
         "nodeId": "start",
         "stateRef": { "kind": "inline_state", "state": {} }
@@ -44,7 +44,7 @@
       "outcome": { "ok": true, "result": { "out": "tampered" } },
       "definitionTamper": {
         "document": {
-          "schema": "https://example.org/agent-workflow/poc/v1/workflow-definition",
+          "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
           "name": "conformance-host-linear",
           "version": "9.9.9"
         }

--- a/conformance/vectors/schema/invalid/agent-delegate-invalid-protocol.vector.json
+++ b/conformance/vectors/schema/invalid/agent-delegate-invalid-protocol.vector.json
@@ -1,6 +1,6 @@
 {
   "id": "schema.invalid.agent_delegate_invalid_protocol",
-  "description": "agent_delegate with invalid protocol enum must be rejected by POC schema.",
+  "description": "agent_delegate with invalid protocol enum must be rejected by workflow schema.",
   "kind": "schema",
   "definition": "examples/fixtures.invalid/agent-delegate-invalid-protocol.workflow.json",
   "expect": {

--- a/conformance/vectors/schema/invalid/unsupported-node-type.vector.json
+++ b/conformance/vectors/schema/invalid/unsupported-node-type.vector.json
@@ -1,6 +1,6 @@
 {
   "id": "schema.invalid.unsupported-node-type",
-  "description": "Out-of-scope node type must be rejected by the POC schema node union.",
+  "description": "Out-of-scope node type must be rejected by the workflow schema node union.",
   "kind": "schema",
   "definition": "examples/fixtures.invalid/unsupported-node-type.workflow.json",
   "expect": {

--- a/conformance/vectors/schema/valid/agentic-task-intake-prompt-improver.vector.json
+++ b/conformance/vectors/schema/valid/agentic-task-intake-prompt-improver.vector.json
@@ -1,6 +1,6 @@
 {
   "id": "schema.valid.agentic-task-intake-prompt-improver",
-  "description": "Agentic intake and prompt improver fixture remains valid under current POC schema constraints.",
+  "description": "Agentic intake and prompt improver fixture remains valid under current workflow schema constraints.",
   "kind": "schema",
   "definition": "examples/agentic-task-intake-prompt-improver.workflow.json",
   "expect": {

--- a/conformance/vectors/schema/valid/conformance-agent-delegate-linear.vector.json
+++ b/conformance/vectors/schema/valid/conformance-agent-delegate-linear.vector.json
@@ -1,6 +1,6 @@
 {
   "id": "schema.valid.conformance_agent_delegate_linear",
-  "description": "Linear agent_delegate conformance fixture validates against the POC schema.",
+  "description": "Linear agent_delegate conformance fixture validates against the workflow schema.",
   "kind": "schema",
   "definition": "examples/conformance-agent-delegate-linear.workflow.json",
   "expect": {

--- a/conformance/vectors/schema/valid/conformance-host-activity-linear.vector.json
+++ b/conformance/vectors/schema/valid/conformance-host-activity-linear.vector.json
@@ -1,6 +1,6 @@
 {
   "id": "schema.valid.conformance-host-activity-linear",
-  "description": "Conformance host-activity linear fixture validates against POC schema.",
+  "description": "Conformance host-activity linear fixture validates against workflow schema.",
   "kind": "schema",
   "definition": "examples/conformance-host-activity-linear.workflow.json",
   "expect": {

--- a/conformance/vectors/schema/valid/conformance-host-activity-parallel.vector.json
+++ b/conformance/vectors/schema/valid/conformance-host-activity-parallel.vector.json
@@ -1,6 +1,6 @@
 {
   "id": "schema.valid.conformance-host-activity-parallel",
-  "description": "Conformance host-activity parallel-branch fixture validates against POC schema.",
+  "description": "Conformance host-activity parallel-branch fixture validates against workflow schema.",
   "kind": "schema",
   "definition": "examples/conformance-host-activity-parallel.workflow.json",
   "expect": {

--- a/conformance/vectors/schema/valid/conformance-subworkflow-parent.vector.json
+++ b/conformance/vectors/schema/valid/conformance-subworkflow-parent.vector.json
@@ -1,6 +1,6 @@
 {
   "id": "schema.valid.conformance_subworkflow_parent",
-  "description": "Subworkflow parent conformance fixture validates against the POC schema.",
+  "description": "Subworkflow parent conformance fixture validates against the workflow schema.",
   "kind": "schema",
   "definition": "examples/conformance-subworkflow-parent.workflow.json",
   "expect": {

--- a/conformance/vectors/schema/valid/lighthouse.vector.json
+++ b/conformance/vectors/schema/valid/lighthouse.vector.json
@@ -1,6 +1,6 @@
 {
   "id": "schema.valid.lighthouse",
-  "description": "Canonical lighthouse fixture validates against the POC schema.",
+  "description": "Canonical lighthouse fixture validates against the workflow schema.",
   "kind": "schema",
   "definition": "examples/lighthouse-customer-routing.workflow.json",
   "expect": {

--- a/conformance/vectors/schema/valid/minimal-linear.vector.json
+++ b/conformance/vectors/schema/valid/minimal-linear.vector.json
@@ -1,6 +1,6 @@
 {
   "id": "schema.valid.minimal-linear",
-  "description": "Minimal EPIC-1 style linear workflow validates against the POC schema.",
+  "description": "Minimal EPIC-1 style linear workflow validates against the workflow schema.",
   "kind": "schema",
   "definition": "examples/fixtures.valid/minimal-linear.workflow.json",
   "expect": {

--- a/conformance/vectors/schema/valid/r2-research-parallel.vector.json
+++ b/conformance/vectors/schema/valid/r2-research-parallel.vector.json
@@ -1,6 +1,6 @@
 {
   "id": "schema.valid.r2-research-parallel",
-  "description": "R2 profile: parallel + set_state + wait validate against extended POC schema.",
+  "description": "R2 profile: parallel + set_state + wait validate against extended workflow schema.",
   "kind": "schema",
   "definition": "examples/r2-research-parallel.workflow.json",
   "expect": {

--- a/conformance/vectors/schema/valid/r3-multi-agent-coding.vector.json
+++ b/conformance/vectors/schema/valid/r3-multi-agent-coding.vector.json
@@ -1,6 +1,6 @@
 {
   "id": "schema.valid.r3_multi_agent_coding",
-  "description": "R3 multi-agent coding example (delegate + subworkflow + interrupt) validates against the POC schema.",
+  "description": "R3 multi-agent coding example (delegate + subworkflow + interrupt) validates against the workflow schema.",
   "kind": "schema",
   "definition": "examples/r3-multi-agent-coding.workflow.json",
   "expect": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ This index makes the documentation information architecture explicit:
 - Contributor intake and support boundaries: [../CONTRIBUTING.md](../CONTRIBUTING.md), [../SUPPORT.md](../SUPPORT.md)
 - Alpha security baseline posture: [security/alpha-security-baseline.md](security/alpha-security-baseline.md)
 - Accepted security gaps register: [security/security-gap-register.md](security/security-gap-register.md)
-- Engine profile (normative subset for the reference engine): [poc-scope.md](poc-scope.md)
+- Engine profile (normative subset for the reference engine): [engine-profile.md](engine-profile.md)
 - Specification overview: [RFC/rfc-00-overview.md](RFC/rfc-00-overview.md)
 
 ## Architecture and Demo Walkthroughs

--- a/docs/RFC/rfc-03-workflow-definition-schema.md
+++ b/docs/RFC/rfc-03-workflow-definition-schema.md
@@ -10,7 +10,7 @@
 
 - Workflow definitions **MUST** have a **canonical JSON** serialization suitable for validation, signing, and byte-stable hashing.
 - Authors **MAY** author in **YAML**; a conformant toolchain **MUST** define a deterministic YAML → JSON mapping (YAML 1.2, explicit tags as needed).
-- The document **MUST** declare a `document.schema` URI identifying the protocol version (e.g. `https://example.org/agent-workflow/v1` — final URI assigned by governance).
+- The document **MUST** declare a `document.schema` URI identifying the protocol version (e.g. `https://agent-workflow.dev/schemas/workflow-definition.json` — final URI assigned by governance).
 
 Authoring can start in several forms; all **MUST** normalize to the same canonical JSON before validation and execution (informative):
 
@@ -207,7 +207,7 @@ This RFC text is authoritative for semantics; schemas are authoritative for synt
 
 ```yaml
 document:
-  schema: "https://example.org/agent-workflow/v1"
+  schema: "https://agent-workflow.dev/schemas/workflow-definition.json"
   name: "customer-support"
   version: "1.0.0"
 state_schema:
@@ -266,7 +266,7 @@ edges:
 
 ```yaml
 document:
-  schema: "https://example.org/agent-workflow/v1"
+  schema: "https://agent-workflow.dev/schemas/workflow-definition.json"
   name: "research-summarize"
   version: "1.0.0"
 state_schema:
@@ -320,7 +320,7 @@ edges:
 
 ```yaml
 document:
-  schema: "https://example.org/agent-workflow/v1"
+  schema: "https://agent-workflow.dev/schemas/workflow-definition.json"
   name: "coding-task"
   version: "1.0.0"
 state_schema:
@@ -359,7 +359,7 @@ edges:
 
 ```yaml
 document:
-  schema: "https://example.org/agent-workflow/v1"
+  schema: "https://agent-workflow.dev/schemas/workflow-definition.json"
   name: "agentic-task-intake"
   version: "1.0.0"
 state_schema:

--- a/docs/RFC/rfc-08-reference-implementation.md
+++ b/docs/RFC/rfc-08-reference-implementation.md
@@ -4,7 +4,7 @@
 **Series:** Agent Workflow Protocol (working title)  
 **Related:** [Execution Model](rfc-04-execution-model.md) · [Integration Interfaces](rfc-05-integration-interfaces.md) · [Governance and Adoption](rfc-09-governance-adoption.md)
 
-**As-built note:** This monorepo currently ships a **Node.js** reference implementation as npm package **`@agent-workflow/engine`** under `packages/engine/`, aligned with [`docs/poc-scope.md`](../poc-scope.md). The component and folder layout in §8.4 remains an informative target for a broader multi-language artifact tree.
+**As-built note:** This monorepo currently ships a **Node.js** reference implementation as npm package **`@agent-workflow/engine`** under `packages/engine/`, aligned with [`docs/engine-profile.md`](../engine-profile.md). The component and folder layout in §8.4 remains an informative target for a broader multi-language artifact tree.
 
 ---
 

--- a/docs/architecture/adr/ADR-0001-poc-foundation-decisions.md
+++ b/docs/architecture/adr/ADR-0001-poc-foundation-decisions.md
@@ -17,7 +17,7 @@ At this stage, uncertainty was high and architecture choices needed rapid feedba
 Primary reference constraints:
 
 - Normative target contract: `docs/RFC/`
-- Active implementation boundary: `docs/poc-scope.md`
+- Active implementation boundary: `docs/engine-profile.md`
 - Release evolution path: `ROADMAP.md`
 
 ## Decision
@@ -35,11 +35,11 @@ For the POC alpha phase, the project adopts the following decision set:
    - Use replay/conformance as acceptance gates for behavior stability.
 4. **Bias for practical interoperability over broad platform breadth.**
    - Prioritize MCP stdio path for operator and host integration.
-   - Defer broader interface parity until roadmap phases after the active engine profile (see `docs/poc-scope.md`).
+   - Defer broader interface parity until roadmap phases after the active engine profile (see `docs/engine-profile.md`).
 
 ## Amendment (2026-05-05)
 
-The **authoritative** node and command/event boundary for the reference engine is always [`docs/poc-scope.md`](../poc-scope.md). That profile now includes **`parallel`**, **`wait`**, and **`set_state`** alongside the original core set. The **“Scope implications (historical)”** subsection below preserves the **original 2026-04-14** boundary text for context; it is **not** the current implementation truth.
+The **authoritative** node and command/event boundary for the reference engine is always [`docs/engine-profile.md`](../engine-profile.md). That profile now includes **`parallel`**, **`wait`**, and **`set_state`** alongside the original core set. The **“Scope implications (historical)”** subsection below preserves the **original 2026-04-14** boundary text for context; it is **not** the current implementation truth.
 
 ## Assumptions and reasoning
 
@@ -57,7 +57,7 @@ The **authoritative** node and command/event boundary for the reference engine i
 
 ## Scope implications (historical)
 
-*Recorded at ADR acceptance (2026-04-14); superseded for runtime truth by the amendment above and by `docs/poc-scope.md`.*
+*Recorded at ADR acceptance (2026-04-14); superseded for runtime truth by the amendment above and by `docs/engine-profile.md`.*
 
 In-scope profile **at that date** included:
 
@@ -85,7 +85,7 @@ The narrowed boundary was intentional and not a contradiction of RFC intent; it 
 
 ## Guardrails and compensating controls
 
-- Keep `docs/poc-scope.md` authoritative and explicit about out-of-scope elements.
+- Keep `docs/engine-profile.md` authoritative and explicit about out-of-scope elements.
 - Use conformance harness and CI as non-optional quality gates.
 - Require roadmap/RFC traceability in issue and PR templates.
 - Maintain an **as-is** architecture baseline in [`docs/architecture/arc42/README.md`](../arc42/README.md) plus [Sections **3**](../arc42/03-context-and-scope.md)–[**11**](../arc42/11-risks-and-technical-debt.md) (`docs/architecture/arc42/`), with runtime/deployment rationale concentrated in **[Section 6 (Runtime view)](../arc42/06-runtime-view.md)** and **[Section 7 (Deployment view)](../arc42/07-deployment-view.md)** alongside linked **Draw.io** views.
@@ -110,7 +110,7 @@ At that point, design-first governance and structured ADR sequencing become the 
 ## References
 
 - [ADR-0002: Host-mediated activity execution](ADR-0002-host-mediated-activity-execution.md)
-- `docs/poc-scope.md`
+- `docs/engine-profile.md`
 - `docs/RFC/rfc-00-overview.md`
 - `docs/RFC/rfc-04-execution-model.md`
 - `docs/RFC/rfc-08-reference-implementation.md`

--- a/docs/architecture/adr/ADR-0002-host-mediated-activity-execution.md
+++ b/docs/architecture/adr/ADR-0002-host-mediated-activity-execution.md
@@ -57,7 +57,7 @@ That posture extends **Option C (hybrid)** and optional **Option A**-style surfa
 ## References
 
 - [`docs/architecture/arc42/06-runtime-view.md`](../arc42/06-runtime-view.md) (host-mediated flow + MCP loop)
-- `docs/poc-scope.md`
+- `docs/engine-profile.md`
 - `docs/RFC/rfc-04-execution-model.md`, `docs/RFC/rfc-05-integration-interfaces.md`, `docs/RFC/rfc-06-interoperability.md`
 - `docs/architecture/adr/ADR-0003-engine-direct-mcp-activity-execution.md`
 - `ROADMAP.md`

--- a/docs/architecture/adr/ADR-0003-engine-direct-mcp-activity-execution.md
+++ b/docs/architecture/adr/ADR-0003-engine-direct-mcp-activity-execution.md
@@ -74,5 +74,5 @@ Evidence expectations for changes touching engine-direct surfaces are aligned wi
 - [RFC-06 — Interoperability, §6.1](../../RFC/rfc-06-interoperability.md#61-composing-mcp)
 - [RFC-07 — Security model](../../RFC/rfc-07-security-model.md)
 - [`docs/architecture/arc42/04-solution-strategy.md`](../arc42/04-solution-strategy.md); [`docs/architecture/arc42/06-runtime-view.md`](../arc42/06-runtime-view.md); [`docs/architecture/arc42/07-deployment-view.md`](../arc42/07-deployment-view.md)
-- `docs/poc-scope.md`, `ROADMAP.md`
+- `docs/engine-profile.md`, `ROADMAP.md`
 - `docs/architecture/README.md`, [`docs/architecture/arc42/README.md`](../arc42/README.md)

--- a/docs/architecture/adr/ADR-0004-r3-delegation-and-subworkflow.md
+++ b/docs/architecture/adr/ADR-0004-r3-delegation-and-subworkflow.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-R2 delivered core orchestration (`parallel`, `wait`, `set_state`) on a flat `executionId` history spine. RFC-03 Example C and RFC-04 §4.9 require **native `agent_delegate`** and **`subworkflow`** nodes with auditable parent/child correlation—not `tool_call` shims. Epic [#5](https://github.com/benvdbergh/workflows/issues/5) promotes both types into the POC engine profile while preserving **append-only, replayable** history ([ADR-0001](ADR-0001-poc-foundation-decisions.md)).
+R2 delivered core orchestration (`parallel`, `wait`, `set_state`) on a flat `executionId` history spine. RFC-03 Example C and RFC-04 §4.9 require **native `agent_delegate`** and **`subworkflow`** nodes with auditable parent/child correlation—not `tool_call` shims. Epic [#5](https://github.com/benvdbergh/workflows/issues/5) promotes both types into the reference engine profile while preserving **append-only, replayable** history ([ADR-0001](ADR-0001-poc-foundation-decisions.md)).
 
 **Problems:**
 
@@ -33,7 +33,7 @@ R2 delivered core orchestration (`parallel`, `wait`, `set_state`) on a flat `exe
 2. **Separate port:** `DelegateExecutor` in `delegate-executor.mjs`—not overloaded onto `ActivityExecutor`.
 3. **History shape (R3 RC):** `ActivityRequested` / `ActivityCompleted` with `delegateCorrelationId`, `externalTaskId`, `nodeType: "agent_delegate"`.
 4. **R3 mock A2A:** In-process `MockA2ADelegateExecutor` (single-shot completed output for CI).
-5. **Bridge migration:** `docs/poc-scope.md` §2.2 maps `tool_call` agent tools → native node.
+5. **Bridge migration:** `docs/engine-profile.md` §2.2 maps `tool_call` agent tools → native node.
 6. **Replay:** Prefix `ActivityCompleted` skips delegate port invocation.
 
 ### 3. Cross-cutting
@@ -56,5 +56,5 @@ R2 delivered core orchestration (`parallel`, `wait`, `set_state`) on a flat `exe
 ## References
 
 - RFC-03, RFC-04 §4.9, RFC-06 §6.2
-- `docs/poc-scope.md`
+- `docs/engine-profile.md`
 - `subworkflow-runtime.mjs`, `delegate-runtime.mjs`, `delegate-executor.mjs`

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -44,14 +44,14 @@ Each ADR should include:
 - Anchor decisions to:
   - [`docs/architecture/arc42/`](../arc42/) (baseline narrative, esp. Sections **3–7** runtime/deployment storyline)
   - `docs/RFC/`
-  - `docs/poc-scope.md`
+  - `docs/engine-profile.md`
   - `ROADMAP.md`
 - For contract-impacting decisions, include required conformance/schema/test updates.
 - Use ADRs to document meaningful decisions; avoid creating ADRs for trivial edits.
 
 ## Current ADRs
 
-- `ADR-0001-poc-foundation-decisions.md` — amended 2026-05-05; runtime scope truth is always [`docs/poc-scope.md`](../../poc-scope.md) (see ADR amendment section).
+- `ADR-0001-poc-foundation-decisions.md` — amended 2026-05-05; runtime scope truth is always [`docs/engine-profile.md`](../../engine-profile.md) (see ADR amendment section).
 - `ADR-0002-host-mediated-activity-execution.md`
 - `ADR-0003-engine-direct-mcp-activity-execution.md`
 - `ADR-0004-r3-delegation-and-subworkflow.md`

--- a/docs/architecture/arc42-assets/contracts/integration-parity-matrix.md
+++ b/docs/architecture/arc42-assets/contracts/integration-parity-matrix.md
@@ -48,7 +48,7 @@ Informative command/event prefix narratives remain under `examples/*.trace.*.jso
 
 ## Deferred MCP tools (RFC-05 §5.2)
 
-Not in POC MCP adapter or parity matrix until committed: `workflow_cancel`, `workflow_signal`, `workflow_list`.
+Not in MCP adapter or parity matrix until committed: `workflow_cancel`, `workflow_signal`, `workflow_list`.
 
 ## Running parity checks
 

--- a/docs/architecture/arc42-assets/diagrams/as-built-views.drawio
+++ b/docs/architecture/arc42-assets/diagrams/as-built-views.drawio
@@ -236,10 +236,10 @@
                 <mxCell id="OuT24w1vpQ-nGS25mSiP-36" value="examples/&#10;*.workflow.json&#10;*.trace.*.json (informative)" style="shape=folder;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;" parent="OuT24w1vpQ-nGS25mSiP-31" vertex="1">
                     <mxGeometry x="560" y="60" width="160" height="80" as="geometry"/>
                 </mxCell>
-                <mxCell id="OuT24w1vpQ-nGS25mSiP-37" value="schemas/&#10;workflow-definition-poc.json&#10;(JSON Schema Draft 2020-12)" style="shape=note;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;" parent="OuT24w1vpQ-nGS25mSiP-31" vertex="1">
+                <mxCell id="OuT24w1vpQ-nGS25mSiP-37" value="schemas/&#10;workflow-definition.json&#10;(JSON Schema Draft 2020-12)" style="shape=note;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;" parent="OuT24w1vpQ-nGS25mSiP-31" vertex="1">
                     <mxGeometry x="460" y="280" width="160" height="70" as="geometry"/>
                 </mxCell>
-                <mxCell id="OuT24w1vpQ-nGS25mSiP-38" value="Out of scope for current engine profile&#10;(see docs/poc-scope.md §2.1):&#10;agent_delegate  |  subworkflow&#10;(R3+). R2 nodes run in reference engine." style="text;strokeColor=#cc0000;fillColor=#ffcccc;align=left;verticalAlign=middle;spacingLeft=10;overflow=hidden;fontSize=11;fontStyle=2;" parent="OuT24w1vpQ-nGS25mSiP-31" vertex="1">
+                <mxCell id="OuT24w1vpQ-nGS25mSiP-38" value="Out of scope for current engine profile&#10;(see docs/engine-profile.md §2.1):&#10;agent_delegate  |  subworkflow&#10;(R3+). R2 nodes run in reference engine." style="text;strokeColor=#cc0000;fillColor=#ffcccc;align=left;verticalAlign=middle;spacingLeft=10;overflow=hidden;fontSize=11;fontStyle=2;" parent="OuT24w1vpQ-nGS25mSiP-31" vertex="1">
                     <mxGeometry x="500" y="390" width="220" height="60" as="geometry"/>
                 </mxCell>
                 <mxCell id="OuT24w1vpQ-nGS25mSiP-39" value="runs" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d6b656;fontSize=9;" parent="OuT24w1vpQ-nGS25mSiP-31" source="OuT24w1vpQ-nGS25mSiP-32" target="OuT24w1vpQ-nGS25mSiP-33" edge="1">

--- a/docs/architecture/arc42-assets/runbooks/mcp-stdio-host-smoke.md
+++ b/docs/architecture/arc42-assets/runbooks/mcp-stdio-host-smoke.md
@@ -85,7 +85,7 @@ After connect, discover tools and confirm the host exposes:
 
 ## Canonical workflow definition
 
-Use **one** parsed JSON object for every `definition` field in section 3: the **lighthouse golden fixture** in `examples/lighthouse-customer-routing.workflow.json` (same definition CI validates with `schemas/workflow-definition-poc.json`).
+Use **one** parsed JSON object for every `definition` field in section 3: the **lighthouse golden fixture** in `examples/lighthouse-customer-routing.workflow.json` (same definition CI validates with `schemas/workflow-definition.json`).
 
 | Context | How to obtain it |
 |--------|------------------|
@@ -160,7 +160,7 @@ Expected structured result shape:
 }
 ```
 
-With the default POC stub, `confidence` is deterministic for this fixture (see `packages/engine/test/workflow-graph-walker.test.mjs`). Assert `status` and `intent` first; treat numeric fields as stub-specific unless a real activity adapter is configured.
+With the default reference stub, `confidence` is deterministic for this fixture (see `packages/engine/test/workflow-graph-walker.test.mjs`). Assert `status` and `intent` first; treat numeric fields as stub-specific unless a real activity adapter is configured.
 
 ### 3.4 Optional — `workflow_submit_activity` (host-mediated)
 
@@ -173,7 +173,7 @@ Use a **minimal** workflow (single `tool_call` then `end`) so the run pauses aft
   "execution_id": "story-4-3-host-med-1",
   "definition": {
     "document": {
-      "schema": "https://example.org/agent-workflow/poc/v1/workflow-definition",
+      "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
       "name": "smoke-host-med",
       "version": "1.0.0"
     },
@@ -244,7 +244,7 @@ Expected tool error result (shape):
 
 Some MCP hosts surface the same failure as plain text; the required behavior is **`EXECUTION_NOT_FOUND`**, not the exact JSON wrapper.
 
-## POC security posture and deferred hardening
+## Alpha security posture and deferred hardening
 
 Current posture for this smoke path:
 
@@ -255,4 +255,4 @@ Current posture for this smoke path:
 Deferred hardening tracks to RFC-07:
 
 - `docs/RFC/rfc-07-security-model.md` for identity, policy enforcement, and secret handling expectations.
-- EPIC-level note on GitHub ([#21 — MCP stdio integration surface](https://github.com/benvdbergh/workflows/issues/21)) keeps auth hardening explicitly out of POC scope.
+- EPIC-level note on GitHub ([#21 — MCP stdio integration surface](https://github.com/benvdbergh/workflows/issues/21)) keeps auth hardening explicitly out of engine profile scope.

--- a/docs/architecture/arc42/01-introduction-and-goals.md
+++ b/docs/architecture/arc42/01-introduction-and-goals.md
@@ -5,10 +5,10 @@
 This repository implements the **Agent Workflow Protocol** as:
 
 1. A **normative specification** (`docs/RFC/`).
-2. An **authoritative engine profile** (`docs/poc-scope.md`) with JSON Schema (`schemas/workflow-definition-poc.json`).
+2. An **authoritative engine profile** (`docs/engine-profile.md`) with JSON Schema (`schemas/workflow-definition.json`).
 3. A **reference Node.js engine** (`@agent-workflow/engine`, `packages/engine/`) with validation CLI, MCP stdio integration, deterministic graph execution with replay semantics, and optional SQLite persistence.
 
-These arc42 sections (1–12) are the **as-is baseline** for future design increments, structured ADRs, release planning (`ROADMAP.md`), and onboarding. Normative protocol semantics remain in the RFC texts; **`docs/poc-scope.md`** is authoritative for **which** semantics the reference engine implements.
+These arc42 sections (1–12) are the **as-is baseline** for future design increments, structured ADRs, release planning (`ROADMAP.md`), and onboarding. Normative protocol semantics remain in the RFC texts; **`docs/engine-profile.md`** is authoritative for **which** semantics the reference engine implements.
 
 Primary **C4-style** diagram sources: [`../arc42-assets/diagrams/as-built-views.drawio`](../arc42-assets/diagrams/as-built-views.drawio) (context, deployment, building blocks); target sketches (not baseline evidence): [`../arc42-assets/archive/target-state/rfc-target-views.drawio`](../arc42-assets/archive/target-state/rfc-target-views.drawio).
 
@@ -28,13 +28,13 @@ Current architecture favors **deterministic replay** and a **narrow engine profi
 | Priority | Goal | Notes |
 |----------|------|-------|
 | 1 | **Determinism / replay fidelity** | Command/event progression must reconstruct next steps from history + definition. |
-| 2 | **Contract clarity** | Profile boundary in `docs/poc-scope.md`; schema rejects undefined node types (`additionalProperties: false` at workflow root—no undocumented extensions field). |
+| 2 | **Contract clarity** | Profile boundary in `docs/engine-profile.md`; schema rejects undefined node types (`additionalProperties: false` at workflow root—no undocumented extensions field). |
 | 3 | **Integration clarity** | `createWorkflowApplicationPort` separates orchestration from transport; MCP adapter maps typed failures to stable codes. |
 | 4 | **Regression safety** | Conformance harness (`conformance/`) + engine tests (`packages/engine/test/`). |
 
 ## 1.3 Out of scope for this baseline (documented explicitly elsewhere)
 
-Deferred or non-goals **for current profile**: full multi-surface SDK/REST parity; full RFC-08 breadth in conformance; production A2A adapters (reference engine ships mock A2A for `agent_delegate`). Native `subworkflow` and `agent_delegate` are in profile per [ADR-0004](../adr/ADR-0004-r3-delegation-and-subworkflow.md). Details: `docs/poc-scope.md`, `ROADMAP.md`.
+Deferred or non-goals **for current profile**: full multi-surface SDK/REST parity; full RFC-08 breadth in conformance; production A2A adapters (reference engine ships mock A2A for `agent_delegate`). Native `subworkflow` and `agent_delegate` are in profile per [ADR-0004](../adr/ADR-0004-r3-delegation-and-subworkflow.md). Details: `docs/engine-profile.md`, `ROADMAP.md`.
 
 ## 1.4 Next-phase documentation viewpoints (evolution)
 

--- a/docs/architecture/arc42/02-constraints.md
+++ b/docs/architecture/arc42/02-constraints.md
@@ -13,10 +13,10 @@
 
 | Constraint | Rationale |
 |------------|-----------|
-| **Schema sync at pack (`prepack`)** | Bundled schema under `packages/engine/schemas/` must track root `schemas/workflow-definition-poc.json`; `npm run check-engine-poc-schema-sync` guards drift. |
+| **Schema sync at pack (`prepack`)** | Bundled schema under `packages/engine/schemas/` must track root `schemas/workflow-definition.json`; `npm run check-engine-schema-sync` guards drift. |
 | **ADRs for significant deviations** | `docs/architecture/adr/` anchors decisions with RFC / profile references. |
 
-## 2.3 Conventions enforcing the profile (`docs/poc-scope.md`)
+## 2.3 Conventions enforcing the profile (`docs/engine-profile.md`)
 
 - **Workflow document shape**: `document`, `state_schema`, `nodes`, `edges`; optional `checkpointing`; **no top-level `extensions`** in the engine profile.
 - **Node type set**: in-scope types include `parallel`, `wait`, `set_state`, `subworkflow`, `agent_delegate` ([ADR-0004](../adr/ADR-0004-r3-delegation-and-subworkflow.md)).

--- a/docs/architecture/arc42/03-context-and-scope.md
+++ b/docs/architecture/arc42/03-context-and-scope.md
@@ -22,7 +22,7 @@ The system provides a **vendor-neutral declarative workflow** contract for AI ag
 | Area | Repository location |
 |------|---------------------|
 | RFC text | `docs/RFC/` |
-| Engine profile + schema | `docs/poc-scope.md`, `schemas/workflow-definition-poc.json`, synced `packages/engine/schemas/` |
+| Engine profile + schema | `docs/engine-profile.md`, `schemas/workflow-definition.json`, synced `packages/engine/schemas/` |
 | Reference engine package | `packages/engine/` (`src/index.mjs` public exports; bins `workflows-engine`, `workflows-engine-mcp`) |
 | Golden examples | `examples/` |
 | Deterministic conformance | `conformance/` (`run-conformance.mjs`, `runner.mjs`, `vectors/`) |
@@ -39,7 +39,7 @@ The system provides a **vendor-neutral declarative workflow** contract for AI ag
 Treat the repo concurrently as:
 
 1. **Protocol specification source** (`docs/RFC/`).
-2. **Engine profile contract + fixtures** (`docs/poc-scope.md`, `schemas/`, `examples/`).
+2. **Engine profile contract + fixtures** (`docs/engine-profile.md`, `schemas/`, `examples/`).
 3. **Executable reference package** (`packages/engine/`, **`@agent-workflow/engine`** on npm).
 4. **Regression gates**: deterministic conformance (`conformance/`) plus validation scripts and CI.
 

--- a/docs/architecture/arc42/04-solution-strategy.md
+++ b/docs/architecture/arc42/04-solution-strategy.md
@@ -29,7 +29,7 @@
 |---------|-------|
 | **Hexagonal boundary** | Application port wraps graph operations; MCP is an adapter |
 | **Event sourcing lite** | Command/event streams as source for progression |
-| **Profile-driven narrowing** | `docs/poc-scope.md` is authoritative runtime subset |
+| **Profile-driven narrowing** | `docs/engine-profile.md` is authoritative runtime subset |
 
 ## 4.4 Activity execution positioning (implemented)
 

--- a/docs/architecture/arc42/05-building-block-view.md
+++ b/docs/architecture/arc42/05-building-block-view.md
@@ -7,7 +7,7 @@
 | **`@agent-workflow/engine`** | Validation, orchestration, persistence adapters, MCP server composition, exported library API | `packages/engine/` |
 | **Conformance harness** | Deterministic `schema` and `replay` vectors | `conformance/run-conformance.mjs`, `conformance/runner.mjs`, `conformance/vectors/` |
 | **Repo validation toolchain** | CI-scale AJV sweep over fixtures | `scripts/validate-workflows.mjs`, `npm run validate-workflows` |
-| **Contract artifacts** | Normative prose + schema | `docs/RFC/`, `schemas/workflow-definition-poc.json`, `docs/poc-scope.md` |
+| **Contract artifacts** | Normative prose + schema | `docs/RFC/`, `schemas/workflow-definition.json`, `docs/engine-profile.md` |
 
 **Diagram:** [`../arc42-assets/diagrams/as-built-views.drawio`](../arc42-assets/diagrams/as-built-views.drawio) — **`AS-IS Building Block View`**. See [`../arc42-assets/README.md`](../arc42-assets/README.md) for other asset kinds.
 

--- a/docs/architecture/arc42/09-architecture-decisions.md
+++ b/docs/architecture/arc42/09-architecture-decisions.md
@@ -4,7 +4,7 @@ Significant architectural decisions live as **architecture decision records (ADR
 
 | ADR | Title | Topic |
 |-----|-------|-------|
-| [ADR-0001](../adr/ADR-0001-poc-foundation-decisions.md) | Engine profile foundation | Runtime scope anchored in `docs/poc-scope.md` |
+| [ADR-0001](../adr/ADR-0001-poc-foundation-decisions.md) | Engine profile foundation | Runtime scope anchored in `docs/engine-profile.md` |
 | [ADR-0002](../adr/ADR-0002-host-mediated-activity-execution.md) | Host-mediated activity execution | MCP host submits activity outcomes (`workflow_submit_activity`) |
 | [ADR-0003](../adr/ADR-0003-engine-direct-mcp-activity-execution.md) | Engine-direct MCP activity execution | Optional operator manifests for unattended profiles |
 | [ADR-0004](../adr/ADR-0004-r3-delegation-and-subworkflow.md) | Delegation and subworkflow | Native `agent_delegate` + `subworkflow`, replay invariants |
@@ -15,7 +15,7 @@ Lifecycle and conventions: [`../adr/README.md`](../adr/README.md).
 
 ### ADR bootstrap (themes from the current baseline)
 
-Fertile tension clusters for future ADRs—each record should cite **RFC** sections impacted, deltas to **`docs/poc-scope.md`**, and conformance/test hooks proving regressions cannot slip unnoticed:
+Fertile tension clusters for future ADRs—each record should cite **RFC** sections impacted, deltas to **`docs/engine-profile.md`**, and conformance/test hooks proving regressions cannot slip unnoticed:
 
 | Theme | Typical trigger |
 |-------|----------------|
@@ -28,7 +28,7 @@ Fertile tension clusters for future ADRs—each record should cite **RFC** secti
 Mandatory cross-links inside each ADR body:
 
 1. Supporting **RFC** sections (execution model, integrations, conformance expectations).
-2. **`docs/poc-scope.md`** impact statement (narrow/widen profile).
+2. **`docs/engine-profile.md`** impact statement (narrow/widen profile).
 3. **Conformance** additions (`conformance/vectors/**`) plus targeted **`packages/engine/test/**`** identifiers.
 
 ---

--- a/docs/architecture/arc42/10-quality-requirements.md
+++ b/docs/architecture/arc42/10-quality-requirements.md
@@ -7,7 +7,7 @@
 | **Correctness — replay** | History + definition determines progression | Replay vectors under `conformance/vectors/replay/`; walker tests |
 | **Correctness — schema** | Invalid definitions rejected | `*.vector.json` (`kind: "schema"`) + `npm run validate-workflows` |
 | **Maintainability — boundary clarity** | MCP isolated behind application port | Adapter tests (`packages/engine/test/mcp-stdio-adapter.test.mjs` and related) |
-| **Compliance — profile fidelity** | Node type surface matches scope | AJV enums + poc-scope assertions in documentation |
+| **Compliance — profile fidelity** | Node type surface matches scope | AJV enums + engine-profile assertions in documentation |
 | **Operability — smoke reproducibility** | Operator can exercise MCP lifecycle | [`../arc42-assets/runbooks/mcp-stdio-host-smoke.md`](../arc42-assets/runbooks/mcp-stdio-host-smoke.md) |
 
 ## 10.2 Non-functional backlog (stretch vs GA)
@@ -28,7 +28,7 @@ Themes from **`ROADMAP.md`** not fully realized in reference-engine tooling:
 | `npm run validate-workflows` | CI + local |
 | `npm run conformance` | CI |
 | `npm test` (engine workspace) | CI |
-| `npm run check-engine-poc-schema-sync` | Ensures bundled schema fidelity |
+| `npm run check-engine-schema-sync` | Ensures bundled schema fidelity |
 
 ## 10.4 Architecture strengths (as-is reinforcement)
 
@@ -36,7 +36,7 @@ Together these properties keep the reference engine auditable despite limited su
 
 | Strength | Meaning |
 |---------|---------|
-| **Profile boundary clarity** | `docs/poc-scope.md` cleanly narrows runnable semantics beneath the RFC family. |
+| **Profile boundary clarity** | `docs/engine-profile.md` cleanly narrows runnable semantics beneath the RFC family. |
 | **Deterministic command/event lineage** | History + schema-valid definition drives **replay-shaped** advancement (`workflow-graph-walker.mjs`). |
 | **Hexagonal MCP boundary** | `createWorkflowApplicationPort` shields orchestration logic from MCP transport quirks. |
 | **Conformance harness** | Vectors institutionalize regressions beside golden examples. |

--- a/docs/architecture/arc42/12-glossary.md
+++ b/docs/architecture/arc42/12-glossary.md
@@ -3,7 +3,7 @@
 | Term | Definition |
 |------|------------|
 | **Agent Workflow Protocol** | Specification family under `docs/RFC/` defining declarative workflows for agent systems |
-| **Engine profile** | Authoritative runtime subset documented in [`docs/poc-scope.md`](../../poc-scope.md) |
+| **Engine profile** | Authoritative runtime subset documented in [`docs/engine-profile.md`](../../engine-profile.md) |
 | **Workflow definition** | JSON document complying with the bundled workflow schema describing nodes, edges, state schema |
 | **Execution** | A single invocation of orchestration keyed by **`executionId`** |
 | **`workflows-engine`** | CLI bin for workflow validation/manifest tooling (`packages/engine/src/cli.mjs`) |

--- a/docs/architecture/arc42/README.md
+++ b/docs/architecture/arc42/README.md
@@ -6,7 +6,7 @@ This directory contains the **[arc42](https://arc42.org/)** template applied to 
 - baseline before new features (**where to extend**),
 - alignment with **[C4 model](https://c4model.com/)** diagrams in [`../arc42-assets/diagrams/as-built-views.drawio`](../arc42-assets/diagrams/as-built-views.drawio).
 
-**Status:** As-is baseline. Normative protocol intent remains in [`docs/RFC/`](../../RFC/); engine profile subset in [`docs/poc-scope.md`](../../poc-scope.md).
+**Status:** As-is baseline. Normative protocol intent remains in [`docs/RFC/`](../../RFC/); engine profile subset in [`docs/engine-profile.md`](../../engine-profile.md).
 
 ## Section index
 
@@ -37,7 +37,7 @@ This directory contains the **[arc42](https://arc42.org/)** template applied to 
 |-------|------|
 | Host-mediated versus engine-direct | [`../adr/ADR-0002-host-mediated-activity-execution.md`](../adr/ADR-0002-host-mediated-activity-execution.md), [`../adr/ADR-0003-engine-direct-mcp-activity-execution.md`](../adr/ADR-0003-engine-direct-mcp-activity-execution.md) |
 | Engine package surface | [`../../../packages/engine/README.md`](../../../packages/engine/README.md) |
-| Profile & schema authority | [`../../poc-scope.md`](../../poc-scope.md) |
+| Profile & schema authority | [`../../engine-profile.md`](../../engine-profile.md) |
 | Replay / conformance harness | [`../../../conformance/README.md`](../../../conformance/README.md) |
 | RFC execution model & reference impl narratives | [`../../RFC/rfc-04-execution-model.md`](../../RFC/rfc-04-execution-model.md), [`../../RFC/rfc-08-reference-implementation.md`](../../RFC/rfc-08-reference-implementation.md) |
 

--- a/docs/community-launch-playbook.md
+++ b/docs/community-launch-playbook.md
@@ -7,7 +7,7 @@ Purpose: launch alpha publicly with focused channels, clear calls-to-action, and
 
 ## Launch goals
 
-- Drive high-quality feedback on protocol clarity, POC scope, and engine usability.
+- Drive high-quality feedback on protocol clarity, engine profile, and engine usability.
 - Convert early external interest into structured issues and docs improvements.
 - Avoid maintainer overload via explicit intake rules, support boundaries, and SLA targets.
 
@@ -49,7 +49,7 @@ Template:
 
 Template:
 
-> Alpha deep-dive request: we are validating the POC execution contract and conformance harness for multi-step agent orchestration.  
+> Alpha deep-dive request: we are validating the reference execution contract and conformance harness for multi-step agent orchestration.  
 >  
 > If you evaluate it, please share:  
 > - one area that is underspecified,  
@@ -71,7 +71,7 @@ Template:
 > Best contributions right now:  
 > - docs clarity fixes,  
 > - reproducible bug reports,  
-> - conformance fixture proposals aligned to `docs/poc-scope.md`.  
+> - conformance fixture proposals aligned to `docs/engine-profile.md`.  
 >  
 > Repro command baseline:  
 > - channel: `npx -y -p @agent-workflow/engine@alpha workflows-engine-mcp`  

--- a/docs/engine-profile.md
+++ b/docs/engine-profile.md
@@ -4,7 +4,7 @@ This note is the **authoritative subset** of the Agent Workflow Protocol RFCs th
 
 **Normative sources (read in full for semantics):**
 
-| Document | Sections this POC subsets |
+| Document | Sections this profile subsets |
 |----------|---------------------------|
 | [Workflow Definition Schema](rfc-03-workflow-definition-schema.md) | §3.1–§3.8 (representation, top-level shape, jq, state/reducers, nodes, edges, node types listed below, retry/timeout) |
 | [Execution Model](rfc-04-execution-model.md) | §4.2–§4.6, §4.8 (phases, command/event subsets below, state updates and reducers, interrupt/resume) |
@@ -13,34 +13,34 @@ This note is the **authoritative subset** of the Agent Workflow Protocol RFCs th
 
 ## 1. Workflow document surface (in scope)
 
-Per [RFC-03 §3.2](rfc-03-workflow-definition-schema.md#32-top-level-document-structure), POC documents **MUST** include:
+Per [RFC-03 §3.2](rfc-03-workflow-definition-schema.md#32-top-level-document-structure), workflow documents in this profile **MUST** include:
 
 - `document` (including `schema`, `name`, `version`; optional `description`)
 - `state_schema` (JSON Schema for workflow state)
 - `nodes` (non-empty array)
-- `edges` (array; may be empty only if the graph is fully implied by a node type that carries its own routing — **not** the case for the POC node set below, so in practice edges are required for a valid runnable graph)
+- `edges` (array; may be empty only if the graph is fully implied by a node type that carries its own routing — **not** the case for the profile node set below, so in practice edges are required for a valid runnable graph)
 
-**Optional top-level fields for POC:**
+**Optional top-level fields:**
 
 - `checkpointing` — **allowed** in documents; engines **MAY** implement persistence later (see §5). Validators **SHOULD** still accept the block if present.
 
 **Out of scope (top-level):**
 
-- `extensions` — **not** supported in POC; documents that include `extensions` **SHOULD** be rejected by POC validation, or engines **MUST** reject unknown extension semantics.
+- `extensions` — **not** supported in this profile; documents that include `extensions` **SHOULD** be rejected by profile validation, or engines **MUST** reject unknown extension semantics.
 
 ---
 
 ## 2. Node `type` values (in scope)
 
-These discriminators **MUST** be supported by the POC schema bundle and honored by the first engine milestone (naming matches [RFC-03 §3.7](rfc-03-workflow-definition-schema.md#37-node-types-normative)):
+These discriminators **MUST** be supported by the workflow schema bundle and honored by the first engine milestone (naming matches [RFC-03 §3.7](rfc-03-workflow-definition-schema.md#37-node-types-normative)):
 
-| `type` | POC notes |
+| `type` | Profile notes |
 |--------|-----------|
 | `start` | At most one per document; entry binding per RFC. |
 | `end` | Terminal; `output_schema` / `output_mapping` **MAY** be used if present. |
 | `step` | Deterministic activity boundary; `config` **MUST** include an implementation reference (e.g. `handler` / `code_ref`) per RFC; exact registry is profile-specific. |
 | `llm_call` | Non-deterministic model invocation; **MAY** be stubbed with a fixed transcript in early demos without changing document shape. |
-| `tool_call` | External tool; **SHOULD** be MCP-shaped (`server`, `tool`, `arguments`) for portable POC fixtures. |
+| `tool_call` | External tool; **SHOULD** be MCP-shaped (`server`, `tool`, `arguments`) for portable fixtures. |
 | `switch` | Conditional routing via `config.cases` (`when` jq expression, `target` node id) and optional `config.default`. |
 | `interrupt` | Human-in-the-loop; `config` **MUST** include `resume_schema` and **MUST** include `prompt` or a resolvable reference per RFC; optional `timeout`. |
 | `parallel` | Fork/join per RFC-03: `config.join` is `all` \| `any` \| `n_of_m` (with `n`), `config.branches` is `{ name, entry }[]` where `entry` is the first node id of a branch. Exactly **one** static edge leaves the parallel node to the **join target**; each branch must reach that target via its own linear chain (see golden `examples/r2-research-parallel.workflow.json`). |
@@ -59,7 +59,7 @@ Validators **MUST** reject unknown `type` values.
 
 ### 2.2 Delegation bridge migration (`tool_call` → native)
 
-Prior POC milestones emulated delegation with `tool_call` to agent-shaped tools (for example `agent.execute` / `agent.status`). Native **`agent_delegate`** is now in profile (§2).
+Prior milestones emulated delegation with `tool_call` to agent-shaped tools (for example `agent.execute` / `agent.status`). Native **`agent_delegate`** is now in profile (§2).
 
 | Bridge (`tool_call`) | Native (`agent_delegate`) |
 |----------------------|---------------------------|
@@ -77,7 +77,7 @@ Per [RFC-03 §3.6](rfc-03-workflow-definition-schema.md#36-edges):
 
 - Edges are directed: `{ "source": "<node_id_or___start__>", "target": "<node_id>" }`.
 - Synthetic source `__start__` **MAY** be used for the unique entry edge to the `start` node’s successor (or as specified in golden fixtures).
-- For `switch`, outgoing routing **MAY** be expressed only via `config.cases` / `default`; static `edges` from the `switch` node **MAY** coexist only if the engine documents precedence. **POC recommendation:** prefer `cases` + `default` for switch successors; avoid duplicate routing channels until conformance tests lock precedence.
+- For `switch`, outgoing routing **MAY** be expressed only via `config.cases` / `default`; static `edges` from the `switch` node **MAY** coexist only if the engine documents precedence. **Profile recommendation:** prefer `cases` + `default` for switch successors; avoid duplicate routing channels until conformance tests lock precedence.
 
 **Parallel:** The parallel node lists branch **entry** node ids; each branch follows static edges until it reaches the parallel node’s unique **join target** (the sole edge leaving the parallel node). Nested `parallel` and `switch` inside branches are allowed; **interrupt inside a parallel branch** is not resume-safe in this profile — avoid until correlation is modeled.
 
@@ -90,13 +90,13 @@ Per [RFC-03 §3.6](rfc-03-workflow-definition-schema.md#36-edges):
 Per [RFC-03 §3.3](rfc-03-workflow-definition-schema.md#33-expression-language-jq):
 
 - `switch` `when` expressions and any `end` `output_mapping` **MUST** be jq strings.
-- The exact **jq conformance subset** and the **execution-state binding** (root object shape) **MUST** be documented by the engine and reflected in fixtures; POC schema validation alone **MAY** be limited to syntactic presence.
+- The exact **jq conformance subset** and the **execution-state binding** (root object shape) **MUST** be documented by the engine and reflected in fixtures; workflow schema validation alone **MAY** be limited to syntactic presence.
 
 ### 4.2 Reducers
 
-Per [RFC-03 §3.4](rfc-03-workflow-definition-schema.md#34-state-schema-and-reducers) and [RFC-04 §4.6](rfc-04-execution-model.md#46-state-updates-and-reducers), POC **MUST** support these `state_schema` property annotations when merging node outputs into state:
+Per [RFC-03 §3.4](rfc-03-workflow-definition-schema.md#34-state-schema-and-reducers) and [RFC-04 §4.6](rfc-04-execution-model.md#46-state-updates-and-reducers), this profile **MUST** support these `state_schema` property annotations when merging node outputs into state:
 
-| Reducer | In POC |
+| Reducer | In profile |
 |---------|--------|
 | `overwrite` | Yes (default behavior when omitted). |
 | `append` | Yes. |
@@ -109,7 +109,7 @@ After reducer application, engines **SHOULD** validate state against `state_sche
 
 ## 5. Retry, timeout, checkpointing
 
-- **Retry and timeout** on nodes follow [RFC-03 §3.8](rfc-03-workflow-definition-schema.md#38-retry-and-timeout); POC **MUST** accept at least `retry.max_attempts` (≥ 1) and common duration forms the engine documents.
+- **Retry and timeout** on nodes follow [RFC-03 §3.8](rfc-03-workflow-definition-schema.md#38-retry-and-timeout); this profile **MUST** accept at least `retry.max_attempts` (≥ 1) and common duration forms the engine documents.
 - **Checkpointing** ([RFC-03 §3.9](rfc-03-workflow-definition-schema.md#39-checkpointing-block), [RFC-04 §4.10](rfc-04-execution-model.md#410-checkpointing)) — the reference engine emits `CheckpointWritten` after selected node boundaries (switch completion, interrupt raised, parallel join, wait, `set_state`, and post-resume steps). The optional top-level `checkpointing` object **MAY** set execution policy:
   - `strategy` (or alias `policy`): `after_each_node` (default when omitted or when `checkpointing` is absent), `every_n_nodes` (requires integer `n` ≥ 1), or `disabled` (no checkpoints).
   - For `every_n_nodes`, checkpoint emission uses the same boundary points as `after_each_node`, but only every *n*th opportunity (deterministic ordering of boundaries as implemented by the engine).
@@ -147,7 +147,7 @@ The full taxonomies are [RFC-04 §4.4](rfc-04-execution-model.md#44-command-taxo
 
 - `CheckpointWritten` — emitted when checkpointing is not `disabled`; payload `policy` is `after_each_node` or `every_n_nodes` (with `intervalNodes` when interval policy is used). Checkpoints taken **inside a parallel branch** (per-branch walk before the join target) include **`parallelSpan`**: `{ parallelNodeId, joinTargetId, branchName, branchEntryNodeId }` so readers can correlate inline `stateRef` with fork/join context ([RFC-04 §4.10](rfc-04-execution-model.md#410-checkpointing)).
 
-Lifecycle phases [RFC-04 §4.2](rfc-04-execution-model.md#42-phases) **MUST** be respected at a high level: validate → start → walk graph → complete or fail; interrupt transitions per [§4.8](rfc-04-execution-model.md#48-interrupt-and-resume-protocol). Deterministic replay [§4.3](rfc-04-execution-model.md#43-deterministic-replay) is **normative for the protocol** but **MAY** land in a later milestone than the first runnable scheduler; this document still lists the command/event shapes the POC definition is intended to align with.
+Lifecycle phases [RFC-04 §4.2](rfc-04-execution-model.md#42-phases) **MUST** be respected at a high level: validate → start → walk graph → complete or fail; interrupt transitions per [§4.8](rfc-04-execution-model.md#48-interrupt-and-resume-protocol). Deterministic replay [§4.3](rfc-04-execution-model.md#43-deterministic-replay) is **normative for the protocol** but **MAY** land in a later milestone than the first runnable scheduler; this document still lists the command/event shapes the profile definition is intended to align with.
 
 ---
 
@@ -161,6 +161,6 @@ The Lighthouse demo workflow (`examples/lighthouse-customer-routing.workflow.jso
 
 Updates to this file **SHOULD** be paired with schema bundle version bumps and fixture updates (track in the repository issue backlog).
 
-**Machine-readable contract:** [schemas/workflow-definition-poc.json](../schemas/workflow-definition-poc.json) (see [schemas/README.md](../schemas/README.md)).
+**Machine-readable contract:** [schemas/workflow-definition.json](../schemas/workflow-definition.json) (see [schemas/README.md](../schemas/README.md)).
 
-**v1 profile (core vs optional, GA prep):** [docs/releases/v1-profile-model.md](releases/v1-profile-model.md), [docs/releases/jq-conformance-subset.md](releases/jq-conformance-subset.md), [docs/releases/migration-alpha-to-ga.md](releases/migration-alpha-to-ga.md).
+**Profile model (core vs optional):** [docs/releases/profile-model.md](releases/profile-model.md), [docs/releases/jq-conformance-subset.md](releases/jq-conformance-subset.md), [docs/releases/migration-alpha-to-ga.md](releases/migration-alpha-to-ga.md).

--- a/docs/releases/alpha-release-notes.md
+++ b/docs/releases/alpha-release-notes.md
@@ -24,7 +24,7 @@ Release policy and checklist reference: [alpha-versioning-and-release-commit-flo
 
 ### Docs
 
-- Release notes, `CLAUDE.md`, arc42 product sections, and `docs/poc-scope.md` scrubbed of stale “out of scope” delegation/composition language; capability terms replace release-milestone labels in product docs.
+- Release notes, `CLAUDE.md`, arc42 product sections, and `docs/engine-profile.md` scrubbed of stale “out of scope” delegation/composition language; capability terms replace release-milestone labels in product docs.
 
 ### Internal
 
@@ -37,7 +37,7 @@ Release policy and checklist reference: [alpha-versioning-and-release-commit-flo
 
 ### Validation run
 
-- `npm run check-engine-poc-schema-sync`
+- `npm run check-engine-schema-sync`
 - `npm run validate-workflows`
 - `npm run conformance`
 - `npm test`
@@ -84,7 +84,7 @@ Release policy and checklist reference: [alpha-versioning-and-release-commit-flo
 
 ### Validation run
 
-- `npm run check-engine-poc-schema-sync`
+- `npm run check-engine-schema-sync`
 - `npm run validate-workflows`
 - `npm run conformance`
 - `npm test`
@@ -106,16 +106,16 @@ These notes are for external evaluators and early adopters validating the curren
 ## Highlights for this alpha phase
 
 - Protocol-first repository with a structured RFC set under `docs/RFC/`.
-- JSON Schema contract in `schemas/workflow-definition-poc.json` for the **engine profile** in [`docs/poc-scope.md`](../poc-scope.md) (core orchestration, `parallel`, `wait`, `set_state`, **`agent_delegate`**, **`subworkflow`**).
+- JSON Schema contract in `schemas/workflow-definition.json` for the **engine profile** in [`docs/engine-profile.md`](../engine-profile.md) (core orchestration, `parallel`, `wait`, `set_state`, **`agent_delegate`**, **`subworkflow`**).
 - Golden workflow fixtures and trace companions in `examples/`, including parallel and research-style fixtures.
 - Deterministic conformance harness entrypoint via `npm run conformance` (schema, replay, host-activity, and engine-direct replay invariants).
 - Node.js engine package with validation, append-only execution history, `switch`, `interrupt`/resume, parallel join policies, `wait` duration/until, `set_state`, delegation and nested workflows, checkpoint policy hooks, **host-mediated** and **engine-direct** `tool_call` activity execution (see [ADR-0003](../architecture/adr/ADR-0003-engine-direct-mcp-activity-execution.md)), and MCP stdio adapter.
 
 ## Known limitations
 
-- **`agent_delegate`:** reference engine uses **mock A2A** only; production A2A/MCP/SDK adapters are not bundled (see `docs/poc-scope.md`, [ADR-0004](../architecture/adr/ADR-0004-r3-delegation-and-subworkflow.md)).
+- **`agent_delegate`:** reference engine uses **mock A2A** only; production A2A/MCP/SDK adapters are not bundled (see `docs/engine-profile.md`, [ADR-0004](../architecture/adr/ADR-0004-r3-delegation-and-subworkflow.md)).
 - **`subworkflow` workflow refs:** child definitions must be registered (e.g. `registerWorkflowRef`); built-in URNs load from `examples/` only in a monorepo checkout, not from the npm tarball ([engine README](../../packages/engine/README.md#workflow-references), [arc42 §8.8](../architecture/arc42/08-cross-cutting-concepts.md#88-workflow-reference-resolution-subworkflow)).
-- **Wait `signal`:** requires a host; the bare engine fails this path at runtime (see `docs/poc-scope.md`).
+- **Wait `signal`:** requires a host; the bare engine fails this path at runtime (see `docs/engine-profile.md`).
 - Some RFC sections describe long-term direction (e.g. REST/SDK parity, core binary) that extends beyond this Node.js reference package.
 - Trace companion files are illustrative execution narratives and are not schema-validated executable workflow inputs.
 - Contracts and naming are still pre-1.0 and may change with limited backward compatibility guarantees.

--- a/docs/releases/jq-conformance-subset.md
+++ b/docs/releases/jq-conformance-subset.md
@@ -3,7 +3,7 @@
 **Last reviewed:** 2026-06-04  
 **Status:** Normative for `@agent-workflow/engine` replay and conformance until a fuller RFC-03 jq profile is frozen.  
 **Implementation:** [`jq-wasm`](https://www.npmjs.com/package/jq-wasm) via `loadJq()` in `packages/engine/src/orchestrator/workflow-graph-walker.mjs`.  
-**Profile context:** [v1-profile-model.md](./v1-profile-model.md), [docs/poc-scope.md](../poc-scope.md) §4.
+**Profile context:** [profile-model.md](./profile-model.md), [docs/engine-profile.md](../engine-profile.md) §4.
 
 ---
 

--- a/docs/releases/linear-project-operating-model.md
+++ b/docs/releases/linear-project-operating-model.md
@@ -59,7 +59,7 @@ Configure in the Linear UI (names are suggestive):
 
 ### Planning narrative (issue descriptions)
 
-- **Canonical epic/story content** (description, acceptance criteria, links to `docs/RFC/`, `docs/poc-scope.md`, ADRs) lives in the **Linear issue or milestone description**.
+- **Canonical epic/story content** (description, acceptance criteria, links to `docs/RFC/`, `docs/engine-profile.md`, ADRs) lives in the **Linear issue or milestone description**.
 - Keep **structural** sequencing in Linear **relations**, not only in markdown checklists.
 
 ### Hierarchy

--- a/docs/releases/migration-alpha-to-ga.md
+++ b/docs/releases/migration-alpha-to-ga.md
@@ -2,7 +2,7 @@
 
 **Last reviewed:** 2026-06-04  
 **Status:** Stub — expanded as R4 GA approaches.  
-**Profile model:** [v1-profile-model.md](./v1-profile-model.md)  
+**Profile model:** [profile-model.md](./profile-model.md)  
 **Alpha notes:** [alpha-release-notes.md](./alpha-release-notes.md)
 
 This guide helps operators and workflow authors move from the **alpha reference engine** (`0.1.2` on npm `alpha`) to the **GA v1** contract (schema URI, conformance tag, and engine semver `1.x` when published).
@@ -11,18 +11,18 @@ This guide helps operators and workflow authors move from the **alpha reference 
 
 ## 1. Schema and document metadata
 
-| Alpha (common today) | GA v1 target |
-|----------------------|--------------|
-| `document.schema`: `https://example.org/agent-workflow/poc/v1/workflow-definition` or `https://example.org/agent-workflow/v1` | `https://agent-workflow.dev/schemas/workflow-definition/v1.json` |
-| JSON Schema file `$id`: `https://example.org/agent-workflow/poc/v1/workflow-definition` | `https://agent-workflow.dev/schemas/workflow-definition/v1.json` |
+| Alpha (legacy URIs) | Current canonical URI |
+|----------------------|-------------------------|
+| `https://example.org/agent-workflow/poc/v1/workflow-definition` or `https://example.org/agent-workflow/v1` | `https://agent-workflow.dev/schemas/workflow-definition.json` |
+| JSON Schema file `$id` (legacy) | `https://agent-workflow.dev/schemas/workflow-definition.json` |
 
 **Actions:**
 
 1. Re-validate all workflow JSON against the bundled schema after upgrade (`npm run engine:validate -- path/to/workflow.json` or `npm run validate-workflows`).
-2. Update `document.schema` to the v1 URI in each workflow instance (bulk find/replace is safe if semantics unchanged).
-3. Run `npm run check-engine-poc-schema-sync` in CI to ensure the engine package copies the root schema.
+2. Update `document.schema` to the canonical URI in each workflow instance.
+3. Run `npm run check-engine-schema-sync` in CI to ensure the engine package copies the root schema.
 
-**Note:** GA does not require renaming the on-disk file `workflow-definition-poc.json` immediately; the stable **`$id`** is the interoperability anchor.
+**On-disk entry schema:** `schemas/workflow-definition.json` (bundled under `packages/engine/schemas/`).
 
 ---
 
@@ -40,7 +40,7 @@ Alpha milestones often modeled agent work as MCP-shaped **`tool_call`** nodes (`
 
 1. For each delegation `tool_call`, add an equivalent `agent_delegate` node with the same observable activity lifecycle (requested → completed/failed).
 2. Map `input_mapping` from prior argument shapes; reuse jq expressions where they already read parent state (see [jq-conformance-subset.md](./jq-conformance-subset.md)).
-3. Re-run conformance/replay fixtures; event prefixes should remain valid when lifecycle timing is preserved (`docs/poc-scope.md` §2.2).
+3. Re-run conformance/replay fixtures; event prefixes should remain valid when lifecycle timing is preserved (`docs/engine-profile.md` §2.2).
 4. Keep `tool_call` for non-agent tools (CRM, search, calculators); remove agent-shaped tools once hosts support delegate.
 
 Reference engine: in-process mock A2A for `protocol: "a2a"`; MCP/SDK paths may still use host-mediated activities.
@@ -76,7 +76,7 @@ Reference engine: in-process mock A2A for `protocol: "a2a"`; MCP/SDK paths may s
 ## 5. Validation checklist (pre-GA cutover)
 
 ```bash
-npm run check-engine-poc-schema-sync
+npm run check-engine-schema-sync
 npm run validate-workflows
 npm test
 npm run conformance
@@ -91,4 +91,4 @@ Record conformance summary JSON in release notes when tagging GA artifacts.
 - [ ] Published GA semver and npm dist-tag policy  
 - [ ] Conformance profile name and badge (`passes-v1-core`)  
 - [ ] Changelog entries for any breaking MCP error code changes  
-- [ ] HTTP version negotiation (deferred; see [v1-profile-model.md](./v1-profile-model.md))
+- [ ] HTTP version negotiation (deferred; see [profile-model.md](./profile-model.md))

--- a/docs/releases/profile-model.md
+++ b/docs/releases/profile-model.md
@@ -1,12 +1,12 @@
-# v1 profile model — core vs optional
+# Profile model — core vs optional
 
 **Last reviewed:** 2026-06-04  
 **Status:** Incremental R4 prep (BEN-8); not a GA contract freeze.  
 **Normative protocol:** [RFC-03](../../docs/RFC/rfc-03-workflow-definition-schema.md), [RFC-04](../../docs/RFC/rfc-04-execution-model.md).  
-**Engine profile (alpha):** [docs/poc-scope.md](../poc-scope.md).  
-**JSON Schema entry:** [schemas/workflow-definition-poc.json](../../schemas/workflow-definition-poc.json) (`$id`: `https://agent-workflow.dev/schemas/workflow-definition/v1.json`).
+**Engine profile (alpha):** [docs/engine-profile.md](../engine-profile.md).  
+**JSON Schema entry:** [schemas/workflow-definition.json](../../schemas/workflow-definition.json) (`$id`: `https://agent-workflow.dev/schemas/workflow-definition.json`).
 
-This document formalizes what adopters **must** implement for **v1 core** interoperability versus what remains **optional** or **host-dependent** in the reference engine today. It complements `docs/poc-scope.md` (authoritative engine subset) and will converge with the GA conformance tag.
+This document formalizes what adopters **must** implement for **core profile** interoperability versus what remains **optional** or **host-dependent** in the reference engine today. It complements `docs/engine-profile.md` (authoritative engine subset) and will converge with the GA conformance tag.
 
 ---
 
@@ -14,7 +14,7 @@ This document formalizes what adopters **must** implement for **v1 core** intero
 
 | Artifact | URI |
 |----------|-----|
-| JSON Schema `$id` | `https://agent-workflow.dev/schemas/workflow-definition/v1.json` |
+| JSON Schema `$id` | `https://agent-workflow.dev/schemas/workflow-definition.json` |
 | Suggested `document.schema` in instances | Same URI (legacy POC/example URIs remain valid during alpha→GA migration; see [migration-alpha-to-ga.md](./migration-alpha-to-ga.md)) |
 
 **Deferred (document only):** HTTP **version negotiation** (e.g. `Accept-Profile`, schema discovery registry, multi-profile servers). GA may add a registry publication step; the reference engine continues to bundle a single schema file validated at start.
@@ -34,7 +34,7 @@ This document formalizes what adopters **must** implement for **v1 core** intero
 | `switch` routing via `config.cases` / `default` (jq) | Core | Supported | Static edges from `switch` id ignored. |
 | State reducers: `overwrite`, `append`, `merge` | Core | Supported | `custom` rejected at validate. |
 | jq on `switch.when`, `set_state`, `end.output_mapping`, mappings | Core | Supported | Subset: [jq-conformance-subset.md](./jq-conformance-subset.md). |
-| Command/event subset in `docs/poc-scope.md` §6 | Core | Supported | Replay-oriented history. |
+| Command/event subset in `docs/engine-profile.md` §6 | Core | Supported | Replay-oriented history. |
 | `CheckpointWritten` + `definitionHash` binding | Core | Supported | Canonical JSON hash; resume/submit/continuation verify definition. See BEN-78. |
 | `interrupt` inside `parallel` branch | Refused | Validate + runtime refuse | Code `INTERRUPT_IN_PARALLEL_BRANCH`; invariant in `workflow-graph-invariants.mjs`. See BEN-77. |
 | `wait` `kind: signal` | Optional (host) | Runtime error without host | Requires host `workflow_signal`; not bare engine. |
@@ -43,7 +43,7 @@ This document formalizes what adopters **must** implement for **v1 core** intero
 | `tool_call` delegation bridge | Optional (legacy) | Supported | Prefer native `agent_delegate` for GA; see migration doc. |
 | Definition signing | Optional | Not implemented | R4 security story (BEN-10). |
 | REST / SDK parity with MCP | Optional | Partial | MCP stdio adapter is reference surface. |
-| Full RFC command taxonomy (`CancelTimer`, `EmitSignal`, …) | Optional | Out of profile | Listed in `docs/poc-scope.md` §6. |
+| Full RFC command taxonomy (`CancelTimer`, `EmitSignal`, …) | Optional | Out of profile | Listed in `docs/engine-profile.md` §6. |
 
 ---
 
@@ -68,4 +68,4 @@ This document formalizes what adopters **must** implement for **v1 core** intero
 
 ## Change control
 
-Update this matrix when `docs/poc-scope.md`, the schema bundle, or conformance tags change. Pair with [jq-conformance-subset.md](./jq-conformance-subset.md) and [migration-alpha-to-ga.md](./migration-alpha-to-ga.md) in the same PR when profile boundaries move.
+Update this matrix when `docs/engine-profile.md`, the schema bundle, or conformance tags change. Pair with [jq-conformance-subset.md](./jq-conformance-subset.md) and [migration-alpha-to-ga.md](./migration-alpha-to-ga.md) in the same PR when profile boundaries move.

--- a/docs/repository-metadata-checklist.md
+++ b/docs/repository-metadata-checklist.md
@@ -14,7 +14,7 @@ This checklist tracks discoverability settings that are configured in GitHub UI 
 
 ## Suggested description draft
 
-`Vendor-neutral agent workflow protocol and Node.js POC engine for deterministic, stateful AI workflow orchestration with replay, interrupts, and MCP-compatible tool integration (alpha).`
+`Vendor-neutral agent workflow protocol and Node.js reference engine for deterministic, stateful AI workflow orchestration with replay, interrupts, and MCP-compatible tool integration (alpha).`
 
 ## Suggested topic candidates
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Example workflow fixtures
 
-Golden definitions and **trace companions** for the engine profile ([docs/poc-scope.md](../docs/poc-scope.md), [schemas/](../schemas/)).
+Golden definitions and **trace companions** for the engine profile ([docs/engine-profile.md](../docs/engine-profile.md), [schemas/](../schemas/)).
 
 | File | Purpose |
 |------|---------|
@@ -23,7 +23,7 @@ Preferred: from the repository root run `npm ci` then `npm run validate-workflow
 One-off with [ajv-cli](https://github.com/ajv-validator/ajv-cli):
 
 ```bash
-npx --yes ajv-cli@5 validate -s schemas/workflow-definition-poc.json -d examples/lighthouse-customer-routing.workflow.json --spec=draft2020
+npx --yes ajv-cli@5 validate -s schemas/workflow-definition.json -d examples/lighthouse-customer-routing.workflow.json --spec=draft2020
 ```
 
 Trace companion files are informative and are **not** validated by the workflow schema.

--- a/examples/agentic-task-intake-prompt-improver.workflow.json
+++ b/examples/agentic-task-intake-prompt-improver.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/v1",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "agentic-task-intake-prompt-improver",
     "version": "1.0.0",
     "description": "POC-friendly agentic intake fixture with deterministic execution_mode routing between workflow publication and open-agentic execution bridge."

--- a/examples/conformance-agent-delegate-linear.workflow.json
+++ b/examples/conformance-agent-delegate-linear.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/poc/v1/workflow-definition",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "conformance-agent-delegate-linear",
     "version": "1.0.0",
     "description": "Linear graph: start → agent_delegate → end (conformance / replay)."

--- a/examples/conformance-host-activity-linear.workflow.json
+++ b/examples/conformance-host-activity-linear.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/poc/v1/workflow-definition",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "conformance-host-linear",
     "version": "1.0.0"
   },

--- a/examples/conformance-host-activity-parallel.workflow.json
+++ b/examples/conformance-host-activity-parallel.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/poc/v1/workflow-definition",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "conformance-host-par",
     "version": "1.0.0"
   },

--- a/examples/conformance-subworkflow-parent.workflow.json
+++ b/examples/conformance-subworkflow-parent.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/poc/v1/workflow-definition",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "conformance-subworkflow-parent",
     "version": "1.0.0"
   },

--- a/examples/fixtures.invalid/agent-delegate-invalid-protocol.workflow.json
+++ b/examples/fixtures.invalid/agent-delegate-invalid-protocol.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/poc/v1/workflow-definition",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "invalid-agent-delegate-protocol",
     "version": "0.0.0"
   },

--- a/examples/fixtures.invalid/extensions.workflow.json
+++ b/examples/fixtures.invalid/extensions.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/v1",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "intentionally-invalid",
     "version": "0.0.0"
   },

--- a/examples/fixtures.invalid/interrupt-in-parallel-branch.workflow.json
+++ b/examples/fixtures.invalid/interrupt-in-parallel-branch.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/poc/v1/workflow-definition",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "interrupt-in-parallel-branch-invalid",
     "version": "0.0.0"
   },

--- a/examples/fixtures.invalid/unsupported-node-type.workflow.json
+++ b/examples/fixtures.invalid/unsupported-node-type.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/poc/v1/workflow-definition",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "invalid-unsupported-node-kind",
     "version": "0.0.0"
   },

--- a/examples/fixtures.valid/minimal-linear.workflow.json
+++ b/examples/fixtures.valid/minimal-linear.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/poc/v1/workflow-definition",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "minimal-linear",
     "version": "0.1.0"
   },

--- a/examples/lighthouse-customer-routing.workflow.json
+++ b/examples/lighthouse-customer-routing.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/v1",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "lighthouse-customer-routing",
     "version": "1.0.0",
     "description": "Golden POC fixture: customer-style routing using llm_call, switch, interrupt, and MCP-shaped tool_call. Intended for reuse as the Epic 6 lighthouse definition."

--- a/examples/paperclip-read-compact.workflow.json
+++ b/examples/paperclip-read-compact.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/v1",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "paperclip-read-compact",
     "version": "1.0.0",
     "description": "Same Paperclip read chain as paperclip-read-snapshot, then a set_state step that projects jq-derived summaries and clears the bulky raw tool payload so completed final_state and MCP payloads stay small (token-efficiency demo). Each jq assignment sees the full pre-step state; merge reducers apply after."

--- a/examples/paperclip-read-parallel.workflow.json
+++ b/examples/paperclip-read-parallel.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/v1",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "paperclip-read-parallel",
     "version": "1.0.0",
     "description": "Three Paperclip tool_calls in a parallel fork/join: each branch does tool_call then set_state to copy .text into projects_raw / goals_raw / issues_raw and clear .text so keys do not clobber. Join target runs once after all branches and builds a token-small report, then clears raw blobs. Note: the reference engine executes join-all branches in deterministic branch-list order (not OS-parallel); shared state accumulates across branches."

--- a/examples/paperclip-read-snapshot.workflow.json
+++ b/examples/paperclip-read-snapshot.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/v1",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "paperclip-read-snapshot",
     "version": "1.0.0",
     "description": "Demo: engine-direct tool_call chain against the Paperclip MCP (read-only). Linear sequence lists projects, goals, and issues; each MCP structuredContent or text payload merges into workflow state. Run workflows-engine-mcp with WORKFLOW_ENGINE_MCP_CONFIG pointing at a manifest whose mcpServers.paperclip entry matches your Paperclip stdio server (see examples/mcp-operator-paperclip.example.json)."

--- a/examples/r2-parallel-join-any.workflow.json
+++ b/examples/r2-parallel-join-any.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/poc/v1/workflow-definition",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "r2-parallel-join-any",
     "version": "1.0.0"
   },

--- a/examples/r2-parallel-join-n2-of-3.workflow.json
+++ b/examples/r2-parallel-join-n2-of-3.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/poc/v1/workflow-definition",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "r2-parallel-join-n2-of-3",
     "version": "1.0.0"
   },

--- a/examples/r2-research-parallel.workflow.json
+++ b/examples/r2-research-parallel.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/poc/v1/workflow-definition",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "r2-research-parallel-demo",
     "version": "1.0.0"
   },

--- a/examples/r3-multi-agent-coding.workflow.json
+++ b/examples/r3-multi-agent-coding.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/poc/v1/workflow-definition",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "coding-task",
     "version": "1.0.0",
     "description": "RFC-03 Example C shape: implement (agent_delegate) + verify (subworkflow) + review (interrupt)."

--- a/examples/r3-unit-tests-child.workflow.json
+++ b/examples/r3-unit-tests-child.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/poc/v1/workflow-definition",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "r3-unit-tests-child",
     "version": "1.0.0",
     "description": "Minimal child workflow for R3 subworkflow (urn:awp:wf:unit-tests)."

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "workflows",
   "private": true,
-  "description": "Agent Workflow Protocol — POC contracts, fixtures, and tooling",
+  "description": "Agent Workflow Protocol — contracts, fixtures, and tooling",
   "type": "module",
   "workspaces": [
     "packages/*"
   ],
   "scripts": {
-    "sync-engine-poc-schema": "node scripts/sync-engine-poc-schema.mjs",
-    "check-engine-poc-schema-sync": "node scripts/sync-engine-poc-schema.mjs --check",
+    "sync-engine-schema": "node scripts/sync-engine-schema.mjs",
+    "check-engine-schema-sync": "node scripts/sync-engine-schema.mjs --check",
     "check-schema-breaking-change": "node scripts/check-schema-breaking-change.mjs",
     "check-threat-model-touch": "node scripts/check-threat-model-touch.mjs",
     "check-arc42-export-drift": "node scripts/check-arc42-export-drift.mjs",

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -1,6 +1,6 @@
 # `@agent-workflow/engine`
 
-Publishable npm package: **definition-time** validation for Agent Workflow Protocol workflow documents per [`docs/poc-scope.md`](../../docs/poc-scope.md), an **append-only execution history** port (SQLite or in-memory), a **linear graph runner**, and a **general graph walker** with `switch`, `interrupt` / resume, **parallel** join policies (`all` / `any` / `n_of_m`), **wait** (`duration` / `until`; `signal` needs a host), **set_state**, **`agent_delegate`** (in-process mock A2A), and **`subworkflow`** (nested runs with depth limit; register child defs via `registerWorkflowRef`).
+Publishable npm package: **definition-time** validation for Agent Workflow Protocol workflow documents per [`docs/engine-profile.md`](../../docs/engine-profile.md), an **append-only execution history** port (SQLite or in-memory), a **linear graph runner**, and a **general graph walker** with `switch`, `interrupt` / resume, **parallel** join policies (`all` / `any` / `n_of_m`), **wait** (`duration` / `until`; `signal` needs a host), **set_state**, **`agent_delegate`** (in-process mock A2A), and **`subworkflow`** (nested runs with depth limit; register child defs via `registerWorkflowRef`).
 
 ## Entrypoint (CLI)
 
@@ -144,7 +144,7 @@ The package exports:
 
 - `validateWorkflowDefinition(data)` — returns `{ ok: true }` or `{ ok: false, errors }` where `errors` is AJV’s `ErrorObject[]` (includes `instancePath`, `keyword`, `schemaPath`, etc.).
 - `compileWorkflowValidator()` — returns a reusable `(data) => { ok: true } | { ok: false, errors }` function; the compiled schema is cached per process.
-- `findWorkflowRepoRoot(startDir?)` — locates the **workflows** monorepo root (lighthouse fixture + root `package.json` named `workflows`) for tests and examples; schema loading prefers the bundled `packages/engine/schemas/workflow-definition-poc.json` when present.
+- `findWorkflowRepoRoot(startDir?)` — locates the **workflows** monorepo root (lighthouse fixture + root `package.json` named `workflows`) for tests and examples; schema loading prefers the bundled `packages/engine/schemas/workflow-definition.json` when present.
 - `runGraphWorkflow(...)` / `resumeGraphWorkflow(...)` / `submitActivityOutcome(...)` — general graph walker with `switch`, `interrupt`, parallel joins, and composition nodes (see **General graph orchestration** below).
 
 ### Linear orchestration
@@ -175,7 +175,7 @@ Phases: **validate** (bundled workflow schema + reject `state_schema.properties.
 
 `runGraphWorkflow` supports node types `start`, `end`, `step`, `llm_call`, `tool_call`, `switch`, `interrupt`, `parallel`, `wait`, `set_state`, `agent_delegate`, and `subworkflow`. Phases and command/event names match the linear runner (`ExecutionStarted`, `ScheduleNode`, `NodeScheduled`, activity events, `CompleteNode`, `StateUpdated`, terminal `ExecutionCompleted` / `ExecutionFailed`), plus interrupt lifecycle: `RaiseInterrupt`, `InterruptRaised`, and on resume `ResumeInterrupt`, `InterruptResumed`. On entering an `interrupt` node the walker appends `RaiseInterrupt` / `InterruptRaised` (payload includes `nodeId` and a short `prompt` summary) and returns `{ status: 'interrupted', executionId, nodeId, state }` **without** `CompleteNode` for that node until `resumeGraphWorkflow` runs.
 
-**`switch` routing:** Successors come **only** from `config.cases` (first jq match wins; jq input root is the **current workflow state object**, same as the linear runner) and `config.default` when no case matches. If any `cases` exist and none match and `default` is omitted, the run fails with a clear error. **Static `edges` whose `source` is the switch node id are ignored for routing** (they may exist in documents; the engine does not follow them). This matches the routing guidance in `docs/poc-scope.md` (avoid duplicate routing channels).
+**`switch` routing:** Successors come **only** from `config.cases` (first jq match wins; jq input root is the **current workflow state object**, same as the linear runner) and `config.default` when no case matches. If any `cases` exist and none match and `default` is omitted, the run fails with a clear error. **Static `edges` whose `source` is the switch node id are ignored for routing** (they may exist in documents; the engine does not follow them). This matches the routing guidance in `docs/engine-profile.md` (avoid duplicate routing channels).
 
 **Static `edges` (non-switch):** Exactly one outgoing edge from `__start__`, and from each of `start`, `step`, `llm_call`, `tool_call`, and `interrupt`; none from `end`. The walker does not require outgoing edges from `switch` nodes.
 
@@ -265,10 +265,10 @@ history.close();
 
 ## Stable “valid definition” boundary (for later engine stories)
 
-- **Schema contract:** The engine validates against the same file as CI and `scripts/validate-workflows.mjs`: **`schemas/workflow-definition-poc.json`** (JSON Schema Draft 2020-12).
+- **Schema contract:** The engine validates against the same file as CI and `scripts/validate-workflows.mjs`: **`schemas/workflow-definition.json`** (JSON Schema Draft 2020-12).
 - **Ajv options:** `allErrors: true`, `strict: false` — identical to `scripts/validate-workflows.mjs` to avoid drift from “repo truth.”
 - **Engine-specific limits:** None beyond the schema and JSON parse rules. The engine does **not** enforce file size limits, `document.schema` version bumps, or trace companions; only the workflow **definition** JSON shape is checked.
-- **Resolution rule:** The engine loads `schemas/workflow-definition-poc.json` from the **published package** (`packages/engine/schemas/` next to `src/`, kept in sync with the repo canonical schema). In a full **workflows** monorepo checkout it can fall back to the root `schemas/` copy. `findWorkflowRepoRoot()` locates the monorepo root via `examples/lighthouse-customer-routing.workflow.json` and the root `package.json` named `workflows` (for tests and fixtures), not via schema path alone.
+- **Resolution rule:** The engine loads `schemas/workflow-definition.json` from the **published package** (`packages/engine/schemas/` next to `src/`, kept in sync with the repo canonical schema). In a full **workflows** monorepo checkout it can fall back to the root `schemas/` copy. `findWorkflowRepoRoot()` locates the monorepo root via `examples/lighthouse-customer-routing.workflow.json` and the root `package.json` named `workflows` (for tests and fixtures), not via schema path alone.
 
 ## Tests
 
@@ -288,6 +288,6 @@ Check that:
 
 - tarball metadata resolves to `@agent-workflow/engine` with the intended version/tag source,
 - both binaries are present: `src/cli.mjs` and `src/mcp-stdio-server.mjs`,
-- bundled workflow schema is present: `schemas/workflow-definition-poc.json`,
+- bundled workflow schema is present: `schemas/workflow-definition.json`,
 - runtime/library entrypoint is present: `src/index.mjs`,
 - payload is minimal (runtime `src/`, bundled `schemas/`, package docs), with no test fixtures or unrelated repository files.

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -25,7 +25,7 @@
     "workflows-engine-mcp": "src/mcp-stdio-server.mjs"
   },
   "scripts": {
-    "prepack": "node ../../scripts/sync-engine-poc-schema.mjs",
+    "prepack": "node ../../scripts/sync-engine-schema.mjs",
     "test": "node --test test/*.mjs",
     "mcp:stdio": "node ./src/mcp-stdio-server.mjs"
   },

--- a/packages/engine/schemas/workflow-definition.json
+++ b/packages/engine/schemas/workflow-definition.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://agent-workflow.dev/schemas/workflow-definition/v1.json",
+  "$id": "https://agent-workflow.dev/schemas/workflow-definition.json",
   "title": "Agent Workflow Protocol — reference engine workflow definition",
-  "description": "JSON Schema for the profile defined in docs/poc-scope.md (core orchestration, delegation, and nested subworkflows). Normative semantics: docs/RFC/rfc-03-workflow-definition-schema.md.",
+  "description": "JSON Schema for the profile defined in docs/engine-profile.md (core orchestration, delegation, and nested subworkflows). Normative semantics: docs/RFC/rfc-03-workflow-definition-schema.md.",
   "type": "object",
   "additionalProperties": false,
   "required": ["document", "state_schema", "nodes", "edges"],
@@ -20,7 +20,7 @@
     },
     "checkpointing": {
       "type": "object",
-      "description": "Optional checkpoint policy per RFC-03 §3.9; reference engine honors strategy/n (see docs/poc-scope.md §5).",
+      "description": "Optional checkpoint policy per RFC-03 §3.9; reference engine honors strategy/n (see docs/engine-profile.md §5).",
       "additionalProperties": true,
       "properties": {
         "strategy": {
@@ -62,7 +62,7 @@
     },
     "state_schema_blob": {
       "type": "object",
-      "description": "JSON Schema object describing workflow state. Reducer annotations must be overwrite, append, or merge only (see docs/poc-scope.md); rejecting 'custom' may require additional tooling beyond this schema.",
+      "description": "JSON Schema object describing workflow state. Reducer annotations must be overwrite, append, or merge only (see docs/engine-profile.md); rejecting 'custom' may require additional tooling beyond this schema.",
       "minProperties": 1
     },
     "edge": {
@@ -196,7 +196,7 @@
         "config": {
           "type": "object",
           "additionalProperties": true,
-          "description": "Model, prompts, output_schema, etc. per RFC-03 §3.7; POC allows minimal/stub configs."
+          "description": "Model, prompts, output_schema, etc. per RFC-03 §3.7; profile allows minimal/stub configs."
         },
         "retry": { "$ref": "#/$defs/retry_policy" },
         "timeout": { "$ref": "#/$defs/node_level_timeout" },

--- a/packages/engine/src/cli.mjs
+++ b/packages/engine/src/cli.mjs
@@ -13,7 +13,7 @@ function usage() {
   process.stderr.write(
     "Usage:\n" +
       "  workflows-engine validate [<file>]\n" +
-      "    Validates a workflow JSON document against schemas/workflow-definition-poc.json.\n" +
+      "    Validates a workflow JSON document against schemas/workflow-definition.json.\n" +
       "    If <file> is omitted or `-`, reads JSON from stdin.\n" +
       "  workflows-engine mcp-manifest validate <file>\n" +
       "    Validates an operator MCP manifest (Cursor-style mcpServers subset).\n" +
@@ -70,7 +70,7 @@ async function cmdValidateWorkflow(rest) {
   }
   const result = validateWorkflowDefinition(data);
   if (result.ok) {
-    process.stdout.write("OK: document matches workflow schema (see docs/poc-scope.md).\n");
+    process.stdout.write("OK: document matches workflow schema (see docs/engine-profile.md).\n");
     return;
   }
   process.stderr.write("Validation failed:\n");

--- a/packages/engine/src/orchestrator/linear-runner.mjs
+++ b/packages/engine/src/orchestrator/linear-runner.mjs
@@ -27,7 +27,7 @@ export function assertNoCustomReducers(definition) {
   for (const [key, spec] of Object.entries(props)) {
     if (spec && typeof spec === "object" && spec.reducer === "custom") {
       throw new Error(
-        `Unsupported reducer "custom" on state_schema.properties.${key}. This engine profile only supports overwrite (default), append, and merge (see docs/poc-scope.md).`
+        `Unsupported reducer "custom" on state_schema.properties.${key}. This engine profile only supports overwrite (default), append, and merge (see docs/engine-profile.md).`
       );
     }
   }
@@ -199,7 +199,7 @@ function assertNoUnsupportedNodeTypes(nodes) {
   for (const n of nodes) {
     if (n.type === "switch" || n.type === "interrupt") {
       throw new Error(
-        `Node "${n.id}" has type "${n.type}", which is not supported by the linear runner (see docs/poc-scope.md).`
+        `Node "${n.id}" has type "${n.type}", which is not supported by the linear runner (see docs/engine-profile.md).`
       );
     }
   }

--- a/packages/engine/src/orchestrator/workflow-graph-invariants.mjs
+++ b/packages/engine/src/orchestrator/workflow-graph-invariants.mjs
@@ -3,7 +3,7 @@
  * (single start/end, deterministic fan-out, interrupt/parallel edge counts).
  */
 
-/** @see docs/poc-scope.md §3 — interrupt inside a parallel branch is not resume-safe. */
+/** @see docs/engine-profile.md §3 — interrupt inside a parallel branch is not resume-safe. */
 export const INTERRUPT_IN_PARALLEL_BRANCH_CODE = "INTERRUPT_IN_PARALLEL_BRANCH";
 
 export class InterruptInParallelBranchError extends Error {

--- a/packages/engine/src/validate.mjs
+++ b/packages/engine/src/validate.mjs
@@ -19,7 +19,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * @returns {string}
  */
 function bundledWorkflowSchemaPath() {
-  return path.join(__dirname, "..", "schemas", "workflow-definition-poc.json");
+  return path.join(__dirname, "..", "schemas", "workflow-definition.json");
 }
 
 /**
@@ -58,7 +58,7 @@ function loadWorkflowDefinitionSchema() {
   if (existsSync(bundled)) {
     return JSON.parse(readFileSync(bundled, "utf8"));
   }
-  const schemaPath = path.join(findWorkflowRepoRoot(__dirname), "schemas", "workflow-definition-poc.json");
+  const schemaPath = path.join(findWorkflowRepoRoot(__dirname), "schemas", "workflow-definition.json");
   return JSON.parse(readFileSync(schemaPath, "utf8"));
 }
 
@@ -83,7 +83,7 @@ export function compileWorkflowValidator() {
 }
 
 /**
- * Validates `data` against `schemas/workflow-definition-poc.json` (Draft 2020-12).
+ * Validates `data` against `schemas/workflow-definition.json` (Draft 2020-12).
  * @param {unknown} data Parsed JSON value (object).
  * @returns {{ ok: true } | { ok: false, errors: import("ajv").ErrorObject[] }}
  */

--- a/packages/engine/test/agent-delegate.test.mjs
+++ b/packages/engine/test/agent-delegate.test.mjs
@@ -235,7 +235,7 @@ describe("agent_delegate", () => {
     /** @type {object} */
     const definition = {
       document: {
-        schema: "https://example.org/agent-workflow/poc/v1/workflow-definition",
+        schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
         name: "delegate-after-interrupt",
         version: "1.0.0",
       },

--- a/packages/engine/test/definition-signing.test.mjs
+++ b/packages/engine/test/definition-signing.test.mjs
@@ -8,7 +8,7 @@ import {
 describe("definition signing stub", () => {
   it("unsigned definitions pass verification", () => {
     const r = verifyDefinitionSignature({
-      document: { schema: "https://example.org/agent-workflow/poc/v1/workflow-definition", name: "x", version: "1" },
+      document: { schema: "https://agent-workflow.dev/schemas/workflow-definition.json", name: "x", version: "1" },
       nodes: [],
       edges: [],
     });
@@ -22,7 +22,7 @@ describe("definition signing stub", () => {
   it("signed definitions pass stub verify hook", () => {
     const definition = {
       document: {
-        schema: "https://example.org/agent-workflow/poc/v1/workflow-definition",
+        schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
         name: "signed",
         version: "1",
         signature: { alg: "none", value: "stub" },

--- a/packages/engine/test/fixtures/linear.workflow.json
+++ b/packages/engine/test/fixtures/linear.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/v1",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "linear-fixture",
     "version": "1.0.0",
     "description": "Minimal linear graph for STORY-2-3 tests (start → step → end)."

--- a/packages/engine/test/fixtures/switch-precedence.workflow.json
+++ b/packages/engine/test/fixtures/switch-precedence.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/v1",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "switch-precedence",
     "version": "1.0.0",
     "description": "Switch has static edges from sw plus cases; engine must follow cases/default only."

--- a/packages/engine/test/mcp-stdio-adapter.test.mjs
+++ b/packages/engine/test/mcp-stdio-adapter.test.mjs
@@ -19,7 +19,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 function minimalValidWorkflowDefinition() {
   return {
     document: {
-      schema: "https://example.org/agent-workflow/poc/v1/workflow-definition",
+      schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
       name: "mcp-mock",
       version: "1.0.0",
     },
@@ -38,7 +38,7 @@ function minimalValidWorkflowDefinition() {
 function hostMediatedLinearDefinition() {
   return {
     document: {
-      schema: "https://example.org/agent-workflow/poc/v1/workflow-definition",
+      schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
       name: "mcp-host-med-linear",
       version: "1.0.0",
     },

--- a/packages/engine/test/mcp-transport-validation.test.mjs
+++ b/packages/engine/test/mcp-transport-validation.test.mjs
@@ -36,7 +36,7 @@ describe("MCP transport validation", () => {
     const handlers = createMcpWorkflowToolHandlers(createWorkflowApplicationPort({ store }));
     const invalidDefinition = {
       document: {
-        schema: "https://example.org/agent-workflow/poc/v1/workflow-definition",
+        schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
         name: "bad",
         version: "1",
       },

--- a/packages/engine/test/workflow-graph-walker.test.mjs
+++ b/packages/engine/test/workflow-graph-walker.test.mjs
@@ -501,7 +501,7 @@ describe("runGraphWorkflow (host-mediated activities)", () => {
     /** @type {object} */
     const definition = {
       document: {
-        schema: "https://example.org/agent-workflow/poc/v1/workflow-definition",
+        schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
         name: "host-med-linear",
         version: "1.0.0",
       },
@@ -593,7 +593,7 @@ describe("runGraphWorkflow (host-mediated activities)", () => {
     /** @type {object} */
     const definition = {
       document: {
-        schema: "https://example.org/agent-workflow/poc/v1/workflow-definition",
+        schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
         name: "host-input-check",
         version: "1.0.0",
       },
@@ -647,7 +647,7 @@ describe("runGraphWorkflow (host-mediated activities)", () => {
     /** @type {object} */
     const definition = {
       document: {
-        schema: "https://example.org/agent-workflow/poc/v1/workflow-definition",
+        schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
         name: "host-med-parallel",
         version: "1.0.0",
       },
@@ -731,12 +731,12 @@ describe("runGraphWorkflow (host-mediated activities)", () => {
   });
 
   it("submitActivityOutcome forwards subworkflowDepth to continuation (max depth enforced)", async () => {
-    const pocSchema = "https://example.org/agent-workflow/poc/v1/workflow-definition";
+    const workflowDefinitionSchemaUri = "https://agent-workflow.dev/schemas/workflow-definition.json";
     const stateSchema = { type: "object", properties: { marker: { type: "string" } } };
 
     /** @type {object} */
     const deepest = {
-      document: { schema: pocSchema, name: "depth-deepest", version: "1.0.0" },
+      document: { schema: workflowDefinitionSchemaUri, name: "depth-deepest", version: "1.0.0" },
       state_schema: stateSchema,
       nodes: [
         { id: "start", type: "start" },
@@ -750,7 +750,7 @@ describe("runGraphWorkflow (host-mediated activities)", () => {
 
     /** @type {object} */
     const inner = {
-      document: { schema: pocSchema, name: "depth-inner", version: "1.0.0" },
+      document: { schema: workflowDefinitionSchemaUri, name: "depth-inner", version: "1.0.0" },
       state_schema: stateSchema,
       nodes: [
         { id: "start", type: "start" },
@@ -773,7 +773,7 @@ describe("runGraphWorkflow (host-mediated activities)", () => {
 
     /** @type {object} */
     const middle = {
-      document: { schema: pocSchema, name: "depth-middle", version: "1.0.0" },
+      document: { schema: workflowDefinitionSchemaUri, name: "depth-middle", version: "1.0.0" },
       state_schema: stateSchema,
       nodes: [
         { id: "start", type: "start" },

--- a/schemas/.schema-breaking-change-ack
+++ b/schemas/.schema-breaking-change-ack
@@ -1,4 +1,4 @@
-BEN-8 (v1 profile): migrated JSON Schema $id from
-https://example.org/agent-workflow/poc/v1/workflow-definition
-to https://agent-workflow.dev/schemas/workflow-definition/v1.json.
-Workflow instances must set document.schema to the new URI per docs/poc-scope.md.
+Canonical naming cleanup: JSON Schema $id and document.schema URI are
+https://agent-workflow.dev/schemas/workflow-definition.json
+(on-disk entry schema: schemas/workflow-definition.json).
+Workflow instances should set document.schema to that URI per docs/engine-profile.md.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,22 +1,22 @@
-# POC JSON Schema bundle
+# JSON Schema bundle
 
-Machine-readable contract for the **POC workflow definition** subset. Human-readable scope and semantics:
+Machine-readable contract for the **reference engine workflow definition** profile. Human-readable scope and semantics:
 
-- [docs/poc-scope.md](../docs/poc-scope.md) — authoritative engine profile (`parallel`, `wait`, `set_state`, `agent_delegate`, `subworkflow`, …)
+- [docs/engine-profile.md](../docs/engine-profile.md) — authoritative engine profile (`parallel`, `wait`, `set_state`, `agent_delegate`, `subworkflow`, …)
 - [docs/RFC/rfc-03-workflow-definition-schema.md](../docs/RFC/rfc-03-workflow-definition-schema.md) — normative protocol text
 
 ## Entry schema
 
 | Artifact | Role |
 |----------|------|
-| [workflow-definition-poc.json](./workflow-definition-poc.json) | **Entry schema** (`$id`: `https://agent-workflow.dev/schemas/workflow-definition/v1.json`). Validates canonical **JSON** documents; internal `$defs` hold node shapes. See [v1 profile model](../docs/releases/v1-profile-model.md). |
+| [workflow-definition.json](./workflow-definition.json) | **Entry schema** (`$id`: `https://agent-workflow.dev/schemas/workflow-definition.json`). Validates canonical **JSON** documents; internal `$defs` hold node shapes. See [v1 profile model](../docs/releases/profile-model.md). |
 
 **JSON Schema dialect:** [Draft 2020-12](https://json-schema.org/draft/2020-12/json-schema-core.html) (`$schema` on the entry file).
 
 **Contract hygiene (architecture):**
 
 - Stable **`$id`** on the entry schema for tooling, documentation links, and future registry publication.
-- **`additionalProperties: false`** on the workflow root rejects top-level fields not in the POC surface (including **`extensions`**, which is out of scope per [docs/poc-scope.md](../docs/poc-scope.md)).
+- **`additionalProperties: false`** on the workflow root rejects top-level fields not in the engine profile surface (including **`extensions`**, which is out of scope per [docs/engine-profile.md](../docs/engine-profile.md)).
 - **`oneOf` node discriminated union** rejects unknown `type` values not defined in the schema bundle (including `agent_delegate` and `subworkflow` when present in the profile).
 
 **Limits:** `state_schema` is validated as a non-empty object only; nested `reducer: custom` is called out in the schema description as needing extra checks if you require it. Unique `nodes[].id` values are not expressible in JSON Schema alone—enforce in the engine or a small custom lint.
@@ -34,14 +34,14 @@ npm ci
 npm run validate-workflows
 ```
 
-This validates every `examples/*.workflow.json`, the minimal instance under `schemas/examples/`, and checks that `examples/fixtures.invalid/extensions.workflow.json` is **rejected** (top-level `extensions` is out of POC scope).
+This validates every `examples/*.workflow.json`, the minimal instance under `schemas/examples/`, and checks that `examples/fixtures.invalid/extensions.workflow.json` is **rejected** (top-level `extensions` is out of engine profile scope).
 
 ### One-off validation with ajv-cli
 
 Using [ajv-cli](https://github.com/ajv-validator/ajv-cli) (no project install required):
 
 ```bash
-npx --yes ajv-cli@5 validate -s schemas/workflow-definition-poc.json -d path/to/workflow.json --spec=draft2020
+npx --yes ajv-cli@5 validate -s schemas/workflow-definition.json -d path/to/workflow.json --spec=draft2020
 ```
 
 On Windows PowerShell, the same command works from the repository root.
@@ -52,4 +52,4 @@ Validated example workflows and RFC-04 trace companions: [examples/README.md](..
 
 ## Versioning
 
-Bump **`document.schema`** in workflow instances and revise this bundle together when the POC contract changes; keep [docs/poc-scope.md](../docs/poc-scope.md) and these files aligned in the same change set where possible.
+Bump **`document.schema`** in workflow instances and revise this bundle together when the engine profile contract changes; keep [docs/engine-profile.md](../docs/engine-profile.md) and these files aligned in the same change set where possible.

--- a/schemas/examples/minimal-valid.workflow.json
+++ b/schemas/examples/minimal-valid.workflow.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "schema": "https://example.org/agent-workflow/v1",
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
     "name": "minimal-poc-smoke",
     "version": "0.0.0"
   },

--- a/schemas/workflow-definition.json
+++ b/schemas/workflow-definition.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://agent-workflow.dev/schemas/workflow-definition/v1.json",
+  "$id": "https://agent-workflow.dev/schemas/workflow-definition.json",
   "title": "Agent Workflow Protocol — reference engine workflow definition",
-  "description": "JSON Schema for the profile defined in docs/poc-scope.md (core orchestration, delegation, and nested subworkflows). Normative semantics: docs/RFC/rfc-03-workflow-definition-schema.md.",
+  "description": "JSON Schema for the profile defined in docs/engine-profile.md (core orchestration, delegation, and nested subworkflows). Normative semantics: docs/RFC/rfc-03-workflow-definition-schema.md.",
   "type": "object",
   "additionalProperties": false,
   "required": ["document", "state_schema", "nodes", "edges"],
@@ -20,7 +20,7 @@
     },
     "checkpointing": {
       "type": "object",
-      "description": "Optional checkpoint policy per RFC-03 §3.9; reference engine honors strategy/n (see docs/poc-scope.md §5).",
+      "description": "Optional checkpoint policy per RFC-03 §3.9; reference engine honors strategy/n (see docs/engine-profile.md §5).",
       "additionalProperties": true,
       "properties": {
         "strategy": {
@@ -62,7 +62,7 @@
     },
     "state_schema_blob": {
       "type": "object",
-      "description": "JSON Schema object describing workflow state. Reducer annotations must be overwrite, append, or merge only (see docs/poc-scope.md); rejecting 'custom' may require additional tooling beyond this schema.",
+      "description": "JSON Schema object describing workflow state. Reducer annotations must be overwrite, append, or merge only (see docs/engine-profile.md); rejecting 'custom' may require additional tooling beyond this schema.",
       "minProperties": 1
     },
     "edge": {
@@ -196,7 +196,7 @@
         "config": {
           "type": "object",
           "additionalProperties": true,
-          "description": "Model, prompts, output_schema, etc. per RFC-03 §3.7; POC allows minimal/stub configs."
+          "description": "Model, prompts, output_schema, etc. per RFC-03 §3.7; profile allows minimal/stub configs."
         },
         "retry": { "$ref": "#/$defs/retry_policy" },
         "timeout": { "$ref": "#/$defs/node_level_timeout" },

--- a/scripts/check-schema-breaking-change.mjs
+++ b/scripts/check-schema-breaking-change.mjs
@@ -1,5 +1,5 @@
 /**
- * Fails when the POC workflow schema changes in ways that break existing documents
+ * Fails when the workflow definition schema changes in ways that break existing documents
  * without an explicit acknowledgment (document.schema / $id bump policy).
  *
  * Usage:
@@ -16,7 +16,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, "..");
-const schemaPath = "schemas/workflow-definition-poc.json";
+const schemaPath = "schemas/workflow-definition.json";
 const ackEnv = process.env.SCHEMA_BREAKING_CHANGE_ACK === "1";
 const ackFile = join(repoRoot, "schemas", ".schema-breaking-change-ack");
 
@@ -130,19 +130,19 @@ for (const path of headRequired) {
 }
 
 if (violations.length === 0) {
-  console.log("POC schema breaking-change check: no breaking deltas detected.");
+  console.log("workflow schema breaking-change check: no breaking deltas detected.");
   process.exit(0);
 }
 
 if (hasAcknowledgment()) {
-  console.warn("POC schema breaking-change acknowledged; violations:");
+  console.warn("workflow schema breaking-change acknowledged; violations:");
   for (const v of violations) {
     console.warn(`  - ${v}`);
   }
   process.exit(0);
 }
 
-console.error("POC schema breaking-change gate failed:");
+console.error("workflow schema breaking-change gate failed:");
 for (const v of violations) {
   console.error(`  - ${v}`);
 }
@@ -150,5 +150,5 @@ console.error("");
 console.error("Breaking changes require an explicit bump policy:");
 console.error("  - Set document.schema / profile version in workflow instances, and");
 console.error("  - Acknowledge with SCHEMA_BREAKING_CHANGE_ACK=1 in CI, or");
-console.error(`  - Add ${schemaPath.replace("workflow-definition-poc.json", ".schema-breaking-change-ack")} with rationale.`);
+console.error(`  - Add ${schemaPath.replace("workflow-definition.json", ".schema-breaking-change-ack")} with rationale.`);
 process.exit(1);

--- a/scripts/sync-engine-schema.mjs
+++ b/scripts/sync-engine-schema.mjs
@@ -1,10 +1,10 @@
 /**
- * Keeps `packages/engine/schemas/workflow-definition-poc.json` identical to the
+ * Keeps `packages/engine/schemas/workflow-definition.json` identical to the
  * repository canonical schema (for npm tarball / no-install MCP).
  *
  * Usage:
- *   node scripts/sync-engine-poc-schema.mjs           — copy root schema into engine package
- *   node scripts/sync-engine-poc-schema.mjs --check — exit 1 if copy is missing or stale
+ *   node scripts/sync-engine-schema.mjs           — copy root schema into engine package
+ *   node scripts/sync-engine-schema.mjs --check — exit 1 if copy is missing or stale
  */
 import { copyFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -12,9 +12,9 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, "..");
-const src = join(root, "schemas", "workflow-definition-poc.json");
+const src = join(root, "schemas", "workflow-definition.json");
 const destDir = join(root, "packages", "engine", "schemas");
-const dest = join(destDir, "workflow-definition-poc.json");
+const dest = join(destDir, "workflow-definition.json");
 
 const check = process.argv.includes("--check");
 
@@ -25,21 +25,21 @@ if (!existsSync(src)) {
 
 if (check) {
   if (!existsSync(dest)) {
-    console.error("Engine bundled schema missing; run: node scripts/sync-engine-poc-schema.mjs");
+    console.error("Engine bundled schema missing; run: node scripts/sync-engine-schema.mjs");
     process.exit(1);
   }
   const canonical = readFileSync(src, "utf8");
   const bundled = readFileSync(dest, "utf8");
   if (canonical !== bundled) {
     console.error(
-      "packages/engine/schemas/workflow-definition-poc.json is out of date; run: node scripts/sync-engine-poc-schema.mjs"
+      "packages/engine/schemas/workflow-definition.json is out of date; run: node scripts/sync-engine-schema.mjs"
     );
     process.exit(1);
   }
-  console.log("POC schema copy is in sync.");
+  console.log("Engine schema bundle is in sync.");
   process.exit(0);
 }
 
 mkdirSync(destDir, { recursive: true });
 copyFileSync(src, dest);
-console.log(`Synced POC schema to ${dest}`);
+console.log(`Synced schema to ${dest}`);

--- a/scripts/validate-workflows.mjs
+++ b/scripts/validate-workflows.mjs
@@ -1,5 +1,5 @@
 /**
- * Validates golden workflow JSON instances against schemas/workflow-definition-poc.json (JSON Schema Draft 2020-12).
+ * Validates golden workflow JSON instances against schemas/workflow-definition.json (JSON Schema Draft 2020-12).
  * Run: npm run validate-workflows
  */
 import Ajv2020 from "ajv/dist/2020.js";
@@ -10,7 +10,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, "..");
 
-const schemaPath = path.join(root, "schemas", "workflow-definition-poc.json");
+const schemaPath = path.join(root, "schemas", "workflow-definition.json");
 const schema = JSON.parse(readFileSync(schemaPath, "utf8"));
 
 const ajv = new Ajv2020({ allErrors: true, strict: false });


### PR DESCRIPTION
## Summary

- Rename `docs/poc-scope.md` → `docs/engine-profile.md`, `workflow-definition-poc.json` → `workflow-definition.json`, and `sync-engine-poc-schema.mjs` → `sync-engine-schema.mjs`
- Update schema `$id` URIs, npm scripts (`check-engine-schema-sync`, `sync-engine-schema`), and doc/fixture references across the repo for consistent engine-profile terminology
- Rebased on current `master` (includes dependabot bumps from #81–#88); supersedes the two follow-up commits that were on merged `feat/BEN-11-ci-gates`

## Test plan

- [x] `npm run check-engine-schema-sync`
- [x] `npm run validate-workflows`
- [x] `npm test` (113 tests pass)