### PR TITLE
feat(engine): BEN-82 activity execution — replace StubActivityExecutor defaults

### DIFF
--- a/conformance/runner.mjs
+++ b/conformance/runner.mjs
@@ -7,6 +7,8 @@ import {
   RejectingDelegateExecutor,
   resumeGraphWorkflow,
   runGraphWorkflow,
+  StepActivityExecutor,
+  StepHandlerRegistry,
   submitActivityOutcome,
   validateWorkflowDefinition,
 } from "../packages/engine/src/index.mjs";
@@ -30,6 +32,7 @@ const vectorsRoot = path.join(__dirname, "vectors");
  *   }>;
  *   activityExecutionMode?: "in_process" | "host_mediated";
  *   assertNoActivityExecutorInvocation?: boolean;
+ *   stepHandlers?: Record<string, Record<string, unknown>>;
  *   assertNoSubworkflowInvocation?: boolean;
  *   assertNoDelegateExecutorInvocation?: boolean;
  *   resumePayload?: Record<string, unknown>;
@@ -106,8 +109,17 @@ export function discoverVectors() {
 }
 
 /**
- * @param {ConformanceVector} vector
+ * @param {Record<string, Record<string, unknown>>} stepHandlers
+ * @returns {import("../packages/engine/src/orchestrator/step-activity-executor.mjs").StepActivityExecutor}
  */
+function buildConformanceStepActivityExecutor(stepHandlers) {
+  const registry = new StepHandlerRegistry();
+  for (const [urn, output] of Object.entries(stepHandlers)) {
+    registry.register(urn, async () => output);
+  }
+  return new StepActivityExecutor({ registry: registry.createFrozenCopy() });
+}
+
 /**
  * @param {object} definition
  * @param {Record<string, unknown> | undefined} tamper
@@ -194,7 +206,15 @@ async function runReplayVector(vector) {
   const assertNoActivityExecutorInvocation = vector.assertNoActivityExecutorInvocation === true;
   const assertNoSubworkflowInvocation = vector.assertNoSubworkflowInvocation === true;
   const assertNoDelegateExecutorInvocation = vector.assertNoDelegateExecutorInvocation === true;
-  const activityExecutor = assertNoActivityExecutorInvocation ? new RejectingActivityExecutor() : undefined;
+  let activityExecutor = assertNoActivityExecutorInvocation ? new RejectingActivityExecutor() : undefined;
+  if (
+    !activityExecutor &&
+    vector.stepHandlers &&
+    typeof vector.stepHandlers === "object" &&
+    !Array.isArray(vector.stepHandlers)
+  ) {
+    activityExecutor = buildConformanceStepActivityExecutor(vector.stepHandlers);
+  }
   const delegateExecutor = assertNoDelegateExecutorInvocation ? new RejectingDelegateExecutor() : undefined;
 
   let run = await runGraphWorkflow({

--- a/conformance/vectors/parity/host-mediated-lighthouse-classify.vector.json
+++ b/conformance/vectors/parity/host-mediated-lighthouse-classify.vector.json
@@ -1,0 +1,32 @@
+{
+  "id": "parity.r2.host_mediated_lighthouse_classify",
+  "description": "Lighthouse billing path: host_mediated llm_call (classify) then tool_call (open_ticket); port and MCP snapshots match.",
+  "kind": "parity",
+  "definition": "examples/lighthouse-customer-routing.workflow.json",
+  "executionId": "parity-host-lighthouse-billing-1",
+  "steps": [
+    {
+      "op": "start",
+      "input": { "ticket_text": "double charge on invoice" },
+      "activityExecutionMode": "host_mediated",
+      "expect": { "status": "awaiting_activity", "node_id": "classify" }
+    },
+    {
+      "op": "submit_activity",
+      "nodeId": "classify",
+      "outcome": { "ok": true, "result": { "intent": "billing", "confidence": 0.92 } },
+      "activityExecutionMode": "host_mediated",
+      "expect": { "status": "awaiting_activity", "node_id": "open_ticket" }
+    },
+    {
+      "op": "submit_activity",
+      "nodeId": "open_ticket",
+      "outcome": { "ok": true, "result": { "ticket_id": "T-1001" } },
+      "activityExecutionMode": "host_mediated",
+      "expect": {
+        "status": "completed",
+        "result": { "intent": "billing", "confidence": 0.92 }
+      }
+    }
+  ]
+}

--- a/conformance/vectors/replay/step-activity/step-handler-dispatch.vector.json
+++ b/conformance/vectors/replay/step-activity/step-handler-dispatch.vector.json
@@ -1,0 +1,21 @@
+{
+  "id": "replay.step_activity.step_handler_dispatch",
+  "description": "In-process StepActivityExecutor dispatches a registered handler URN and completes a minimal start → step → end workflow.",
+  "kind": "replay",
+  "definition": "examples/conformance-step-handler.workflow.json",
+  "input": {},
+  "stepHandlers": {
+    "urn:conformance:step:test-handler": { "value": "dispatched" }
+  },
+  "expect": {
+    "status": "completed",
+    "tailCommands": [
+      { "name": "ScheduleNode", "nodeId": "begin" },
+      { "name": "CompleteNode", "nodeId": "begin" },
+      { "name": "ScheduleNode", "nodeId": "dispatch" },
+      { "name": "CompleteNode", "nodeId": "dispatch" },
+      { "name": "ScheduleNode", "nodeId": "finish" },
+      { "name": "CompleteNode", "nodeId": "finish" }
+    ]
+  }
+}

--- a/docs/architecture/arc42-assets/contracts/integration-parity-matrix.md
+++ b/docs/architecture/arc42-assets/contracts/integration-parity-matrix.md
@@ -9,7 +9,7 @@ Normative orchestration behavior lives in `createWorkflowApplicationPort` ([RFC-
 | Start execution | `workflow_start` | `startWorkflow` | `POST /v1/workflows/{wf_id}/executions` | `parity.*` start steps |
 | Observe phase | `workflow_status` | `getWorkflowStatus` | `GET /v1/executions/{exec_id}` | all parity vectors with `status` steps |
 | Continue interrupt | `workflow_resume` | `resumeWorkflow` | `POST /v1/executions/{exec_id}:resume` | `parity.r2.interrupt_resume` |
-| Complete host activity | `workflow_submit_activity` | `submitWorkflowActivity` | (host-mediated; REST TBD) | `parity.r2.host_mediated_submit`, `parity.r2.parallel_join` |
+| Complete host activity | `workflow_submit_activity` | `submitWorkflowActivity` | (host-mediated; REST TBD) | `parity.r2.host_mediated_submit`, `parity.r2.host_mediated_lighthouse_classify`, `parity.r2.parallel_join` |
 
 ### Core orchestration parity (implemented)
 
@@ -18,6 +18,7 @@ Normative orchestration behavior lives in `createWorkflowApplicationPort` ([RFC-
 | `parity.r2.linear_complete` | `examples/lighthouse-customer-routing.workflow.json` | start → completed; status → completed |
 | `parity.r2.interrupt_resume` | lighthouse | start → interrupted; status; resume → completed |
 | `parity.r2.host_mediated_submit` | `examples/conformance-host-activity-linear.workflow.json` | start → awaiting_activity; submit → completed |
+| `parity.r2.host_mediated_lighthouse_classify` | `examples/lighthouse-customer-routing.workflow.json` | host_mediated start → classify submit → open_ticket submit → completed |
 | `parity.r2.parallel_join` | `examples/conformance-host-activity-parallel.workflow.json` | start with `parallel_span`; submit with span correlation → completed |
 
 ### Composition parity (implemented)

--- a/docs/architecture/arc42/06-runtime-view.md
+++ b/docs/architecture/arc42/06-runtime-view.md
@@ -38,7 +38,7 @@ Exported orchestrators used by `createWorkflowApplicationPort` (**`workflow-grap
 3. Host observes progress via **`workflow_status`** (**`phase`** values: **`running`**, **`completed`**, **`failed`**, **`interrupted`**, **`awaiting_activity`**). When history includes composition milestones, the same response may include optional correlation fields (snake_case on MCP; camelCase on the application port):
    - **`delegate_correlation_id`** — latest `agent_delegate` correlation id from history.
    - **`child_execution_id`** / **`parent_execution_id`** — nested **`subworkflow`** child run id and parent execution id (derived from `SubworkflowStarted` / child execution id suffix rules).
-4. Host calls **`workflow_resume`** with **`resumePayload`** after **`interrupt`** milestones, and **`workflow_submit_activity`** when **`phase`** is **`awaiting_activity`** on a **`host_mediated`** boundary (operator walkthrough [`../arc42-assets/runbooks/mcp-stdio-host-smoke.md`](../arc42-assets/runbooks/mcp-stdio-host-smoke.md)). Assistant-class hosts pass **`activity_execution_mode: "host_mediated"`** on start/resume/submit (runtime default remains **`in_process`** for backward-compatible demos — see **ADR-0002**).
+4. Host calls **`workflow_resume`** with **`resumePayload`** after **`interrupt`** milestones, and **`workflow_submit_activity`** when **`phase`** is **`awaiting_activity`** on a **`host_mediated`** boundary (operator walkthrough [`../arc42-assets/runbooks/mcp-stdio-host-smoke.md`](../arc42-assets/runbooks/mcp-stdio-host-smoke.md), end-user guide [`../../user/host-mediated-activities.md`](../../user/host-mediated-activities.md)). Assistant-class hosts pass **`activity_execution_mode: "host_mediated"`** on start/resume/submit (runtime default remains **`in_process`** for backward-compatible demos — see **ADR-0002**).
 
 **Integration parity harness:** `conformance/vectors/parity/` runs table-driven scenarios against the application port and MCP handlers in-process ([`../arc42-assets/contracts/integration-parity-matrix.md`](../arc42-assets/contracts/integration-parity-matrix.md)). Status correlation is asserted by **`parity.r3.delegate_status_correlation`** and **`parity.r3.subworkflow_status_correlation`** (`conformance/vectors/parity/r3-*-status-correlation.vector.json`).
 
@@ -83,7 +83,7 @@ Detailed stepping (replay spine):
 
 **Checkpointing:** Checkpoint events emit at deterministic graph-walker boundaries; parallel-branch checkpoints can carry **`parallelSpan`** snapshots (parallel node id, join target, branch label, branch entry) alongside inlined state excerpts for correlated recovery submits.
 
-Further operator procedure: [`../arc42-assets/runbooks/mcp-stdio-host-smoke.md`](../arc42-assets/runbooks/mcp-stdio-host-smoke.md).
+Further operator procedure: [`../arc42-assets/runbooks/mcp-stdio-host-smoke.md`](../arc42-assets/runbooks/mcp-stdio-host-smoke.md). End-user integration guide: [`../../user/host-mediated-activities.md`](../../user/host-mediated-activities.md). Lighthouse **`classify`** + **`open_ticket`** host-mediated parity: conformance vector **`parity.r2.host_mediated_lighthouse_classify`** (`conformance/vectors/parity/host-mediated-lighthouse-classify.vector.json`).
 
 ## 6.5 Scenario: Conformance replay vector (`kind: "replay"`)
 

--- a/docs/engine-profile.md
+++ b/docs/engine-profile.md
@@ -38,7 +38,7 @@ These discriminators **MUST** be supported by the workflow schema bundle and hon
 |--------|-----------|
 | `start` | At most one per document; entry binding per RFC. |
 | `end` | Terminal; `output_schema` / `output_mapping` **MAY** be used if present. |
-| `step` | Deterministic activity boundary; `config` **MUST** include an implementation reference (e.g. `handler` / `code_ref`) per RFC; exact registry is profile-specific. |
+| `step` | Deterministic activity boundary; `config` **MUST** include an implementation reference (e.g. `handler` / `code_ref`) per RFC. The reference engine provides **`StepHandlerRegistry`** and **`StepActivityExecutor`**: operators register handler URNs → async `(ctx) => output` functions at bootstrap; `StepActivityExecutor` dispatches `config.handler` in-process (v1 — same Node.js process; isolated workers deferred). Unknown URNs fail with `HANDLER_NOT_FOUND`; missing `handler` fails with `STEP_CONFIG_INVALID`. |
 | `llm_call` | Non-deterministic model invocation; **MAY** be stubbed with a fixed transcript in early demos without changing document shape. |
 | `tool_call` | External tool; **SHOULD** be MCP-shaped (`server`, `tool`, `arguments`) for portable fixtures. |
 | `switch` | Conditional routing via `config.cases` (`when` jq expression, `target` node id) and optional `config.default`. |

--- a/docs/user/host-mediated-activities.md
+++ b/docs/user/host-mediated-activities.md
@@ -1,0 +1,133 @@
+# Host-mediated activities
+
+Assistant-class MCP hosts (Cursor, Claude Desktop, Codex-style clients) already own tool servers, LLM credentials, and policy. **Host-mediated** activity execution keeps orchestration and history in `@agent-workflow/engine` while the **host performs** each `step`, `llm_call`, or `tool_call` and reports the outcome back.
+
+> **Read order:** [Run with MCP](mcp-operator-guide.md) (wiring and tools) → this guide (activity loop) → [ADR-0002: Host-mediated activity execution](../architecture/adr/ADR-0002-host-mediated-activity-execution.md) (architecture decision) → [MCP stdio host smoke runbook](../architecture/arc42-assets/runbooks/mcp-stdio-host-smoke.md) (QA acceptance).
+
+## When to use `host_mediated`
+
+| Mode | Who runs activities | Typical use |
+|------|---------------------|-------------|
+| `in_process` (default) | Engine activity port (stub, engine-direct MCP, or injected executor) | Demos, CI, automation workers |
+| `host_mediated` | MCP host out of band, then `workflow_submit_activity` | Assistant hosts that already aggregate MCP tools and API keys |
+
+The runtime default is **`in_process`** for backward-compatible smoke tests. Assistant hosts **must opt in** to `host_mediated` on every control-plane call that can continue execution (see [ADR-0002](../architecture/adr/ADR-0002-host-mediated-activity-execution.md)).
+
+## Opt-in: `activity_execution_mode`
+
+Pass **`activity_execution_mode: "host_mediated"`** on:
+
+| MCP tool | Parameter |
+|----------|-----------|
+| `workflow_start` | `activity_execution_mode` |
+| `workflow_resume` | `activity_execution_mode` |
+| `workflow_submit_activity` | `activity_execution_mode` |
+
+Omit the field (or pass `"in_process"`) to keep the in-process stub or engine-direct profile.
+
+Example start (lighthouse fixture):
+
+```json
+{
+  "execution_id": "lighthouse-host-1",
+  "definition": { "...": "examples/lighthouse-customer-routing.workflow.json" },
+  "input": { "ticket_text": "I was charged twice on my last invoice" },
+  "activity_execution_mode": "host_mediated"
+}
+```
+
+Expected response: `status: "awaiting_activity"` with `node_id: "classify"` (first activity boundary).
+
+## Host responsibilities
+
+For each activity boundary the engine yields **`awaiting_activity`**. The host loop is:
+
+1. **Read pending context** — from the tool result or `workflow_status`: `execution_id`, `node_id`, optional `parallel_span`, and workflow `state`.
+2. **Resolve the node** — look up `node_id` in the same `definition` object passed to `workflow_start` (type: `step`, `llm_call`, or `tool_call`; `config` holds model, tool, handler URN, etc.).
+3. **Perform work out of band** — invoke the host's LLM API, MCP `tools/call`, or registered step handler. Credentials and side effects stay on the host; the engine does not call your tools in this mode.
+4. **Submit the outcome** — call `workflow_submit_activity` with the **same** `definition` and `input` as the original start, matching `node_id`, and a typed `outcome`.
+5. **Repeat** — until status is `completed`, `failed`, or `interrupted` (then use `workflow_resume` for interrupt nodes).
+
+### Submit shape
+
+```json
+{
+  "execution_id": "lighthouse-host-1",
+  "definition": "<same object as workflow_start>",
+  "input": { "ticket_text": "I was charged twice on my last invoice" },
+  "node_id": "classify",
+  "activity_execution_mode": "host_mediated",
+  "outcome": {
+    "ok": true,
+    "result": { "intent": "billing", "confidence": 0.92 }
+  }
+}
+```
+
+Success outcomes use `{ "ok": true, "result": { ... } }` (merged into workflow state per node completion). Failures use `{ "ok": false, "error": "...", "code": "..." }`.
+
+Under **`parallel`**, include the same **`parallel_span`** the engine returned when submitting for a branch activity (see [MCP stdio host smoke runbook](../architecture/arc42-assets/runbooks/mcp-stdio-host-smoke.md)).
+
+### Stable submit error codes
+
+| Code | Meaning |
+|------|---------|
+| `ACTIVITY_SUBMIT_NOT_AWAITING` | No pending `ActivityRequested` |
+| `ACTIVITY_SUBMIT_NODE_MISMATCH` | `node_id` does not match the pending request |
+| `ACTIVITY_SUBMIT_PARALLEL_MISMATCH` | Branch correlation does not match |
+
+Full MCP error table: [Run with MCP](mcp-operator-guide.md#stable-error-codes).
+
+## Cursor MCP configuration (credential ownership)
+
+Register the workflow engine as one MCP server. Register **tool and LLM servers separately** on the host — the engine orchestrates; the host executes.
+
+```json
+{
+  "mcpServers": {
+    "workflow-engine": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "-p",
+        "@agent-workflow/engine@alpha",
+        "workflows-engine-mcp"
+      ]
+    },
+    "support-mcp": {
+      "command": "npx",
+      "args": ["-y", "@your-org/support-mcp-server"],
+      "env": {
+        "SUPPORT_API_KEY": "${env:SUPPORT_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+**Trust boundary:**
+
+- **`workflow-engine`** — validation, graph walking, history; no host LLM or business-tool credentials required for `host_mediated`.
+- **`support-mcp`** (and similar) — owned by the host; invoked only when the assistant handles an `awaiting_activity` for a `tool_call` node (for example lighthouse `open_ticket` / `search_kb`).
+- **LLM provider keys** — stay in the host environment; used when completing `llm_call` nodes (for example lighthouse `classify`).
+
+Do **not** point `WORKFLOW_ENGINE_MCP_CONFIG` at host tool servers unless you intentionally run **engine-direct** `tool_call` (see [ADR-0003](../architecture/adr/ADR-0003-engine-direct-mcp-activity-execution.md)). Host-mediated and engine-direct are complementary profiles.
+
+## Lighthouse walkthrough (`classify` → `tool_call`)
+
+Fixture: `examples/lighthouse-customer-routing.workflow.json`.
+
+| Step | Host action | Expected engine status |
+|------|-------------|------------------------|
+| 1. `workflow_start` with `host_mediated` | Pass ticket text | `awaiting_activity`, `node_id: "classify"` |
+| 2. Complete `classify` (`llm_call`) | Host LLM returns `{ intent, confidence }`; `workflow_submit_activity` | `awaiting_activity`, `node_id: "open_ticket"` or `"search_kb"` (via `switch`), or `interrupted` at `human_review` when confidence is low |
+| 3. Complete `open_ticket` (`tool_call`) | Host calls `support-mcp` / `create_ticket`; submit tool result | `completed` with mapped intent/confidence |
+
+Conformance parity vector `parity.r2.host_mediated_lighthouse_classify` exercises the billing path (`classify` → `open_ticket` → `finish`) with simulated host submits.
+
+## Related documentation
+
+- [Run with MCP](mcp-operator-guide.md) — package install, tool reference, development setup
+- [ADR-0002: Host-mediated activity execution](../architecture/adr/ADR-0002-host-mediated-activity-execution.md)
+- [Engine package README](https://github.com/benvdbergh/workflows/blob/main/packages/engine/README.md) — library API and MCP tool schemas
+- [Integration parity matrix](../architecture/arc42-assets/contracts/integration-parity-matrix.md) — port ↔ MCP conformance vectors

--- a/docs/user/mcp-operator-guide.md
+++ b/docs/user/mcp-operator-guide.md
@@ -2,7 +2,7 @@
 
 This is the **canonical operator guide** for running `@agent-workflow/engine` through MCP stdio. Use a **development setup** (local `mcp-stdio-server.mjs` from a clone) only when modifying the engine or adapter.
 
-> **Read order:** start here for wiring and tools → [MCP stdio host smoke runbook](../architecture/arc42-assets/runbooks/mcp-stdio-host-smoke.md) (QA acceptance) → [Lighthouse MCP walkthrough](../architecture/arc42-assets/demos/lighthouse-mcp-host-guided-demo-walkthrough.md) (guided demo) → [operator manifest contract](../architecture/arc42-assets/contracts/mcp-operator-manifest.md) (JSON schema).
+> **Read order:** start here for wiring and tools → [Host-mediated activities](host-mediated-activities.md) (assistant hosts) → [MCP stdio host smoke runbook](../architecture/arc42-assets/runbooks/mcp-stdio-host-smoke.md) (QA acceptance) → [Lighthouse MCP walkthrough](../architecture/arc42-assets/demos/lighthouse-mcp-host-guided-demo-walkthrough.md) (guided demo) → [operator manifest contract](../architecture/arc42-assets/contracts/mcp-operator-manifest.md) (JSON schema).
 
 ## Package and bins
 
@@ -79,7 +79,7 @@ See the [engine package README](https://github.com/benvdbergh/workflows/blob/mai
 1. **`workflow_start`** — pass `definition` (workflow JSON object) and `input` (initial state seed).
 2. **`workflow_status`** — repeat until `completed`, `failed`, or `awaiting_resume`.
 3. **`workflow_resume`** — when status shows an interrupt; pass `resume_payload` matching the node's `resume_schema`.
-4. **`workflow_submit_activity`** — when the engine requests a host-mediated `tool_call` or parallel activity.
+4. **`workflow_submit_activity`** — when the engine requests a host-mediated `llm_call`, `tool_call`, or `step`. Pass **`activity_execution_mode: "host_mediated"`** on start/resume/submit when the host owns credentials. See [Host-mediated activities](host-mediated-activities.md).
 
 ### Stable error codes
 
@@ -133,5 +133,6 @@ Operator checklist: [Security (operators)](security-operators.md).
 
 ## Further reading (repository)
 
+- [Host-mediated activities](host-mediated-activities.md)
 - [Lighthouse MCP walkthrough](https://github.com/benvdbergh/workflows/blob/main/docs/architecture/arc42-assets/demos/lighthouse-mcp-host-guided-demo-walkthrough.md)
 - [MCP stdio host smoke runbook](https://github.com/benvdbergh/workflows/blob/main/docs/architecture/arc42-assets/runbooks/mcp-stdio-host-smoke.md)

--- a/examples/conformance-step-handler.workflow.json
+++ b/examples/conformance-step-handler.workflow.json
@@ -1,0 +1,33 @@
+{
+  "document": {
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
+    "name": "conformance-step-handler",
+    "version": "1.0.0"
+  },
+  "state_schema": {
+    "type": "object",
+    "properties": {
+      "value": { "type": "string" }
+    }
+  },
+  "nodes": [
+    { "id": "begin", "type": "start" },
+    {
+      "id": "dispatch",
+      "type": "step",
+      "config": {
+        "handler": "urn:conformance:step:test-handler"
+      }
+    },
+    {
+      "id": "finish",
+      "type": "end",
+      "config": { "output_mapping": ".value" }
+    }
+  ],
+  "edges": [
+    { "source": "__start__", "target": "begin" },
+    { "source": "begin", "target": "dispatch" },
+    { "source": "dispatch", "target": "finish" }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1167,7 +1167,7 @@
     },
     "packages/engine": {
       "name": "@agent-workflow/engine",
-      "version": "0.1.2",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -86,6 +86,23 @@ The manifest matches the schema validated by `workflows-engine mcp-manifest vali
 
 Security, credentials, and trust boundaries for this profile are documented in [ADR-0003: Engine-direct MCP activity execution](../../docs/architecture/adr/ADR-0003-engine-direct-mcp-activity-execution.md). Host-mediated completion via `workflow_submit_activity` is unchanged when you use `activity_execution_mode: host_mediated`; after a submit, continuations still use the same port-level executor when engine-direct is enabled.
 
+### Engine-direct `llm_call` execution (`LlmActivityExecutor`)
+
+`LlmActivityExecutor` implements the **`ActivityExecutor`** port for **`llm_call`** nodes. It reads `node.config` (`model`, `system_prompt`, `user_prompt` / `prompt`, optional `output_schema`) and resolves provider credentials from **operator config** — not workflow JSON ([RFC-07 §7.3](../../docs/RFC/rfc-07-security-model.md)).
+
+```js
+import { LlmActivityExecutor, runGraphWorkflow } from "@agent-workflow/engine";
+
+const activityExecutor = new LlmActivityExecutor({
+  operatorConfig: {
+    apiKeyEnv: "OPENAI_API_KEY", // apiKeySecretRef accepted; vault resolver deferred to BEN-103
+    baseUrl: "https://api.openai.com/v1", // optional OpenAI-compatible base
+  },
+});
+```
+
+Inject a custom **`LlmProvider`** for tests or non-OpenAI backends; the default uses fetch against `/chat/completions` with no extra SDK. Structured outputs are validated with AJV when `output_schema` is set. Failures return stable codes: `LLM_CONFIG_INVALID`, `LLM_CREDENTIALS_MISSING`, `LLM_PROVIDER_ERROR`, `LLM_OUTPUT_VALIDATION_FAILED` (surfaced as `ActivityFailed` in execution history).
+
 ### Host compatibility constraints for no-install use
 
 - **Node runtime:** Node.js `>=22.5.0` is required (uses `node:sqlite`).

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -75,7 +75,7 @@ Operator smoke runbook: `docs/architecture/arc42-assets/runbooks/mcp-stdio-host-
 
 ### Engine-direct `tool_call` execution (optional)
 
-By default, `workflows-engine-mcp` uses the **in-process stub** executor for activity placeholders (same backward-compatible demo behavior as before).
+By default, `workflows-engine-mcp` uses the **in-process stub** executor for activity placeholders when **no operator activity config** is set. That default is intended for **local demo and smoke tests only** — not a silent production fallback. For production, configure at least one real sub-executor (see **Composite activity routing** below).
 
 To run **`tool_call` nodes against real MCP stdio servers**, enable engine-direct configuration:
 
@@ -120,6 +120,37 @@ const activityExecutor = new StepActivityExecutor({ registry: registry.createFro
 **v1 sandboxing:** handlers run in the **same Node.js process** as the engine (in-process dispatch). There is no worker isolation, VM sandbox, or resource cap in this profile milestone — treat registered handlers as trusted operator code. Isolated worker processes are deferred to a later release.
 
 Stable failure codes: `STEP_CONFIG_INVALID` (missing/invalid `handler`), `HANDLER_NOT_FOUND` (URN not registered), `HANDLER_ERROR` (handler threw). Success merges handler output into workflow state per `state_schema` reducers.
+
+### Composite activity routing (`CompositeActivityExecutor`)
+
+`CompositeActivityExecutor` is the production router for **`step`**, **`llm_call`**, and **`tool_call`** nodes. It dispatches by `ctx.node.type` to optional sub-executors (`StepActivityExecutor`, `LlmActivityExecutor`, `McpManifestActivityExecutor`). When a routed node type has no configured sub-executor, execution fails with stable code **`COMPOSITE_EXECUTOR_NOT_CONFIGURED`** (unless an explicit **`fallback`** is injected — see demo profile below).
+
+```js
+import {
+  buildCompositeActivityExecutor,
+  LlmActivityExecutor,
+  McpManifestActivityExecutor,
+  StepActivityExecutor,
+} from "@agent-workflow/engine";
+
+const activityExecutor = buildCompositeActivityExecutor({
+  step: new StepActivityExecutor({ registry }),
+  llm_call: new LlmActivityExecutor({ operatorConfig: { apiKeyEnv: "OPENAI_API_KEY" } }),
+  tool_call: new McpManifestActivityExecutor({ manifest }),
+});
+```
+
+Pass the composite (or any custom `ActivityExecutor`) to `createWorkflowApplicationPort({ activityExecutor })` or `runGraphWorkflow({ activityExecutor })`.
+
+**`workflows-engine-mcp` wiring:** when any operator config is present, the stdio bin loads a composite via `loadProductionActivityExecutor`:
+
+| Env var | Sub-executor |
+|---------|----------------|
+| `WORKFLOW_ENGINE_MCP_CONFIG` / `--mcp-config` | `tool_call` → `McpManifestActivityExecutor` |
+| `WORKFLOW_ENGINE_LLM_CONFIG` (inline JSON or file path) | `llm_call` → `LlmActivityExecutor` |
+| `WORKFLOW_ENGINE_STEP_HANDLERS` (inline JSON or file path; URN → static output map) | `step` → `StepActivityExecutor` |
+
+When **none** of these are set, the MCP adapter omits `activityExecutor` and the walker uses **`StubActivityExecutor`** (demo/local only). Set **`WORKFLOW_ENGINE_PROFILE=demo`** to add stub **fallback** inside a partial composite (unconfigured node types return `{}` instead of `COMPOSITE_EXECUTOR_NOT_CONFIGURED`). Do **not** rely on stub fallback in production deployments.
 
 ### Host compatibility constraints for no-install use
 
@@ -190,7 +221,7 @@ Phases: **validate** (bundled workflow schema + reject `state_schema.properties.
 
 **Graph rules:** Edges must form a **single linear path** covering every node: exactly one edge from `__start__`, at most one outgoing edge per node, no cycles, exactly one `start` and one `end`. `switch` and `interrupt` nodes are rejected by this runner (use the general graph walker). Unknown topology errors throw from `computeLinearNodePath` or return `{ status: 'failed', error }` from `runLinearWorkflow`.
 
-**Activity boundary:** `step`, `llm_call`, and `tool_call` are executed through an **`ActivityExecutor`** port (`executeActivity(ctx)` → success with `output` or failure with `error` / optional `code`). The walker only calls this port (no MCP, HTTP, or provider SDKs inside the runner). **`StubActivityExecutor`** is the default: deterministic, returns `{}` or per-node outputs from an `outputsByNodeId` map. Pass `activityExecutor` to inject real adapters; pass `stubActivityOutputs` only affects the default stub when `activityExecutor` is omitted.
+**Activity boundary:** `step`, `llm_call`, and `tool_call` are executed through an **`ActivityExecutor`** port (`executeActivity(ctx)` → success with `output` or failure with `error` / optional `code`). The walker only calls this port (no MCP, HTTP, or provider SDKs inside the runner). **`StubActivityExecutor`** is the default when `activityExecutor` is omitted: deterministic, returns `{}` or per-node outputs from an `outputsByNodeId` map (library demos and tests). **`CompositeActivityExecutor`** routes production workloads to configured sub-executors; pass `activityExecutor` to inject real adapters; pass `stubActivityOutputs` only affects the default stub when `activityExecutor` is omitted.
 
 **Limitation:** Per-node **`retry`** and **`timeout`** settings from the workflow definition are **not** applied by this runner yet; failures return immediately after a single `executeActivity` call.
 

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -103,6 +103,24 @@ const activityExecutor = new LlmActivityExecutor({
 
 Inject a custom **`LlmProvider`** for tests or non-OpenAI backends; the default uses fetch against `/chat/completions` with no extra SDK. Structured outputs are validated with AJV when `output_schema` is set. Failures return stable codes: `LLM_CONFIG_INVALID`, `LLM_CREDENTIALS_MISSING`, `LLM_PROVIDER_ERROR`, `LLM_OUTPUT_VALIDATION_FAILED` (surfaced as `ActivityFailed` in execution history).
 
+### Engine-direct `step` execution (`StepActivityExecutor`)
+
+`StepActivityExecutor` implements the **`ActivityExecutor`** port for **`step`** nodes. It reads `node.config.handler` (a string URN) and looks up the implementation in an operator-provided **`StepHandlerRegistry`** registered at bootstrap — not in workflow JSON.
+
+```js
+import { StepActivityExecutor, StepHandlerRegistry, runGraphWorkflow } from "@agent-workflow/engine";
+
+const registry = new StepHandlerRegistry();
+registry.register("urn:my-app:handlers:lookup-customer", async (ctx) => {
+  return { customerId: "c-1", name: "Ada" };
+});
+const activityExecutor = new StepActivityExecutor({ registry: registry.createFrozenCopy() });
+```
+
+**v1 sandboxing:** handlers run in the **same Node.js process** as the engine (in-process dispatch). There is no worker isolation, VM sandbox, or resource cap in this profile milestone — treat registered handlers as trusted operator code. Isolated worker processes are deferred to a later release.
+
+Stable failure codes: `STEP_CONFIG_INVALID` (missing/invalid `handler`), `HANDLER_NOT_FOUND` (URN not registered), `HANDLER_ERROR` (handler threw). Success merges handler output into workflow state per `state_schema` reducers.
+
 ### Host compatibility constraints for no-install use
 
 - **Node runtime:** Node.js `>=22.5.0` is required (uses `node:sqlite`).

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -73,6 +73,8 @@ This starts a dedicated MCP stdio adapter layer with tools `workflow_start`, `wo
 
 Operator smoke runbook: `docs/architecture/arc42-assets/runbooks/mcp-stdio-host-smoke.md`.
 
+**Assistant hosts** that own LLM/tool credentials should pass `activity_execution_mode: "host_mediated"` and complete activities via `workflow_submit_activity`. End-user guide: [`docs/user/host-mediated-activities.md`](../../docs/user/host-mediated-activities.md) ([ADR-0002](../../docs/architecture/adr/ADR-0002-host-mediated-activity-execution.md)).
+
 ### Engine-direct `tool_call` execution (optional)
 
 By default, `workflows-engine-mcp` uses the **in-process stub** executor for activity placeholders when **no operator activity config** is set. That default is intended for **local demo and smoke tests only** — not a silent production fallback. For production, configure at least one real sub-executor (see **Composite activity routing** below).

--- a/packages/engine/src/adapters/mcp/stdio-server-config.mjs
+++ b/packages/engine/src/adapters/mcp/stdio-server-config.mjs
@@ -9,7 +9,17 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { readAndValidateMcpOperatorManifestFile } from "../../config/mcp-operator-manifest.mjs";
+import { StubActivityExecutor } from "../../orchestrator/activity-executor.mjs";
+import {
+  buildCompositeActivityExecutor,
+  CompositeActivityExecutor,
+} from "../../orchestrator/composite-activity-executor.mjs";
+import { LlmActivityExecutor } from "../../orchestrator/llm-activity-executor.mjs";
 import { McpManifestActivityExecutor } from "../../orchestrator/mcp-stdio-activity-executor.mjs";
+import {
+  StepActivityExecutor,
+  StepHandlerRegistry,
+} from "../../orchestrator/step-activity-executor.mjs";
 
 const enginePackageJsonPath = fileURLToPath(new URL("../../../package.json", import.meta.url));
 const enginePackageVersion = JSON.parse(readFileSync(enginePackageJsonPath, "utf8")).version;
@@ -33,6 +43,72 @@ export function resolveWorkflowEngineMcpConfigPath(argv, cwd = process.cwd()) {
     return path.isAbsolute(p) ? p : path.resolve(cwd, p);
   }
   return null;
+}
+
+/**
+ * @param {string} raw Env value (inline JSON object or file path).
+ * @param {string} cwd
+ * @param {string} label Env var name for error messages.
+ * @returns {Record<string, unknown>}
+ */
+function parseJsonEnvOrFilePath(raw, cwd, label) {
+  const trimmed = String(raw).trim();
+  let text;
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    text = trimmed;
+  } else {
+    const p = path.isAbsolute(trimmed) ? trimmed : path.resolve(cwd, trimmed);
+    text = readFileSync(p, "utf8");
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`${label} is not valid JSON: ${message}`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${label} must be a JSON object`);
+  }
+  return /** @type {Record<string, unknown>} */ (parsed);
+}
+
+/**
+ * Reads LLM operator config from `WORKFLOW_ENGINE_LLM_CONFIG` (inline JSON or file path).
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @param {string} [cwd]
+ * @returns {import("../../orchestrator/llm-activity-executor.mjs").LlmOperatorConfig | null}
+ */
+export function resolveLlmOperatorConfigFromEnv(env = process.env, cwd = process.cwd()) {
+  const raw = env.WORKFLOW_ENGINE_LLM_CONFIG;
+  if (!raw || String(raw).trim() === "") {
+    return null;
+  }
+  const parsed = parseJsonEnvOrFilePath(raw, cwd, "WORKFLOW_ENGINE_LLM_CONFIG");
+  return /** @type {import("../../orchestrator/llm-activity-executor.mjs").LlmOperatorConfig} */ (parsed);
+}
+
+/**
+ * Loads a frozen {@link StepHandlerRegistry} from `WORKFLOW_ENGINE_STEP_HANDLERS`.
+ * Value is inline JSON or a file path. Each key is a handler URN; each value is the static handler output
+ * (same shape as conformance `stepHandlers` vectors).
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @param {string} [cwd]
+ * @returns {import("../../orchestrator/step-activity-executor.mjs").StepHandlerRegistry | null}
+ */
+export function loadStepHandlerRegistryFromEnv(env = process.env, cwd = process.cwd()) {
+  const raw = env.WORKFLOW_ENGINE_STEP_HANDLERS;
+  if (!raw || String(raw).trim() === "") {
+    return null;
+  }
+  const handlers = parseJsonEnvOrFilePath(raw, cwd, "WORKFLOW_ENGINE_STEP_HANDLERS");
+  const registry = new StepHandlerRegistry();
+  for (const [urn, output] of Object.entries(handlers)) {
+    registry.register(urn, async () => /** @type {Record<string, unknown>} */ (output));
+  }
+  return registry.createFrozenCopy();
 }
 
 /**
@@ -75,6 +151,66 @@ export async function loadEngineDirectActivityExecutor(manifestPath, options = {
     clientVersion: enginePackageVersion,
   });
   return { ok: true, executor };
+}
+
+/**
+ * @param {{
+ *   manifestPath?: string | null;
+ *   llmConfig?: import("../../orchestrator/llm-activity-executor.mjs").LlmOperatorConfig | null;
+ *   stepHandlerRegistry?: import("../../orchestrator/step-activity-executor.mjs").StepHandlerRegistry | null;
+ *   env?: NodeJS.ProcessEnv;
+ *   cwd?: string;
+ *   profile?: string | null;
+ * }} [options]
+ * @returns {Promise<
+ *   | { ok: true; executor: CompositeActivityExecutor | undefined }
+ *   | { ok: false; errors: ReadonlyArray<{ instancePath?: string; keyword: string; message?: string }> }
+ *   | { ok: false; error: string }
+ * >}
+ */
+export async function loadProductionActivityExecutor(options = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  const env = options.env ?? process.env;
+  const profile = options.profile ?? env.WORKFLOW_ENGINE_PROFILE ?? null;
+  const demoProfile = profile === "demo";
+
+  /** @type {Partial<{ step: import("../../orchestrator/activity-executor.mjs").ActivityExecutor; llm_call: import("../../orchestrator/activity-executor.mjs").ActivityExecutor; tool_call: import("../../orchestrator/activity-executor.mjs").ActivityExecutor; fallback?: import("../../orchestrator/activity-executor.mjs").ActivityExecutor }>} */
+  const subExecutors = {};
+
+  const manifestPath =
+    options.manifestPath !== undefined ? options.manifestPath : resolveWorkflowEngineMcpConfigPath(process.argv, cwd);
+
+  if (manifestPath) {
+    const loaded = await loadEngineDirectActivityExecutor(manifestPath, { cwd });
+    if (!loaded.ok) {
+      return loaded;
+    }
+    subExecutors.tool_call = loaded.executor;
+  }
+
+  const llmConfig =
+    options.llmConfig !== undefined ? options.llmConfig : resolveLlmOperatorConfigFromEnv(env, cwd);
+  if (llmConfig) {
+    subExecutors.llm_call = new LlmActivityExecutor({ operatorConfig: llmConfig, env });
+  }
+
+  const stepRegistry =
+    options.stepHandlerRegistry !== undefined
+      ? options.stepHandlerRegistry
+      : loadStepHandlerRegistryFromEnv(env, cwd);
+  if (stepRegistry) {
+    subExecutors.step = new StepActivityExecutor({ registry: stepRegistry });
+  }
+
+  if (!subExecutors.step && !subExecutors.llm_call && !subExecutors.tool_call) {
+    return { ok: true, executor: undefined };
+  }
+
+  if (demoProfile) {
+    subExecutors.fallback = new StubActivityExecutor();
+  }
+
+  return { ok: true, executor: buildCompositeActivityExecutor(subExecutors) };
 }
 
 export { enginePackageVersion };

--- a/packages/engine/src/index.mjs
+++ b/packages/engine/src/index.mjs
@@ -48,6 +48,11 @@ export {
   resolveLlmApiKey,
   validateLlmStructuredOutput,
 } from "./orchestrator/llm-activity-executor.mjs";
+export {
+  parseStepNodeConfig,
+  StepActivityExecutor,
+  StepHandlerRegistry,
+} from "./orchestrator/step-activity-executor.mjs";
 export { MemoryExecutionHistoryStore } from "./persistence/memory-history-store.mjs";
 export { SqliteExecutionHistoryStore } from "./persistence/sqlite-history-store.mjs";
 export {

--- a/packages/engine/src/index.mjs
+++ b/packages/engine/src/index.mjs
@@ -53,6 +53,10 @@ export {
   StepActivityExecutor,
   StepHandlerRegistry,
 } from "./orchestrator/step-activity-executor.mjs";
+export {
+  buildCompositeActivityExecutor,
+  CompositeActivityExecutor,
+} from "./orchestrator/composite-activity-executor.mjs";
 export { MemoryExecutionHistoryStore } from "./persistence/memory-history-store.mjs";
 export { SqliteExecutionHistoryStore } from "./persistence/sqlite-history-store.mjs";
 export {

--- a/packages/engine/src/index.mjs
+++ b/packages/engine/src/index.mjs
@@ -39,6 +39,15 @@ export {
   mapMcpClientThrownError,
   McpManifestActivityExecutor,
 } from "./orchestrator/mcp-stdio-activity-executor.mjs";
+export {
+  buildLlmChatMessages,
+  LlmActivityExecutor,
+  OpenAiCompatibleLlmProvider,
+  parseLlmAssistantContent,
+  parseLlmCallNodeConfig,
+  resolveLlmApiKey,
+  validateLlmStructuredOutput,
+} from "./orchestrator/llm-activity-executor.mjs";
 export { MemoryExecutionHistoryStore } from "./persistence/memory-history-store.mjs";
 export { SqliteExecutionHistoryStore } from "./persistence/sqlite-history-store.mjs";
 export {

--- a/packages/engine/src/mcp-stdio-server.mjs
+++ b/packages/engine/src/mcp-stdio-server.mjs
@@ -3,7 +3,7 @@ import { createWorkflowApplicationPort } from "./application/workflow-applicatio
 import { createMcpWorkflowStdioServer } from "./adapters/mcp/stdio-server.mjs";
 import {
   formatMcpManifestValidationErrors,
-  loadEngineDirectActivityExecutor,
+  loadProductionActivityExecutor,
   resolveWorkflowEngineMcpConfigPath,
 } from "./adapters/mcp/stdio-server-config.mjs";
 import { MemoryExecutionHistoryStore } from "./persistence/memory-history-store.mjs";
@@ -15,9 +15,12 @@ async function main() {
       "Usage: workflows-engine-mcp [--mcp-config <path>]\n" +
         "Starts MCP stdio adapter with workflow_start/workflow_status/workflow_resume/workflow_submit_activity tools.\n" +
         "\n" +
-        "Engine-direct activity execution (real MCP tool_call via operator manifest):\n" +
-        "  Set WORKFLOW_ENGINE_MCP_CONFIG to a JSON file path, or pass --mcp-config <path>.\n" +
-        "  When unset, tool_call nodes use the in-process stub (backward-compatible default).\n" +
+        "Production activity execution (composite router):\n" +
+        "  WORKFLOW_ENGINE_MCP_CONFIG — operator MCP manifest for tool_call (or --mcp-config <path>).\n" +
+        "  WORKFLOW_ENGINE_LLM_CONFIG — inline JSON or file path for llm_call operator credentials.\n" +
+        "  WORKFLOW_ENGINE_STEP_HANDLERS — inline JSON or file path mapping handler URNs to static outputs.\n" +
+        "  When none are set, activities use StubActivityExecutor (local demo only; set WORKFLOW_ENGINE_PROFILE=demo\n" +
+        "  to enable stub fallback for unconfigured node types inside a partial composite).\n" +
         "  Manifest schema: same as `workflows-engine mcp-manifest validate` (mcpServers stdio subset).\n"
     );
     return;
@@ -25,16 +28,26 @@ async function main() {
 
   const manifestPath = resolveWorkflowEngineMcpConfigPath(process.argv);
   let activityExecutor = undefined;
-  if (manifestPath) {
-    const loaded = await loadEngineDirectActivityExecutor(manifestPath);
+  try {
+    const loaded = await loadProductionActivityExecutor({ manifestPath });
     if (!loaded.ok) {
-      process.stderr.write(
-        `[engine-mcp-stdio] Invalid operator manifest at ${manifestPath}:\n${formatMcpManifestValidationErrors(loaded.errors)}\n`
-      );
+      if ("errors" in loaded && loaded.errors) {
+        process.stderr.write(
+          `[engine-mcp-stdio] Invalid operator manifest at ${manifestPath}:\n${formatMcpManifestValidationErrors(loaded.errors)}\n`
+        );
+      } else {
+        process.stderr.write(`[engine-mcp-stdio] Activity executor configuration failed: ${loaded.error}\n`);
+      }
       process.exitCode = 1;
       return;
     }
     activityExecutor = loaded.executor;
+  } catch (err) {
+    process.stderr.write(
+      `[engine-mcp-stdio] Activity executor configuration failed: ${err instanceof Error ? err.message : String(err)}\n`
+    );
+    process.exitCode = 1;
+    return;
   }
 
   const store = new MemoryExecutionHistoryStore();

--- a/packages/engine/src/orchestrator/composite-activity-executor.mjs
+++ b/packages/engine/src/orchestrator/composite-activity-executor.mjs
@@ -1,0 +1,80 @@
+/**
+ * Routes activity execution by node type to configured sub-executors (`step`, `llm_call`, `tool_call`).
+ */
+
+/** @typedef {"step" | "llm_call" | "tool_call"} RoutedActivityNodeType */
+
+/** @type {ReadonlySet<string>} */
+const ROUTED_ACTIVITY_TYPES = new Set(["step", "llm_call", "tool_call"]);
+
+/**
+ * @typedef {import("./activity-executor.mjs").ActivityExecutor} ActivityExecutor
+ * @typedef {import("./activity-executor.mjs").ActivityExecutorContext} ActivityExecutorContext
+ * @typedef {import("./activity-executor.mjs").ActivityExecutorResult} ActivityExecutorResult
+ */
+
+/**
+ * @param {{
+ *   step?: ActivityExecutor;
+ *   llm_call?: ActivityExecutor;
+ *   tool_call?: ActivityExecutor;
+ *   fallback?: ActivityExecutor;
+ * }} subExecutors
+ */
+export function buildCompositeActivityExecutor(subExecutors = {}) {
+  return new CompositeActivityExecutor(subExecutors);
+}
+
+/**
+ * Composite {@link ActivityExecutor} that dispatches by `ctx.node.type`.
+ *
+ * @implements {ActivityExecutor}
+ */
+export class CompositeActivityExecutor {
+  /**
+   * @param {{
+   *   step?: ActivityExecutor;
+   *   llm_call?: ActivityExecutor;
+   *   tool_call?: ActivityExecutor;
+   *   fallback?: ActivityExecutor;
+   * }} subExecutors
+   */
+  constructor(subExecutors = {}) {
+    /** @type {Partial<Record<RoutedActivityNodeType, ActivityExecutor>>} */
+    this._executors = {
+      ...(subExecutors.step ? { step: subExecutors.step } : {}),
+      ...(subExecutors.llm_call ? { llm_call: subExecutors.llm_call } : {}),
+      ...(subExecutors.tool_call ? { tool_call: subExecutors.tool_call } : {}),
+    };
+    this._fallback = subExecutors.fallback;
+  }
+
+  /**
+   * @param {ActivityExecutorContext} ctx
+   * @returns {Promise<ActivityExecutorResult>}
+   */
+  async executeActivity(ctx) {
+    const nodeType = ctx.node.type;
+    if (!ROUTED_ACTIVITY_TYPES.has(nodeType)) {
+      return {
+        ok: false,
+        error: `CompositeActivityExecutor does not route node type "${nodeType}"`,
+        code: "COMPOSITE_EXECUTOR_NOT_CONFIGURED",
+      };
+    }
+    const executor = /** @type {RoutedActivityNodeType} */ (nodeType) in this._executors
+      ? this._executors[/** @type {RoutedActivityNodeType} */ (nodeType)]
+      : undefined;
+    if (executor) {
+      return executor.executeActivity(ctx);
+    }
+    if (this._fallback) {
+      return this._fallback.executeActivity(ctx);
+    }
+    return {
+      ok: false,
+      error: `No activity executor configured for node type "${nodeType}"`,
+      code: "COMPOSITE_EXECUTOR_NOT_CONFIGURED",
+    };
+  }
+}

--- a/packages/engine/src/orchestrator/llm-activity-executor.mjs
+++ b/packages/engine/src/orchestrator/llm-activity-executor.mjs
@@ -1,0 +1,321 @@
+/**
+ * Engine-direct LLM activity executor for `llm_call` nodes (OpenAI-compatible chat completions).
+ *
+ * Credentials and provider endpoints come from operator config (env / future vault refs), not workflow JSON (RFC-07 §7.3).
+ * Full `apiKeySecretRef` vault resolution is deferred to BEN-103.
+ */
+
+import Ajv2020 from "ajv/dist/2020.js";
+
+/** @typedef {"LLM_CONFIG_INVALID" | "LLM_CREDENTIALS_MISSING" | "LLM_PROVIDER_ERROR" | "LLM_OUTPUT_VALIDATION_FAILED" | "ACTIVITY_EXECUTOR_UNSUPPORTED_NODE"} LlmActivityErrorCode */
+
+/**
+ * Minimal operator-side LLM credentials (not stored in workflow documents).
+ *
+ * @typedef {object} LlmOperatorConfig
+ * @property {string} [apiKeyEnv] Env var name holding the provider API key.
+ * @property {string} [apiKeySecretRef] Vault secret ref (full resolver in BEN-103).
+ * @property {string} [baseUrl] OpenAI-compatible API base URL (default `https://api.openai.com/v1`).
+ */
+
+/**
+ * @typedef {object} LlmChatMessage
+ * @property {"system" | "user" | "assistant"} role
+ * @property {string} content
+ */
+
+/**
+ * @typedef {object} LlmChatCompletionRequest
+ * @property {string} apiKey
+ * @property {string} model
+ * @property {LlmChatMessage[]} messages
+ * @property {{ type: "json_object" } | undefined} [responseFormat]
+ */
+
+/**
+ * @typedef {object} LlmChatCompletionResponse
+ * @property {string} content Raw assistant message content.
+ */
+
+/**
+ * Injectable LLM transport (mock in tests; default uses fetch against OpenAI-compatible APIs).
+ *
+ * @typedef {object} LlmProvider
+ * @property {(req: LlmChatCompletionRequest) => Promise<LlmChatCompletionResponse>} chatCompletion
+ */
+
+/**
+ * @param {LlmOperatorConfig | undefined} operatorConfig
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {{ ok: true, apiKey: string } | { ok: false, error: string, code: "LLM_CREDENTIALS_MISSING" }}
+ */
+export function resolveLlmApiKey(operatorConfig, env = process.env) {
+  const cfg = operatorConfig && typeof operatorConfig === "object" ? operatorConfig : {};
+  const apiKeyEnv = typeof cfg.apiKeyEnv === "string" ? cfg.apiKeyEnv.trim() : "";
+  if (apiKeyEnv) {
+    const value = env[apiKeyEnv];
+    if (typeof value === "string" && value.trim() !== "") {
+      return { ok: true, apiKey: value };
+    }
+    return {
+      ok: false,
+      error: `LLM API key env var "${apiKeyEnv}" is unset or empty`,
+      code: "LLM_CREDENTIALS_MISSING",
+    };
+  }
+  const secretRef = typeof cfg.apiKeySecretRef === "string" ? cfg.apiKeySecretRef.trim() : "";
+  if (secretRef) {
+    return {
+      ok: false,
+      error: `apiKeySecretRef "${secretRef}" requires vault resolution (planned in BEN-103); set apiKeyEnv for now`,
+      code: "LLM_CREDENTIALS_MISSING",
+    };
+  }
+  return {
+    ok: false,
+    error: "LLM operator config requires apiKeyEnv or apiKeySecretRef",
+    code: "LLM_CREDENTIALS_MISSING",
+  };
+}
+
+/**
+ * @param {unknown} cfg
+ * @returns {{ ok: true, config: { model: string; systemPrompt?: string; userPrompt?: string; outputSchema?: object } } | { ok: false, error: string, code: "LLM_CONFIG_INVALID" }}
+ */
+export function parseLlmCallNodeConfig(cfg) {
+  const raw = cfg && typeof cfg === "object" && !Array.isArray(cfg) ? /** @type {Record<string, unknown>} */ (cfg) : {};
+  const model = typeof raw.model === "string" ? raw.model.trim() : "";
+  if (!model) {
+    return { ok: false, error: "llm_call node requires config.model (non-empty string)", code: "LLM_CONFIG_INVALID" };
+  }
+  const systemPrompt = typeof raw.system_prompt === "string" ? raw.system_prompt : undefined;
+  const userFromUser = typeof raw.user_prompt === "string" ? raw.user_prompt : undefined;
+  const userFromPrompt = typeof raw.prompt === "string" ? raw.prompt : undefined;
+  const userPrompt = userFromUser ?? userFromPrompt;
+  if (raw.system_prompt !== undefined && typeof raw.system_prompt !== "string") {
+    return { ok: false, error: "llm_call config.system_prompt must be a string when present", code: "LLM_CONFIG_INVALID" };
+  }
+  if (raw.user_prompt !== undefined && typeof raw.user_prompt !== "string") {
+    return { ok: false, error: "llm_call config.user_prompt must be a string when present", code: "LLM_CONFIG_INVALID" };
+  }
+  if (raw.prompt !== undefined && typeof raw.prompt !== "string") {
+    return { ok: false, error: "llm_call config.prompt must be a string when present", code: "LLM_CONFIG_INVALID" };
+  }
+  let outputSchema;
+  if (raw.output_schema !== undefined) {
+    if (!raw.output_schema || typeof raw.output_schema !== "object" || Array.isArray(raw.output_schema)) {
+      return { ok: false, error: "llm_call config.output_schema must be a JSON Schema object when present", code: "LLM_CONFIG_INVALID" };
+    }
+    outputSchema = /** @type {object} */ ({ .../** @type {object} */ (raw.output_schema) });
+  }
+  return {
+    ok: true,
+    config: {
+      model,
+      ...(systemPrompt !== undefined ? { systemPrompt } : {}),
+      ...(userPrompt !== undefined ? { userPrompt } : {}),
+      ...(outputSchema !== undefined ? { outputSchema } : {}),
+    },
+  };
+}
+
+/**
+ * @param {string} content
+ * @returns {Record<string, unknown> | { text: string }}
+ */
+export function parseLlmAssistantContent(content) {
+  const trimmed = content.trim();
+  if (!trimmed) return { text: "" };
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return /** @type {Record<string, unknown>} */ ({ ...parsed });
+    }
+  } catch {
+    // fall through to text wrapper
+  }
+  return { text: content };
+}
+
+/**
+ * @param {unknown} output
+ * @param {object | undefined} outputSchema
+ * @returns {{ ok: true, output: Record<string, unknown> } | { ok: false, error: string, code: "LLM_OUTPUT_VALIDATION_FAILED" }}
+ */
+export function validateLlmStructuredOutput(output, outputSchema) {
+  if (!outputSchema) {
+    const record =
+      output && typeof output === "object" && !Array.isArray(output)
+        ? /** @type {Record<string, unknown>} */ ({ .../** @type {object} */ (output) })
+        : { value: output };
+    return { ok: true, output: record };
+  }
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  const validate = ajv.compile(outputSchema);
+  const valid = validate(output);
+  if (!valid) {
+    const detail = (validate.errors ?? [])
+      .map((e) => `${e.instancePath || "/"} ${e.message ?? "invalid"}`)
+      .join("; ");
+    return {
+      ok: false,
+      error: `LLM output failed output_schema validation: ${detail || "invalid"}`,
+      code: "LLM_OUTPUT_VALIDATION_FAILED",
+    };
+  }
+  return {
+    ok: true,
+    output: /** @type {Record<string, unknown>} */ ({ .../** @type {object} */ (output) }),
+  };
+}
+
+/**
+ * @param {Record<string, unknown>} state
+ * @param {{ systemPrompt?: string; userPrompt?: string }} prompts
+ * @returns {LlmChatMessage[]}
+ */
+export function buildLlmChatMessages(state, prompts) {
+  /** @type {LlmChatMessage[]} */
+  const messages = [];
+  if (prompts.systemPrompt) {
+    messages.push({ role: "system", content: prompts.systemPrompt });
+  }
+  const userContent =
+    prompts.userPrompt ??
+    (Object.keys(state).length > 0 ? JSON.stringify(state) : "Respond according to the system instructions.");
+  messages.push({ role: "user", content: userContent });
+  return messages;
+}
+
+/**
+ * Default fetch-based OpenAI-compatible chat completions client.
+ *
+ * @implements {LlmProvider}
+ */
+export class OpenAiCompatibleLlmProvider {
+  /**
+   * @param {{ baseUrl?: string; fetchImpl?: typeof fetch }} [opts]
+   */
+  constructor(opts = {}) {
+    this.baseUrl = (opts.baseUrl ?? "https://api.openai.com/v1").replace(/\/$/, "");
+    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  }
+
+  /**
+   * @param {LlmChatCompletionRequest} req
+   * @returns {Promise<LlmChatCompletionResponse>}
+   */
+  async chatCompletion(req) {
+    if (typeof this.fetchImpl !== "function") {
+      throw new Error("fetch is not available; inject fetchImpl on OpenAiCompatibleLlmProvider");
+    }
+    const body = {
+      model: req.model,
+      messages: req.messages,
+      ...(req.responseFormat ? { response_format: req.responseFormat } : {}),
+    };
+    const res = await this.fetchImpl(`${this.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${req.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    const rawText = await res.text();
+    if (!res.ok) {
+      throw new Error(`LLM provider HTTP ${res.status}: ${rawText.slice(0, 500)}`);
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(rawText);
+    } catch {
+      throw new Error("LLM provider returned non-JSON response body");
+    }
+    const content = parsed?.choices?.[0]?.message?.content;
+    if (typeof content !== "string") {
+      throw new Error("LLM provider response missing choices[0].message.content");
+    }
+    return { content };
+  }
+}
+
+/**
+ * ActivityExecutor for `llm_call` nodes via an injectable {@link LlmProvider}.
+ *
+ * @implements {import("./activity-executor.mjs").ActivityExecutor}
+ */
+export class LlmActivityExecutor {
+  /**
+   * @param {{
+   *   operatorConfig?: LlmOperatorConfig;
+   *   provider?: LlmProvider;
+   *   env?: NodeJS.ProcessEnv;
+   * }} [opts]
+   */
+  constructor(opts = {}) {
+    this.operatorConfig = opts.operatorConfig ?? {};
+    this.env = opts.env ?? process.env;
+    this.provider =
+      opts.provider ??
+      new OpenAiCompatibleLlmProvider({
+        baseUrl: this.operatorConfig.baseUrl,
+      });
+  }
+
+  /**
+   * @param {import("./activity-executor.mjs").ActivityExecutorContext} ctx
+   * @returns {Promise<import("./activity-executor.mjs").ActivityExecutorResult>}
+   */
+  async executeActivity(ctx) {
+    const { node, state } = ctx;
+    if (node.type !== "llm_call") {
+      return {
+        ok: false,
+        error: `LlmActivityExecutor only supports llm_call nodes (got ${node.type})`,
+        code: "ACTIVITY_EXECUTOR_UNSUPPORTED_NODE",
+      };
+    }
+    const parsedCfg = parseLlmCallNodeConfig(node.config);
+    if (!parsedCfg.ok) {
+      return { ok: false, error: parsedCfg.error, code: parsedCfg.code };
+    }
+    const keyResult = resolveLlmApiKey(this.operatorConfig, this.env);
+    if (!keyResult.ok) {
+      return { ok: false, error: keyResult.error, code: keyResult.code };
+    }
+    const { model, systemPrompt, userPrompt, outputSchema } = parsedCfg.config;
+    const messages = buildLlmChatMessages(state, { systemPrompt, userPrompt });
+    let providerResponse;
+    try {
+      providerResponse = await this.provider.chatCompletion({
+        apiKey: keyResult.apiKey,
+        model,
+        messages,
+        ...(outputSchema ? { responseFormat: { type: "json_object" } } : {}),
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: message, code: "LLM_PROVIDER_ERROR" };
+    }
+    let parsedOutput;
+    if (outputSchema) {
+      try {
+        parsedOutput = JSON.parse(providerResponse.content.trim());
+      } catch {
+        return {
+          ok: false,
+          error: "LLM provider returned content that is not valid JSON (required when output_schema is set)",
+          code: "LLM_OUTPUT_VALIDATION_FAILED",
+        };
+      }
+    } else {
+      parsedOutput = parseLlmAssistantContent(providerResponse.content);
+    }
+    const validated = validateLlmStructuredOutput(parsedOutput, outputSchema);
+    if (!validated.ok) {
+      return { ok: false, error: validated.error, code: validated.code };
+    }
+    return { ok: true, output: validated.output };
+  }
+}

--- a/packages/engine/src/orchestrator/step-activity-executor.mjs
+++ b/packages/engine/src/orchestrator/step-activity-executor.mjs
@@ -1,0 +1,172 @@
+/**
+ * Engine-direct step activity executor: dispatches `step` nodes via an operator-side handler registry.
+ *
+ * v1 sandboxing: handlers run in the same Node.js process as the engine (no worker isolation).
+ */
+
+/**
+ * @typedef {"STEP_CONFIG_INVALID" | "HANDLER_NOT_FOUND" | "HANDLER_ERROR" | "ACTIVITY_EXECUTOR_UNSUPPORTED_NODE"} StepActivityErrorCode
+ */
+
+/**
+ * Context passed to registered step handlers.
+ *
+ * @typedef {object} StepHandlerContext
+ * @property {string} executionId
+ * @property {{ id: string; type: string; config?: object }} node
+ * @property {Record<string, unknown>} state
+ */
+
+/**
+ * @typedef {import("./activity-executor.mjs").ActivityExecutorResult} ActivityExecutorResult
+ */
+
+/**
+ * @typedef {(ctx: StepHandlerContext) => Promise<Record<string, unknown> | ActivityExecutorResult>} StepHandlerFn
+ */
+
+/**
+ * Operator-side registry mapping handler URNs to async step implementations.
+ */
+export class StepHandlerRegistry {
+  constructor() {
+    /** @type {Map<string, StepHandlerFn>} */
+    this._handlers = new Map();
+    this._frozen = false;
+  }
+
+  /**
+   * @param {string} urn Handler URN (non-empty string).
+   * @param {StepHandlerFn} fn
+   */
+  register(urn, fn) {
+    if (this._frozen) {
+      throw new Error("StepHandlerRegistry is frozen; cannot register handlers");
+    }
+    const key = typeof urn === "string" ? urn.trim() : "";
+    if (!key) {
+      throw new Error("StepHandlerRegistry.register requires a non-empty URN string");
+    }
+    if (typeof fn !== "function") {
+      throw new Error("StepHandlerRegistry.register requires an async function");
+    }
+    this._handlers.set(key, fn);
+  }
+
+  /**
+   * @param {string} urn
+   * @returns {StepHandlerFn | undefined}
+   */
+  get(urn) {
+    const key = typeof urn === "string" ? urn.trim() : "";
+    return key ? this._handlers.get(key) : undefined;
+  }
+
+  /**
+   * Returns a new registry with the same handlers that rejects further `register` calls.
+   *
+   * @returns {StepHandlerRegistry}
+   */
+  createFrozenCopy() {
+    const copy = new StepHandlerRegistry();
+    for (const [urn, fn] of this._handlers) {
+      copy._handlers.set(urn, fn);
+    }
+    copy._frozen = true;
+    return copy;
+  }
+}
+
+/**
+ * @param {unknown} cfg
+ * @returns {{ ok: true, config: { handler: string } } | { ok: false, error: string, code: "STEP_CONFIG_INVALID" }}
+ */
+export function parseStepNodeConfig(cfg) {
+  const raw = cfg && typeof cfg === "object" && !Array.isArray(cfg) ? /** @type {Record<string, unknown>} */ (cfg) : {};
+  const handler = typeof raw.handler === "string" ? raw.handler.trim() : "";
+  if (!handler) {
+    return {
+      ok: false,
+      error: "step node requires config.handler (non-empty string URN)",
+      code: "STEP_CONFIG_INVALID",
+    };
+  }
+  return { ok: true, config: { handler } };
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is ActivityExecutorResult}
+ */
+function isActivityExecutorResult(value) {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    "ok" in value &&
+    typeof /** @type {{ ok: unknown }} */ (value).ok === "boolean"
+  );
+}
+
+/**
+ * ActivityExecutor for `step` nodes via a {@link StepHandlerRegistry}.
+ *
+ * @implements {import("./activity-executor.mjs").ActivityExecutor}
+ */
+export class StepActivityExecutor {
+  /**
+   * @param {{ registry: StepHandlerRegistry }} opts
+   */
+  constructor(opts) {
+    if (!opts?.registry || !(opts.registry instanceof StepHandlerRegistry)) {
+      throw new Error("StepActivityExecutor requires a StepHandlerRegistry");
+    }
+    this.registry = opts.registry;
+  }
+
+  /**
+   * @param {import("./activity-executor.mjs").ActivityExecutorContext} ctx
+   * @returns {Promise<ActivityExecutorResult>}
+   */
+  async executeActivity(ctx) {
+    const { node, state, executionId } = ctx;
+    if (node.type !== "step") {
+      return {
+        ok: false,
+        error: `StepActivityExecutor only supports step nodes (got ${node.type})`,
+        code: "ACTIVITY_EXECUTOR_UNSUPPORTED_NODE",
+      };
+    }
+    const parsedCfg = parseStepNodeConfig(node.config);
+    if (!parsedCfg.ok) {
+      return { ok: false, error: parsedCfg.error, code: parsedCfg.code };
+    }
+    const handlerFn = this.registry.get(parsedCfg.config.handler);
+    if (!handlerFn) {
+      return {
+        ok: false,
+        error: `No step handler registered for URN "${parsedCfg.config.handler}"`,
+        code: "HANDLER_NOT_FOUND",
+      };
+    }
+    /** @type {StepHandlerContext} */
+    const handlerCtx = { executionId, node, state };
+    let rawResult;
+    try {
+      rawResult = await handlerFn(handlerCtx);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: message, code: "HANDLER_ERROR" };
+    }
+    if (isActivityExecutorResult(rawResult)) {
+      return rawResult;
+    }
+    if (rawResult && typeof rawResult === "object" && !Array.isArray(rawResult)) {
+      return {
+        ok: true,
+        output: /** @type {Record<string, unknown>} */ ({ .../** @type {object} */ (rawResult) }),
+      };
+    }
+    return { ok: true, output: { value: rawResult } };
+  }
+}

--- a/packages/engine/test/composite-activity-executor.test.mjs
+++ b/packages/engine/test/composite-activity-executor.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import {
+  buildCompositeActivityExecutor,
+  CompositeActivityExecutor,
+} from "../src/orchestrator/composite-activity-executor.mjs";
+
+/**
+ * @param {string} tag
+ * @returns {import("../src/orchestrator/activity-executor.mjs").ActivityExecutor}
+ */
+function mockExecutor(tag) {
+  return {
+    async executeActivity(ctx) {
+      return { ok: true, output: { routed: tag, nodeId: ctx.node.id } };
+    },
+  };
+}
+
+describe("CompositeActivityExecutor", () => {
+  it("routes step, llm_call, and tool_call to configured sub-executors", async () => {
+    const composite = new CompositeActivityExecutor({
+      step: mockExecutor("step"),
+      llm_call: mockExecutor("llm_call"),
+      tool_call: mockExecutor("tool_call"),
+    });
+
+    const step = await composite.executeActivity({
+      executionId: "e1",
+      node: { id: "s1", type: "step", config: { handler: "urn:test" } },
+      state: {},
+    });
+    assert.equal(step.ok, true);
+    if (step.ok) assert.deepEqual(step.output, { routed: "step", nodeId: "s1" });
+
+    const llm = await composite.executeActivity({
+      executionId: "e1",
+      node: { id: "l1", type: "llm_call", config: { model: "m" } },
+      state: {},
+    });
+    assert.equal(llm.ok, true);
+    if (llm.ok) assert.deepEqual(llm.output, { routed: "llm_call", nodeId: "l1" });
+
+    const tool = await composite.executeActivity({
+      executionId: "e1",
+      node: { id: "t1", type: "tool_call", config: { server: "x", tool: "y" } },
+      state: {},
+    });
+    assert.equal(tool.ok, true);
+    if (tool.ok) assert.deepEqual(tool.output, { routed: "tool_call", nodeId: "t1" });
+  });
+
+  it("returns COMPOSITE_EXECUTOR_NOT_CONFIGURED when sub-executor is missing", async () => {
+    const composite = buildCompositeActivityExecutor({ tool_call: mockExecutor("tool_call") });
+    const r = await composite.executeActivity({
+      executionId: "e1",
+      node: { id: "l1", type: "llm_call", config: { model: "m" } },
+      state: {},
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.code, "COMPOSITE_EXECUTOR_NOT_CONFIGURED");
+      assert.match(r.error, /llm_call/);
+    }
+  });
+
+  it("uses fallback only when explicitly configured", async () => {
+    const composite = buildCompositeActivityExecutor({
+      tool_call: mockExecutor("tool_call"),
+      fallback: mockExecutor("fallback"),
+    });
+    const r = await composite.executeActivity({
+      executionId: "e1",
+      node: { id: "s1", type: "step", config: { handler: "urn:test" } },
+      state: {},
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.output.routed, "fallback");
+  });
+
+  it("rejects non-activity node types", async () => {
+    const composite = buildCompositeActivityExecutor({
+      step: mockExecutor("step"),
+      llm_call: mockExecutor("llm_call"),
+      tool_call: mockExecutor("tool_call"),
+    });
+    const r = await composite.executeActivity({
+      executionId: "e1",
+      node: { id: "w1", type: "wait", config: {} },
+      state: {},
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "COMPOSITE_EXECUTOR_NOT_CONFIGURED");
+  });
+});

--- a/packages/engine/test/llm-activity-executor.test.mjs
+++ b/packages/engine/test/llm-activity-executor.test.mjs
@@ -1,0 +1,297 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { runLinearWorkflow } from "../src/orchestrator/linear-runner.mjs";
+import { MemoryExecutionHistoryStore } from "../src/persistence/memory-history-store.mjs";
+import {
+  buildLlmChatMessages,
+  LlmActivityExecutor,
+  OpenAiCompatibleLlmProvider,
+  parseLlmCallNodeConfig,
+  resolveLlmApiKey,
+  validateLlmStructuredOutput,
+} from "../src/orchestrator/llm-activity-executor.mjs";
+
+describe("resolveLlmApiKey", () => {
+  it("reads api key from apiKeyEnv", () => {
+    const r = resolveLlmApiKey({ apiKeyEnv: "OPENAI_API_KEY" }, { OPENAI_API_KEY: "sk-test" });
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.apiKey, "sk-test");
+  });
+
+  it("fails when env var is missing", () => {
+    const r = resolveLlmApiKey({ apiKeyEnv: "MISSING_KEY" }, {});
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "LLM_CREDENTIALS_MISSING");
+  });
+
+  it("fails for apiKeySecretRef until BEN-103 vault resolver", () => {
+    const r = resolveLlmApiKey({ apiKeySecretRef: "vault/openai" }, {});
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.code, "LLM_CREDENTIALS_MISSING");
+      assert.match(r.error, /BEN-103/);
+    }
+  });
+});
+
+describe("parseLlmCallNodeConfig", () => {
+  it("requires model", () => {
+    const r = parseLlmCallNodeConfig({ system_prompt: "hi" });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "LLM_CONFIG_INVALID");
+  });
+
+  it("accepts system_prompt, user_prompt, and output_schema", () => {
+    const r = parseLlmCallNodeConfig({
+      model: "gpt-4",
+      system_prompt: "sys",
+      user_prompt: "user",
+      output_schema: { type: "object", properties: { a: { type: "string" } } },
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.config.model, "gpt-4");
+      assert.equal(r.config.systemPrompt, "sys");
+      assert.equal(r.config.userPrompt, "user");
+      assert.ok(r.config.outputSchema);
+    }
+  });
+
+  it("treats prompt as user prompt alias", () => {
+    const r = parseLlmCallNodeConfig({ model: "m", prompt: "from-prompt" });
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.config.userPrompt, "from-prompt");
+  });
+});
+
+describe("validateLlmStructuredOutput", () => {
+  it("validates against output_schema", () => {
+    const schema = {
+      type: "object",
+      properties: { intent: { type: "string" }, confidence: { type: "number" } },
+      required: ["intent", "confidence"],
+    };
+    const ok = validateLlmStructuredOutput({ intent: "billing", confidence: 0.9 }, schema);
+    assert.equal(ok.ok, true);
+    const bad = validateLlmStructuredOutput({ intent: "billing" }, schema);
+    assert.equal(bad.ok, false);
+    if (!bad.ok) assert.equal(bad.code, "LLM_OUTPUT_VALIDATION_FAILED");
+  });
+});
+
+describe("buildLlmChatMessages", () => {
+  it("serializes state when user prompt is omitted", () => {
+    const msgs = buildLlmChatMessages({ ticket_text: "help" }, { systemPrompt: "classify" });
+    assert.equal(msgs.length, 2);
+    assert.equal(msgs[0].role, "system");
+    assert.equal(msgs[1].role, "user");
+    assert.match(msgs[1].content, /ticket_text/);
+  });
+});
+
+describe("LlmActivityExecutor", () => {
+  it("rejects non-llm_call nodes", async () => {
+    const ex = new LlmActivityExecutor({ operatorConfig: { apiKeyEnv: "K" }, env: { K: "sk" } });
+    const r = await ex.executeActivity({
+      executionId: "e1",
+      node: { id: "n1", type: "step", config: {} },
+      state: {},
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "ACTIVITY_EXECUTOR_UNSUPPORTED_NODE");
+  });
+
+  it("returns LLM_CONFIG_INVALID for missing model", async () => {
+    const ex = new LlmActivityExecutor({ operatorConfig: { apiKeyEnv: "K" }, env: { K: "sk" } });
+    const r = await ex.executeActivity({
+      executionId: "e1",
+      node: { id: "n1", type: "llm_call", config: { system_prompt: "x" } },
+      state: {},
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "LLM_CONFIG_INVALID");
+  });
+
+  it("returns LLM_CREDENTIALS_MISSING without operator config", async () => {
+    const ex = new LlmActivityExecutor({ env: {} });
+    const r = await ex.executeActivity({
+      executionId: "e1",
+      node: { id: "n1", type: "llm_call", config: { model: "gpt-4" } },
+      state: {},
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "LLM_CREDENTIALS_MISSING");
+  });
+
+  it("returns LLM_PROVIDER_ERROR when provider throws", async () => {
+    /** @type {import("../src/orchestrator/llm-activity-executor.mjs").LlmProvider} */
+    const provider = {
+      async chatCompletion() {
+        throw new Error("upstream unavailable");
+      },
+    };
+    const ex = new LlmActivityExecutor({
+      operatorConfig: { apiKeyEnv: "K" },
+      env: { K: "sk" },
+      provider,
+    });
+    const r = await ex.executeActivity({
+      executionId: "e1",
+      node: { id: "classify", type: "llm_call", config: { model: "gpt-4", system_prompt: "go" } },
+      state: { ticket_text: "billing" },
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.code, "LLM_PROVIDER_ERROR");
+      assert.match(r.error, /upstream/);
+    }
+  });
+
+  it("validates structured output from mocked provider", async () => {
+    /** @type {import("../src/orchestrator/llm-activity-executor.mjs").LlmProvider} */
+    const provider = {
+      async chatCompletion(req) {
+        assert.equal(req.model, "stub-or-live");
+        assert.equal(req.responseFormat?.type, "json_object");
+        assert.ok(req.messages.some((m) => m.role === "system"));
+        return { content: JSON.stringify({ intent: "billing", confidence: 0.95 }) };
+      },
+    };
+    const ex = new LlmActivityExecutor({
+      operatorConfig: { apiKeyEnv: "K" },
+      env: { K: "sk" },
+      provider,
+    });
+    const r = await ex.executeActivity({
+      executionId: "e1",
+      node: {
+        id: "classify",
+        type: "llm_call",
+        config: {
+          model: "stub-or-live",
+          system_prompt: "Classify intent.",
+          output_schema: {
+            type: "object",
+            properties: { intent: { type: "string" }, confidence: { type: "number" } },
+            required: ["intent", "confidence"],
+          },
+        },
+      },
+      state: { ticket_text: "I was charged twice" },
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.output.intent, "billing");
+      assert.equal(r.output.confidence, 0.95);
+    }
+  });
+
+  it("returns LLM_OUTPUT_VALIDATION_FAILED for schema mismatch", async () => {
+    /** @type {import("../src/orchestrator/llm-activity-executor.mjs").LlmProvider} */
+    const provider = {
+      async chatCompletion() {
+        return { content: JSON.stringify({ intent: "billing" }) };
+      },
+    };
+    const ex = new LlmActivityExecutor({
+      operatorConfig: { apiKeyEnv: "K" },
+      env: { K: "sk" },
+      provider,
+    });
+    const r = await ex.executeActivity({
+      executionId: "e1",
+      node: {
+        id: "classify",
+        type: "llm_call",
+        config: {
+          model: "m",
+          output_schema: {
+            type: "object",
+            properties: { intent: { type: "string" }, confidence: { type: "number" } },
+            required: ["intent", "confidence"],
+          },
+        },
+      },
+      state: {},
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "LLM_OUTPUT_VALIDATION_FAILED");
+  });
+});
+
+describe("OpenAiCompatibleLlmProvider", () => {
+  it("maps fetch response to assistant content", async () => {
+    /** @type {typeof fetch} */
+    const fetchImpl = async () =>
+      new Response(
+        JSON.stringify({ choices: [{ message: { content: '{"a":1}' } }] }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    const provider = new OpenAiCompatibleLlmProvider({ baseUrl: "https://example.test/v1", fetchImpl });
+    const res = await provider.chatCompletion({
+      apiKey: "sk",
+      model: "m",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    assert.equal(res.content, '{"a":1}');
+  });
+
+  it("throws on HTTP error", async () => {
+    /** @type {typeof fetch} */
+    const fetchImpl = async () => new Response("rate limited", { status: 429 });
+    const provider = new OpenAiCompatibleLlmProvider({ fetchImpl });
+    await assert.rejects(() =>
+      provider.chatCompletion({
+        apiKey: "sk",
+        model: "m",
+        messages: [{ role: "user", content: "hi" }],
+      })
+    );
+  });
+});
+
+describe("LlmActivityExecutor with linear runner", () => {
+  it("emits ActivityFailed with LLM_PROVIDER_ERROR on provider failure", async () => {
+    const definition = {
+      document: {
+        schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
+        name: "llm-linear",
+        version: "1.0.0",
+      },
+      state_schema: { type: "object", properties: {} },
+      nodes: [
+        { id: "begin", type: "start", config: { input_schema: { type: "object" } } },
+        { id: "classify", type: "llm_call", config: { model: "m", user_prompt: "u" } },
+        { id: "finish", type: "end", config: { result: { jq: "." } } },
+      ],
+      edges: [
+        { from: "__start__", to: "begin" },
+        { from: "begin", to: "classify" },
+        { from: "classify", to: "finish" },
+      ],
+    };
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "exec-llm-fail";
+    const executor = new LlmActivityExecutor({
+      operatorConfig: { apiKeyEnv: "K" },
+      env: { K: "sk" },
+      provider: {
+        async chatCompletion() {
+          throw new Error("upstream down");
+        },
+      },
+    });
+    const out = await runLinearWorkflow({
+      definition,
+      input: {},
+      executionId,
+      store,
+      activityExecutor: executor,
+    });
+    assert.equal(out.status, "failed");
+    const failedRow = store.listByExecution(executionId).find((r) => r.name === "ActivityFailed");
+    assert.ok(failedRow);
+    assert.equal(failedRow.payload.code, "LLM_PROVIDER_ERROR");
+    assert.match(failedRow.payload.error, /upstream down/);
+  });
+});

--- a/packages/engine/test/llm-activity-executor.test.mjs
+++ b/packages/engine/test/llm-activity-executor.test.mjs
@@ -262,12 +262,12 @@ describe("LlmActivityExecutor with linear runner", () => {
       nodes: [
         { id: "begin", type: "start", config: { input_schema: { type: "object" } } },
         { id: "classify", type: "llm_call", config: { model: "m", user_prompt: "u" } },
-        { id: "finish", type: "end", config: { result: { jq: "." } } },
+        { id: "finish", type: "end", config: { output_mapping: "{ ok: true }" } },
       ],
       edges: [
-        { from: "__start__", to: "begin" },
-        { from: "begin", to: "classify" },
-        { from: "classify", to: "finish" },
+        { source: "__start__", target: "begin" },
+        { source: "begin", target: "classify" },
+        { source: "classify", target: "finish" },
       ],
     };
     const store = new MemoryExecutionHistoryStore();

--- a/packages/engine/test/mcp-stdio-server-config.test.mjs
+++ b/packages/engine/test/mcp-stdio-server-config.test.mjs
@@ -7,9 +7,15 @@ import { describe, it } from "node:test";
 import {
   formatMcpManifestValidationErrors,
   loadEngineDirectActivityExecutor,
+  loadProductionActivityExecutor,
+  loadStepHandlerRegistryFromEnv,
+  resolveLlmOperatorConfigFromEnv,
   resolveWorkflowEngineMcpConfigPath,
 } from "../src/adapters/mcp/stdio-server-config.mjs";
 import { createWorkflowApplicationPort } from "../src/application/workflow-application-port.mjs";
+import { buildCompositeActivityExecutor } from "../src/orchestrator/composite-activity-executor.mjs";
+import { LlmActivityExecutor } from "../src/orchestrator/llm-activity-executor.mjs";
+import { StepActivityExecutor } from "../src/orchestrator/step-activity-executor.mjs";
 import { MemoryExecutionHistoryStore } from "../src/persistence/memory-history-store.mjs";
 
 const echoServerPath = fileURLToPath(new URL("./fixtures/mcp-echo-stdio-server.mjs", import.meta.url));
@@ -112,9 +118,10 @@ describe("createWorkflowApplicationPort + engine-direct executor", () => {
       })
     );
 
-    const loaded = await loadEngineDirectActivityExecutor(manifestPath);
+    const loaded = await loadProductionActivityExecutor({ manifestPath, env: {} });
     assert.equal(loaded.ok, true);
     if (!loaded.ok) return;
+    assert.ok(loaded.executor);
 
     const store = new MemoryExecutionHistoryStore();
     const port = createWorkflowApplicationPort({ store, activityExecutor: loaded.executor });
@@ -130,6 +137,134 @@ describe("createWorkflowApplicationPort + engine-direct executor", () => {
     assert.ok(completed.length >= 1);
     const last = completed[completed.length - 1];
     assert.deepEqual(last.payload.result.echoed, { via: "port" });
+  });
+});
+
+describe("loadProductionActivityExecutor", () => {
+  it("returns undefined executor when no operator config is present", async () => {
+    const r = await loadProductionActivityExecutor({
+      manifestPath: null,
+      llmConfig: null,
+      stepHandlerRegistry: null,
+      env: {},
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.executor, undefined);
+  });
+
+  it("builds composite when manifest and LLM config are set", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-mcp-"));
+    const manifestPath = path.join(dir, "mcp.json");
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        mcpServers: {
+          echoSrv: {
+            command: process.execPath,
+            args: [echoServerPath],
+            env: {},
+          },
+        },
+      })
+    );
+    const r = await loadProductionActivityExecutor({
+      manifestPath,
+      llmConfig: { apiKeyEnv: "TEST_LLM_KEY" },
+      env: { TEST_LLM_KEY: "sk-test" },
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) assert.ok(r.executor);
+  });
+});
+
+describe("resolveLlmOperatorConfigFromEnv", () => {
+  it("parses inline JSON", () => {
+    const cfg = resolveLlmOperatorConfigFromEnv(
+      { WORKFLOW_ENGINE_LLM_CONFIG: '{"apiKeyEnv":"OPENAI_API_KEY"}' },
+      process.cwd()
+    );
+    assert.deepEqual(cfg, { apiKeyEnv: "OPENAI_API_KEY" });
+  });
+});
+
+describe("loadStepHandlerRegistryFromEnv", () => {
+  it("registers static outputs from inline JSON", () => {
+    const registry = loadStepHandlerRegistryFromEnv(
+      { WORKFLOW_ENGINE_STEP_HANDLERS: '{"urn:test:handler":{"value":42}}' },
+      process.cwd()
+    );
+    assert.ok(registry);
+    assert.ok(registry.get("urn:test:handler"));
+  });
+});
+
+describe("CompositeActivityExecutor integration", () => {
+  it("routes tool_call to MCP, llm_call to LLM adapter, step to handler registry", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-mcp-"));
+    const manifestPath = path.join(dir, "manifest.json");
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        mcpServers: {
+          echoSrv: {
+            command: process.execPath,
+            args: [echoServerPath],
+            env: {},
+          },
+        },
+      })
+    );
+
+    const toolLoaded = await loadEngineDirectActivityExecutor(manifestPath);
+    assert.equal(toolLoaded.ok, true);
+    if (!toolLoaded.ok) return;
+
+    const stepRegistry = loadStepHandlerRegistryFromEnv(
+      { WORKFLOW_ENGINE_STEP_HANDLERS: '{"urn:composite:test":{"stepValue":"ok"}}' },
+      dir
+    );
+    assert.ok(stepRegistry);
+
+    /** @type {import("../src/orchestrator/llm-activity-executor.mjs").LlmProvider} */
+    const provider = {
+      async chatCompletion() {
+        return { content: JSON.stringify({ intent: "composite-llm" }) };
+      },
+    };
+
+    const composite = buildCompositeActivityExecutor({
+      tool_call: toolLoaded.executor,
+      llm_call: new LlmActivityExecutor({
+        operatorConfig: { apiKeyEnv: "K" },
+        env: { K: "sk" },
+        provider,
+      }),
+      step: new StepActivityExecutor({ registry: stepRegistry }),
+    });
+
+    const tool = await composite.executeActivity({
+      executionId: "composite-1",
+      node: { id: "tool-node", type: "tool_call", config: { server: "echoSrv", tool: "echo", arguments: { x: 1 } } },
+      state: {},
+    });
+    assert.equal(tool.ok, true);
+    if (tool.ok) assert.deepEqual(tool.output.echoed, { x: 1 });
+
+    const llm = await composite.executeActivity({
+      executionId: "composite-1",
+      node: { id: "llm-node", type: "llm_call", config: { model: "stub" } },
+      state: {},
+    });
+    assert.equal(llm.ok, true);
+    if (llm.ok) assert.equal(llm.output.intent, "composite-llm");
+
+    const step = await composite.executeActivity({
+      executionId: "composite-1",
+      node: { id: "step-node", type: "step", config: { handler: "urn:composite:test" } },
+      state: {},
+    });
+    assert.equal(step.ok, true);
+    if (step.ok) assert.equal(step.output.stepValue, "ok");
   });
 });
 

--- a/packages/engine/test/step-activity-executor.test.mjs
+++ b/packages/engine/test/step-activity-executor.test.mjs
@@ -1,0 +1,220 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { runLinearWorkflow } from "../src/orchestrator/linear-runner.mjs";
+import { MemoryExecutionHistoryStore } from "../src/persistence/memory-history-store.mjs";
+import {
+  parseStepNodeConfig,
+  StepActivityExecutor,
+  StepHandlerRegistry,
+} from "../src/orchestrator/step-activity-executor.mjs";
+
+describe("parseStepNodeConfig", () => {
+  it("requires handler URN", () => {
+    const r = parseStepNodeConfig({ code_ref: "x" });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "STEP_CONFIG_INVALID");
+  });
+
+  it("accepts handler string", () => {
+    const r = parseStepNodeConfig({ handler: "urn:test:handler" });
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.config.handler, "urn:test:handler");
+  });
+});
+
+describe("StepHandlerRegistry", () => {
+  it("registers and retrieves handlers", () => {
+    const registry = new StepHandlerRegistry();
+    const fn = async () => ({ a: 1 });
+    registry.register("urn:test:a", fn);
+    assert.equal(registry.get("urn:test:a"), fn);
+    assert.equal(registry.get("missing"), undefined);
+  });
+
+  it("createFrozenCopy rejects further register calls", () => {
+    const registry = new StepHandlerRegistry();
+    registry.register("urn:test:a", async () => ({}));
+    const frozen = registry.createFrozenCopy();
+    assert.throws(() => frozen.register("urn:test:b", async () => ({})), /frozen/);
+    assert.ok(frozen.get("urn:test:a"));
+  });
+});
+
+describe("StepActivityExecutor", () => {
+  it("rejects non-step nodes", async () => {
+    const registry = new StepHandlerRegistry();
+    const ex = new StepActivityExecutor({ registry: registry.createFrozenCopy() });
+    const r = await ex.executeActivity({
+      executionId: "e1",
+      node: { id: "n1", type: "llm_call", config: {} },
+      state: {},
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "ACTIVITY_EXECUTOR_UNSUPPORTED_NODE");
+  });
+
+  it("returns STEP_CONFIG_INVALID for missing handler", async () => {
+    const registry = new StepHandlerRegistry();
+    const ex = new StepActivityExecutor({ registry: registry.createFrozenCopy() });
+    const r = await ex.executeActivity({
+      executionId: "e1",
+      node: { id: "n1", type: "step", config: {} },
+      state: {},
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "STEP_CONFIG_INVALID");
+  });
+
+  it("returns HANDLER_NOT_FOUND for unknown URN", async () => {
+    const registry = new StepHandlerRegistry();
+    const ex = new StepActivityExecutor({ registry: registry.createFrozenCopy() });
+    const r = await ex.executeActivity({
+      executionId: "e1",
+      node: { id: "n1", type: "step", config: { handler: "urn:missing" } },
+      state: {},
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.code, "HANDLER_NOT_FOUND");
+      assert.match(r.error, /urn:missing/);
+    }
+  });
+
+  it("dispatches registered handler and returns plain object output", async () => {
+    const registry = new StepHandlerRegistry();
+    registry.register("urn:test:echo", async (ctx) => ({
+      echoed: ctx.state.input,
+      nodeId: ctx.node.id,
+    }));
+    const ex = new StepActivityExecutor({ registry: registry.createFrozenCopy() });
+    const r = await ex.executeActivity({
+      executionId: "e1",
+      node: { id: "work", type: "step", config: { handler: "urn:test:echo" } },
+      state: { input: "hello" },
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.output.echoed, "hello");
+      assert.equal(r.output.nodeId, "work");
+    }
+  });
+
+  it("passes through ActivityExecutorResult from handler", async () => {
+    const registry = new StepHandlerRegistry();
+    registry.register("urn:test:fail", async () => ({
+      ok: false,
+      error: "business rule",
+      code: "CUSTOM",
+    }));
+    const ex = new StepActivityExecutor({ registry: registry.createFrozenCopy() });
+    const r = await ex.executeActivity({
+      executionId: "e1",
+      node: { id: "work", type: "step", config: { handler: "urn:test:fail" } },
+      state: {},
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.code, "CUSTOM");
+      assert.equal(r.error, "business rule");
+    }
+  });
+
+  it("returns HANDLER_ERROR when handler throws", async () => {
+    const registry = new StepHandlerRegistry();
+    registry.register("urn:test:throw", async () => {
+      throw new Error("handler blew up");
+    });
+    const ex = new StepActivityExecutor({ registry: registry.createFrozenCopy() });
+    const r = await ex.executeActivity({
+      executionId: "e1",
+      node: { id: "work", type: "step", config: { handler: "urn:test:throw" } },
+      state: {},
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.code, "HANDLER_ERROR");
+      assert.match(r.error, /blew up/);
+    }
+  });
+});
+
+describe("StepActivityExecutor with linear runner", () => {
+  it("completes workflow when handler is registered", async () => {
+    const definition = {
+      document: {
+        schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
+        name: "step-linear",
+        version: "1.0.0",
+      },
+      state_schema: {
+        type: "object",
+        properties: { value: { type: "string" } },
+      },
+      nodes: [
+        { id: "begin", type: "start" },
+        {
+          id: "work",
+          type: "step",
+          config: { handler: "urn:test:produce" },
+        },
+        { id: "finish", type: "end", config: { output_mapping: ".value" } },
+      ],
+      edges: [
+        { source: "__start__", target: "begin" },
+        { source: "begin", target: "work" },
+        { source: "work", target: "finish" },
+      ],
+    };
+    const registry = new StepHandlerRegistry();
+    registry.register("urn:test:produce", async () => ({ value: "done" }));
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "exec-step-linear";
+    const out = await runLinearWorkflow({
+      definition,
+      input: {},
+      executionId,
+      store,
+      activityExecutor: new StepActivityExecutor({ registry: registry.createFrozenCopy() }),
+    });
+    assert.equal(out.status, "completed");
+    assert.equal(out.result, "done");
+    const failedRow = store.listByExecution(executionId).find((r) => r.name === "ActivityFailed");
+    assert.equal(failedRow, undefined);
+  });
+
+  it("emits ActivityFailed with HANDLER_NOT_FOUND when handler is missing", async () => {
+    const definition = {
+      document: {
+        schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
+        name: "step-linear-fail",
+        version: "1.0.0",
+      },
+      state_schema: { type: "object", properties: {} },
+      nodes: [
+        { id: "begin", type: "start" },
+        { id: "work", type: "step", config: { handler: "urn:test:missing" } },
+        { id: "finish", type: "end" },
+      ],
+      edges: [
+        { source: "__start__", target: "begin" },
+        { source: "begin", target: "work" },
+        { source: "work", target: "finish" },
+      ],
+    };
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "exec-step-fail";
+    const out = await runLinearWorkflow({
+      definition,
+      input: {},
+      executionId,
+      store,
+      activityExecutor: new StepActivityExecutor({
+        registry: new StepHandlerRegistry().createFrozenCopy(),
+      }),
+    });
+    assert.equal(out.status, "failed");
+    const failedRow = store.listByExecution(executionId).find((r) => r.name === "ActivityFailed");
+    assert.ok(failedRow);
+    assert.equal(failedRow.payload.code, "HANDLER_NOT_FOUND");
+  });
+});

--- a/scripts/docs-user-manifest.mjs
+++ b/scripts/docs-user-manifest.mjs
@@ -5,6 +5,7 @@
 export const USER_DOC_FILES = [
   "getting-started.md",
   "mcp-operator-guide.md",
+  "host-mediated-activities.md",
   "authoring-workflows.md",
   "node-reference.md",
   "state-jq-reducers.md",

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
   - Home: index.md
   - Getting started: getting-started.md
   - Run with MCP: mcp-operator-guide.md
+  - Host-mediated activities: host-mediated-activities.md
   - Author workflows:
       - Overview: authoring-workflows.md
       - Node reference: node-reference.md


### PR DESCRIPTION
## Summary

Implements epic [BEN-82](https://linear.app/ben-van-den-bergh/issue/BEN-82) (first child epic under GA 1.0 runtime stub replacement) with four feature commits:

- **BEN-93** — `LlmActivityExecutor` (engine-direct `llm_call`, injectable provider, AJV `output_schema`, env credentials)
- **BEN-90** — `StepHandlerRegistry` + `StepActivityExecutor` (`HANDLER_NOT_FOUND`, conformance replay vector)
- **BEN-91** — `CompositeActivityExecutor` routing + `workflows-engine-mcp` production wiring (`WORKFLOW_ENGINE_*` operator config, demo-profile-only stub fallback)
- **BEN-92** — Host-mediated activities user guide + lighthouse classify/tool_call parity vector

## Roadmap alignment

- Linear epic: BEN-82 (parent BEN-81 GA stub replacement umbrella)
- Target release: R4 GA 1.0
- Type: feature + docs/runway

## Spec and architecture traceability

- Spec artifact: `docs/engine-profile.md` (step handler registry note), `docs/user/host-mediated-activities.md`
- ADRs: ADR-0002 (host-mediated), ADR-0003 (engine-direct MCP)
- RFC trace: RFC-05 §5.2 (`workflow_submit_activity`), RFC-07 §7.3 (credentials outside workflow JSON)
- [x] Scope reviewed against `docs/engine-profile.md`
- [x] User docs + arc42 §6 cross-links updated for host-mediated path

## Architecture runway impact

- [x] Adds runway enabler for real activity completion (engine-direct + host-mediated) ahead of BEN-89 GA gate

## Test plan

- [x] `npm test` — 151 engine tests pass
- [x] `npm run conformance` — 48/48 vectors pass (incl. step-handler-dispatch, host-mediated-lighthouse-classify)
- [x] `npm run validate-workflows`
- [x] `npm run check-docs-nav-sync`

## Risk and rollback

- Risk level: medium (new default wiring paths for MCP bin; backward-compatible when operator env unset)
- Rollback: revert PR; stub default restored when no `WORKFLOW_ENGINE_*` config
