### PR TITLE
feat(engine): agent delegation production adapters (BEN-83)

### DIFF
--- a/conformance/parity-runner.mjs
+++ b/conformance/parity-runner.mjs
@@ -1,11 +1,13 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import {
+  A2ADelegateExecutor,
   createMcpWorkflowToolHandlers,
   createWorkflowApplicationPort,
   MemoryExecutionHistoryStore,
   StubActivityExecutor,
 } from "../packages/engine/src/index.mjs";
+import { createA2AMockHttpServer } from "../packages/engine/test/helpers/a2a-mock-http-server.mjs";
 
 /**
  * @typedef {"start" | "status" | "resume" | "submit_activity"} ParityOp
@@ -35,6 +37,7 @@ import {
  * @property {string} [pendingReason]
  * @property {string} definition
  * @property {string} executionId
+ * @property {boolean} [useProductionA2ADelegate] When true, wire A2ADelegateExecutor against in-process mock A2A HTTP.
  * @property {Record<string, Record<string, unknown>>} [stubActivityOutputs]
  * @property {ParityStep[]} steps
  */
@@ -358,6 +361,30 @@ async function executeStep(surface, port, handlers, definition, executionId, ste
 const allowPending =
   process.env.CONFORMANCE_ALLOW_PENDING === "1" || process.env.CONFORMANCE_ALLOW_PENDING === "true";
 
+/**
+ * @param {ParityVector} vector
+ * @returns {Promise<{ delegateExecutor?: import("../packages/engine/src/orchestrator/delegate-executor.mjs").DelegateExecutor; closeMockA2A?: () => Promise<void> }>}
+ */
+async function resolveParityDelegateExecutor(vector) {
+  if (!vector.useProductionA2ADelegate) {
+    return {};
+  }
+  const mock = createA2AMockHttpServer({ workingPolls: 1 });
+  const { baseUrl, close } = await mock.listen();
+  return {
+    delegateExecutor: new A2ADelegateExecutor({
+      operatorConfig: {
+        baseUrl,
+        apiKeyEnv: "CONFORMANCE_A2A_API_KEY",
+        pollIntervalMs: 10,
+        pollTimeoutMs: 5_000,
+      },
+      env: { CONFORMANCE_A2A_API_KEY: "conformance-a2a-token" },
+    }),
+    closeMockA2A: close,
+  };
+}
+
 export async function runParityVector(vector, repoRoot) {
   if (vector.pending) {
     const reason = vector.pendingReason ?? "Scenario pending implementation";
@@ -378,6 +405,7 @@ export async function runParityVector(vector, repoRoot) {
   const definitionPath = path.resolve(repoRoot, vector.definition);
   const definition = JSON.parse(readFileSync(definitionPath, "utf8"));
   const scenarioInput = vector.steps.find((s) => s.input)?.input ?? {};
+  const { delegateExecutor, closeMockA2A } = await resolveParityDelegateExecutor(vector);
 
   /**
    * @param {"port" | "mcp"} surface
@@ -389,6 +417,7 @@ export async function runParityVector(vector, repoRoot) {
       ...(vector.stubActivityOutputs
         ? { activityExecutor: new StubActivityExecutor(vector.stubActivityOutputs) }
         : {}),
+      ...(delegateExecutor ? { delegateExecutor } : {}),
     });
     const handlers = createMcpWorkflowToolHandlers(port);
     /** @type {Record<string, unknown>[]} */
@@ -437,24 +466,30 @@ export async function runParityVector(vector, repoRoot) {
     return { passed: true, snapshots };
   }
 
-  const portRun = await runScenario("port");
-  if (!portRun.passed) {
-    return portRun;
-  }
-  const mcpRun = await runScenario("mcp");
-  if (!mcpRun.passed) {
-    return mcpRun;
-  }
+  try {
+    const portRun = await runScenario("port");
+    if (!portRun.passed) {
+      return portRun;
+    }
+    const mcpRun = await runScenario("mcp");
+    if (!mcpRun.passed) {
+      return mcpRun;
+    }
 
-  for (let i = 0; i < portRun.snapshots.length; i += 1) {
-    if (!snapshotsEqual(portRun.snapshots[i], mcpRun.snapshots[i])) {
-      return {
-        passed: false,
-        reason: `Step index ${i} (${vector.steps[i].op}): port and MCP normalized snapshots differ`,
-        context: { port: portRun.snapshots[i], mcp: mcpRun.snapshots[i] },
-      };
+    for (let i = 0; i < portRun.snapshots.length; i += 1) {
+      if (!snapshotsEqual(portRun.snapshots[i], mcpRun.snapshots[i])) {
+        return {
+          passed: false,
+          reason: `Step index ${i} (${vector.steps[i].op}): port and MCP normalized snapshots differ`,
+          context: { port: portRun.snapshots[i], mcp: mcpRun.snapshots[i] },
+        };
+      }
+    }
+
+    return { passed: true, context: { stepCount: vector.steps.length } };
+  } finally {
+    if (closeMockA2A) {
+      await closeMockA2A();
     }
   }
-
-  return { passed: true, context: { stepCount: vector.steps.length } };
 }

--- a/conformance/parity-runner.mjs
+++ b/conformance/parity-runner.mjs
@@ -17,7 +17,7 @@ import {
  * @property {Record<string, unknown>} [input]
  * @property {Record<string, unknown>} [resumePayload]
  * @property {string} [nodeId]
- * @property {{ ok: true; result?: Record<string, unknown> } | { ok: false; error: string; code?: string }} [outcome]
+ * @property {{ ok: true; result?: Record<string, unknown>; delegateCorrelationId?: string; delegate_correlation_id?: string; externalTaskId?: string; external_task_id?: string } | { ok: false; error: string; code?: string }} [outcome]
  * @property {"in_process" | "host_mediated"} [activityExecutionMode]
  * @property {Record<string, Record<string, unknown>>} [stubActivityOutputs]
  * @property {object} [expectedParallelSpan]
@@ -76,6 +76,9 @@ function normalizePortSnapshot(op, portResult, isError, errorCode) {
       ...(r.delegateCorrelationId !== undefined
         ? { delegate_correlation_id: r.delegateCorrelationId }
         : {}),
+      ...(r.agentId !== undefined ? { agent_id: r.agentId } : {}),
+      ...(r.protocol !== undefined ? { protocol: r.protocol } : {}),
+      ...(r.delegateInput !== undefined ? { delegate_input: r.delegateInput } : {}),
       ...(r.childExecutionId !== undefined ? { child_execution_id: r.childExecutionId } : {}),
       ...(r.parentExecutionId !== undefined ? { parent_execution_id: r.parentExecutionId } : {}),
     };
@@ -95,6 +98,12 @@ function normalizePortSnapshot(op, portResult, isError, errorCode) {
     ...(r.nodeId !== undefined ? { node_id: r.nodeId } : {}),
     ...(r.state !== undefined ? { state: r.state } : {}),
     ...(r.code !== undefined ? { code: r.code } : {}),
+    ...(r.agentId !== undefined ? { agent_id: r.agentId } : {}),
+    ...(r.protocol !== undefined ? { protocol: r.protocol } : {}),
+    ...(r.delegateInput !== undefined ? { delegate_input: r.delegateInput } : {}),
+    ...(r.delegateCorrelationId !== undefined
+      ? { delegate_correlation_id: r.delegateCorrelationId }
+      : {}),
     ...(parallelSpan ? { parallel_span: parallelSpanToMcp(parallelSpan) } : {}),
   };
 }
@@ -126,6 +135,9 @@ function normalizeMcpSnapshot(op, mcpResult) {
     ...(s.delegate_correlation_id !== undefined
       ? { delegate_correlation_id: s.delegate_correlation_id }
       : {}),
+    ...(s.agent_id !== undefined ? { agent_id: s.agent_id } : {}),
+    ...(s.protocol !== undefined ? { protocol: s.protocol } : {}),
+    ...(s.delegate_input !== undefined ? { delegate_input: s.delegate_input } : {}),
     ...(s.child_execution_id !== undefined ? { child_execution_id: s.child_execution_id } : {}),
     ...(s.parent_execution_id !== undefined ? { parent_execution_id: s.parent_execution_id } : {}),
     ...(s.parallel_span !== undefined ? { parallel_span: s.parallel_span } : {}),
@@ -153,7 +165,51 @@ function snapshotMatchesExpect(snapshot, expect) {
  * @param {Record<string, unknown>} b
  */
 function snapshotsEqual(a, b) {
-  return JSON.stringify(a) === JSON.stringify(b);
+  return JSON.stringify(a, Object.keys(a).sort()) === JSON.stringify(b, Object.keys(b).sort());
+}
+
+/**
+ * @param {ParityStep["outcome"]} outcome
+ */
+function normalizeSubmitOutcomeForPort(outcome) {
+  if (!outcome || outcome.ok !== true) {
+    return outcome ?? { ok: true, result: {} };
+  }
+  return {
+    ok: true,
+    ...(outcome.result !== undefined ? { result: outcome.result } : {}),
+    ...((outcome.delegateCorrelationId ?? outcome.delegate_correlation_id) !== undefined
+      ? {
+          delegateCorrelationId:
+            outcome.delegateCorrelationId ?? outcome.delegate_correlation_id,
+        }
+      : {}),
+    ...((outcome.externalTaskId ?? outcome.external_task_id) !== undefined
+      ? { externalTaskId: outcome.externalTaskId ?? outcome.external_task_id }
+      : {}),
+  };
+}
+
+/**
+ * @param {ParityStep["outcome"]} outcome
+ */
+function normalizeSubmitOutcomeForMcp(outcome) {
+  if (!outcome || outcome.ok !== true) {
+    return outcome ?? { ok: true, result: {} };
+  }
+  return {
+    ok: true,
+    ...(outcome.result !== undefined ? { result: outcome.result } : {}),
+    ...((outcome.delegateCorrelationId ?? outcome.delegate_correlation_id) !== undefined
+      ? {
+          delegate_correlation_id:
+            outcome.delegateCorrelationId ?? outcome.delegate_correlation_id,
+        }
+      : {}),
+    ...((outcome.externalTaskId ?? outcome.external_task_id) !== undefined
+      ? { external_task_id: outcome.externalTaskId ?? outcome.external_task_id }
+      : {}),
+  };
 }
 
 /**
@@ -249,13 +305,15 @@ async function executeStep(surface, port, handlers, definition, executionId, ste
 
   if (step.op === "submit_activity") {
     const expectedParallelSpan = step.expectedParallelSpan;
+    const portOutcome = normalizeSubmitOutcomeForPort(step.outcome);
+    const mcpOutcome = normalizeSubmitOutcomeForMcp(step.outcome);
     if (surface === "port") {
       const portResult = await port.submitWorkflowActivity({
         executionId,
         definition,
         input: scenarioInput,
         nodeId: step.nodeId ?? "",
-        outcome: step.outcome ?? { ok: true, result: {} },
+        outcome: portOutcome,
         ...(expectedParallelSpan ? { expectedParallelSpan } : {}),
         ...(activityMode ? { activityExecutionMode: activityMode } : {}),
       });
@@ -283,7 +341,7 @@ async function executeStep(surface, port, handlers, definition, executionId, ste
       definition,
       input: scenarioInput,
       node_id: step.nodeId ?? "",
-      outcome: step.outcome ?? { ok: true, result: {} },
+      outcome: mcpOutcome,
       ...(mcpParallelSpan ? { parallel_span: mcpParallelSpan } : {}),
       ...(activityMode ? { activity_execution_mode: activityMode } : {}),
     });

--- a/conformance/vectors/parity/r3-a2a-delegate-executor.vector.json
+++ b/conformance/vectors/parity/r3-a2a-delegate-executor.vector.json
@@ -1,0 +1,22 @@
+{
+  "id": "parity.r3.a2a_delegate_executor",
+  "description": "agent_delegate completes via production A2ADelegateExecutor against in-process mock A2A HTTP server.",
+  "kind": "parity",
+  "useProductionA2ADelegate": true,
+  "definition": "examples/conformance-agent-delegate-linear.workflow.json",
+  "executionId": "parity-a2a-delegate-1",
+  "steps": [
+    {
+      "op": "start",
+      "input": { "task": "implement feature X" },
+      "expect": { "status": "completed" }
+    },
+    {
+      "op": "status",
+      "expect": {
+        "phase": "completed",
+        "delegate_correlation_id": "parity-a2a-delegate-1:delegate:implement"
+      }
+    }
+  ]
+}

--- a/conformance/vectors/parity/r3-host-mediated-delegate-submit.vector.json
+++ b/conformance/vectors/parity/r3-host-mediated-delegate-submit.vector.json
@@ -1,0 +1,45 @@
+{
+  "id": "parity.r3.host_mediated_delegate_submit",
+  "description": "Host-mediated agent_delegate yields awaiting_activity; submit with delegate_correlation_id completes.",
+  "kind": "parity",
+  "definition": "examples/conformance-agent-delegate-linear.workflow.json",
+  "executionId": "parity-host-delegate-1",
+  "steps": [
+    {
+      "op": "start",
+      "input": { "task": "implement feature X" },
+      "activityExecutionMode": "host_mediated",
+      "expect": {
+        "status": "awaiting_activity",
+        "node_id": "implement",
+        "agent_id": "coder",
+        "protocol": "a2a",
+        "delegate_input": { "task": "implement feature X" },
+        "delegate_correlation_id": "parity-host-delegate-1:delegate:implement"
+      }
+    },
+    {
+      "op": "status",
+      "expect": {
+        "phase": "awaiting_activity",
+        "current_node_id": "implement",
+        "agent_id": "coder",
+        "protocol": "a2a",
+        "delegate_input": { "task": "implement feature X" },
+        "delegate_correlation_id": "parity-host-delegate-1:delegate:implement"
+      }
+    },
+    {
+      "op": "submit_activity",
+      "nodeId": "implement",
+      "outcome": {
+        "ok": true,
+        "delegate_correlation_id": "parity-host-delegate-1:delegate:implement",
+        "external_task_id": "a2a-task-host-1",
+        "result": { "patch": "// host delegate patch", "delegate_status": "completed" }
+      },
+      "activityExecutionMode": "host_mediated",
+      "expect": { "status": "completed" }
+    }
+  ]
+}

--- a/conformance/vectors/replay/delegate/a2a-recorded-prefix-no-reinvoke.vector.json
+++ b/conformance/vectors/replay/delegate/a2a-recorded-prefix-no-reinvoke.vector.json
@@ -1,0 +1,79 @@
+{
+  "id": "replay.delegate.a2a_recorded_prefix_no_reinvoke",
+  "description": "Recorded ActivityCompleted from A2A delegate (externalTaskId from HTTP task); tail replay must not invoke executeDelegate.",
+  "kind": "replay",
+  "definition": "examples/conformance-agent-delegate-linear.workflow.json",
+  "input": { "task": "add unit tests" },
+  "assertNoDelegateExecutorInvocation": true,
+  "historyPrefix": [
+    {
+      "kind": "event",
+      "name": "ExecutionStarted",
+      "payload": {
+        "workflowName": "conformance-agent-delegate-linear",
+        "workflowVersion": "1.0.0",
+        "inputKeys": ["task"]
+      }
+    },
+    {
+      "kind": "command",
+      "name": "ScheduleNode",
+      "payload": { "nodeId": "start" }
+    },
+    {
+      "kind": "event",
+      "name": "NodeScheduled",
+      "payload": { "nodeId": "start" }
+    },
+    {
+      "kind": "command",
+      "name": "CompleteNode",
+      "payload": { "nodeId": "start", "output": {} }
+    },
+    {
+      "kind": "event",
+      "name": "StateUpdated",
+      "payload": { "nodeId": "start", "state": { "task": "add unit tests" } }
+    },
+    {
+      "kind": "command",
+      "name": "ScheduleNode",
+      "payload": { "nodeId": "implement" }
+    },
+    {
+      "kind": "event",
+      "name": "NodeScheduled",
+      "payload": { "nodeId": "implement" }
+    },
+    {
+      "kind": "event",
+      "name": "ActivityRequested",
+      "payload": {
+        "nodeId": "implement",
+        "nodeType": "agent_delegate",
+        "agentId": "coder",
+        "protocol": "a2a",
+        "delegateCorrelationId": "replay.delegate.a2a_recorded_prefix_no_reinvoke::exec:delegate:implement",
+        "delegateInput": { "task": "add unit tests" }
+      }
+    },
+    {
+      "kind": "event",
+      "name": "ActivityCompleted",
+      "payload": {
+        "nodeId": "implement",
+        "result": { "patch": "// A2A HTTP patch", "delegate_status": "completed" },
+        "delegateCorrelationId": "replay.delegate.a2a_recorded_prefix_no_reinvoke::exec:delegate:implement",
+        "externalTaskId": "a2a-task-http-42"
+      }
+    }
+  ],
+  "expect": {
+    "status": "completed",
+    "tailCommands": [
+      { "name": "CompleteNode", "nodeId": "implement" },
+      { "name": "ScheduleNode", "nodeId": "end" },
+      { "name": "CompleteNode", "nodeId": "end" }
+    ]
+  }
+}

--- a/conformance/vectors/replay/delegate/prefix-requested-submit-tail.vector.json
+++ b/conformance/vectors/replay/delegate/prefix-requested-submit-tail.vector.json
@@ -1,0 +1,81 @@
+{
+  "id": "replay.delegate.prefix_requested_submit_tail",
+  "description": "Replay prefix ends at ActivityRequested for agent_delegate; host_mediated yields; submit completes; tail commands are deterministic.",
+  "kind": "replay",
+  "definition": "examples/conformance-agent-delegate-linear.workflow.json",
+  "input": { "task": "add unit tests" },
+  "activityExecutionMode": "host_mediated",
+  "assertNoDelegateExecutorInvocation": true,
+  "historyPrefix": [
+    {
+      "kind": "event",
+      "name": "ExecutionStarted",
+      "payload": {
+        "workflowName": "conformance-agent-delegate-linear",
+        "workflowVersion": "1.0.0",
+        "inputKeys": ["task"]
+      }
+    },
+    {
+      "kind": "command",
+      "name": "ScheduleNode",
+      "payload": { "nodeId": "start" }
+    },
+    {
+      "kind": "event",
+      "name": "NodeScheduled",
+      "payload": { "nodeId": "start" }
+    },
+    {
+      "kind": "command",
+      "name": "CompleteNode",
+      "payload": { "nodeId": "start", "output": {} }
+    },
+    {
+      "kind": "event",
+      "name": "StateUpdated",
+      "payload": { "nodeId": "start", "state": { "task": "add unit tests" } }
+    },
+    {
+      "kind": "command",
+      "name": "ScheduleNode",
+      "payload": { "nodeId": "implement" }
+    },
+    {
+      "kind": "event",
+      "name": "NodeScheduled",
+      "payload": { "nodeId": "implement" }
+    },
+    {
+      "kind": "event",
+      "name": "ActivityRequested",
+      "payload": {
+        "nodeId": "implement",
+        "nodeType": "agent_delegate",
+        "agentId": "coder",
+        "protocol": "a2a",
+        "delegateCorrelationId": "replay.delegate.prefix_requested_submit_tail::exec:delegate:implement",
+        "delegateInput": { "task": "add unit tests" }
+      }
+    }
+  ],
+  "activitySubmissions": [
+    {
+      "nodeId": "implement",
+      "outcome": {
+        "ok": true,
+        "delegateCorrelationId": "replay.delegate.prefix_requested_submit_tail::exec:delegate:implement",
+        "externalTaskId": "a2a-task-replay-submit",
+        "result": { "patch": "// host replay submit", "delegate_status": "completed" }
+      }
+    }
+  ],
+  "expect": {
+    "status": "completed",
+    "tailCommands": [
+      { "name": "CompleteNode", "nodeId": "implement" },
+      { "name": "ScheduleNode", "nodeId": "end" },
+      { "name": "CompleteNode", "nodeId": "end" }
+    ]
+  }
+}

--- a/docs/architecture/arc42-assets/contracts/mcp-operator-manifest.md
+++ b/docs/architecture/arc42-assets/contracts/mcp-operator-manifest.md
@@ -16,7 +16,40 @@ The schema accepts **only** this top-level shape:
 - Required property: `mcpServers` — object whose keys are server labels and values are **stdio** definitions.
 - Each server **MUST** include `command` (non-empty string).
 - Optional: `args` (array of strings), `env` (object with string values only).
+- Optional: `delegateAgents` — maps workflow `agent_id` strings to MCP `{ server, tool }` bindings for `agent_delegate` nodes with `protocol: "mcp"`. Each binding **MUST** reference a key in `mcpServers`.
 - **No** additional properties are allowed on the root or on each server entry (unknown keys fail validation with AJV instance paths).
+
+## Delegate agent bindings (`delegateAgents`)
+
+For **`agent_delegate`** nodes with `protocol: "mcp"`, the reference engine's **`McpDelegateExecutor`** resolves the workflow `agent_id` to an MCP stdio invocation:
+
+| Manifest key | Purpose |
+|--------------|---------|
+| `delegateAgents.<agent_id>.server` | Label in `mcpServers` for the stdio subprocess |
+| `delegateAgents.<agent_id>.tool` | MCP tool name passed to `tools/call` |
+
+The resolved `input_mapping` payload is sent as the MCP tool `arguments` object. Stable failure codes: **`DELEGATE_AGENT_NOT_FOUND`** (unknown agent or server label), **`DELEGATE_PROTOCOL_ERROR`** (MCP wire/tool failure), **`DELEGATE_PROTOCOL_UNSUPPORTED`** (wrong protocol for the executor).
+
+Example fragment:
+
+```json
+{
+  "mcpServers": {
+    "coderAgent": {
+      "command": "node",
+      "args": ["./agents/coder-mcp-server.mjs"]
+    }
+  },
+  "delegateAgents": {
+    "urn:my-org:agents:coder": {
+      "server": "coderAgent",
+      "tool": "run_task"
+    }
+  }
+}
+```
+
+For in-process bridges without MCP, use **`SdkDelegateExecutor`** with a registered handler map keyed by `agent_id` (`protocol: "sdk"`).
 
 ## Resolution order (file path)
 

--- a/docs/user/a2a-delegate-mapping.md
+++ b/docs/user/a2a-delegate-mapping.md
@@ -1,0 +1,145 @@
+# A2A delegate mapping guide
+
+This guide describes how the reference engine's **`A2ADelegateExecutor`** maps `agent_delegate` nodes with `protocol: "a2a"` to an HTTP A2A task API. Workflow JSON carries **agent identity and input mapping only**; operator credentials and the A2A base URL live in **operator config** (environment variables), not in workflow documents (RFC-07 §7.3).
+
+For host-driven delegation (no in-process HTTP client), see [Host-mediated activities](host-mediated-activities.md).
+
+## When to use
+
+| Mode | Delegate port | Use case |
+|------|---------------|----------|
+| Default (omit `delegateExecutor`) | `MockA2ADelegateExecutor` | CI, demos, offline development |
+| `A2ADelegateExecutor` | HTTP submit + poll | Production A2A agent runtimes |
+| `activity_execution_mode: host_mediated` | None (host submits outcome) | Assistant hosts that own agent credentials |
+
+Wire the production executor when constructing the application port or graph walker:
+
+```javascript
+import { A2ADelegateExecutor, createWorkflowApplicationPort } from "@agent-workflow/engine";
+
+const port = createWorkflowApplicationPort({
+  store,
+  delegateExecutor: new A2ADelegateExecutor({
+    operatorConfig: {
+      baseUrl: process.env.A2A_BASE_URL,
+      apiKeyEnv: "A2A_API_KEY",
+      pollIntervalMs: 500,
+      pollTimeoutMs: 120_000,
+    },
+  }),
+});
+```
+
+## Operator configuration
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `baseUrl` | Yes | A2A HTTP API root (no trailing slash), e.g. `https://a2a.example.com` |
+| `apiKeyEnv` | Yes* | Env var holding the Bearer token sent as `Authorization: Bearer …` |
+| `apiKeySecretRef` | Yes* | Vault ref (deferred; use `apiKeyEnv` until vault resolver ships) |
+| `pollIntervalMs` | No | Poll interval while status is non-terminal (default `500`) |
+| `pollTimeoutMs` | No | Max wait for `completed` / `failed` (default `120000`) |
+
+\* One of `apiKeyEnv` or `apiKeySecretRef` is required.
+
+Example environment:
+
+```bash
+export A2A_BASE_URL=https://a2a.example.com
+export A2A_API_KEY=your-operator-token
+```
+
+## HTTP task API (reference mapping)
+
+The executor uses a minimal task surface aligned with RFC-06 A2A lifecycle semantics (`submitted` → `working` → `completed` / `failed`).
+
+### Submit task
+
+`POST {baseUrl}/tasks`
+
+Request:
+
+```json
+{
+  "agent_id": "coder",
+  "correlation_id": "{executionId}:delegate:{nodeId}",
+  "input": { "task": "implement feature X" }
+}
+```
+
+- `agent_id` — from `config.agent_id` on the `agent_delegate` node.
+- `correlation_id` — engine-minted `delegateCorrelationId` (`mintDelegateCorrelationId(executionId, nodeId)`).
+- `input` — resolved `input_mapping` payload (workflow state → delegate input).
+
+Response `201`:
+
+```json
+{
+  "id": "a2a-task-abc123",
+  "status": "submitted"
+}
+```
+
+### Poll task status
+
+`GET {baseUrl}/tasks/{id}`
+
+Response `200`:
+
+```json
+{
+  "id": "a2a-task-abc123",
+  "status": "working",
+  "output": { "patch": "// …", "delegate_status": "completed" },
+  "error": "optional when status is failed"
+}
+```
+
+Supported `status` values: `submitted`, `working`, `input-required`, `completed`, `failed`.
+
+- The executor polls until `completed` or `failed` (or timeout).
+- `input-required` is **not** handled in-process; use [host-mediated activities](host-mediated-activities.md) so the host can satisfy A2A input prompts and submit via `workflow_submit_activity`.
+
+### Authentication
+
+All requests send `Authorization: Bearer {apiKey}` where `apiKey` is resolved from operator config.
+
+## Workflow history correlation
+
+On in-process execution the engine emits:
+
+| Event | Fields |
+|-------|--------|
+| `ActivityRequested` | `delegateCorrelationId`, `agentId`, `protocol`, `delegateInput` |
+| `ActivityCompleted` | `delegateCorrelationId`, `externalTaskId` (= A2A task `id`), `result` (= task `output`) |
+| `ActivityFailed` | `error`, optional `code` |
+
+`delegateCorrelationId` is always `{executionId}:delegate:{nodeId}`. `externalTaskId` is the A2A server task id from submit/poll responses.
+
+## Stable error codes
+
+| Code | Meaning |
+|------|---------|
+| `A2A_CONFIG_INVALID` | Missing `baseUrl` or node `agent_id` |
+| `A2A_CREDENTIALS_MISSING` | `apiKeyEnv` unset/empty or unresolved `apiKeySecretRef` |
+| `A2A_PROVIDER_ERROR` | HTTP/transport failure or poll timeout |
+| `A2A_TASK_FAILED` | A2A task reached `failed` status |
+| `DELEGATE_PROTOCOL_UNSUPPORTED` | `A2ADelegateExecutor` invoked for non-`a2a` protocol |
+
+## Testing with the mock A2A server
+
+Engine tests and conformance use an in-process mock HTTP server (`packages/engine/test/helpers/a2a-mock-http-server.mjs`) implementing the same `/tasks` contract. Run the opt-in r3 multi-agent smoke in tests:
+
+```bash
+npm test -- --test-name-pattern "r3-multi-agent-coding implement"
+```
+
+Or run the full engine test suite:
+
+```bash
+npm test
+```
+
+## Vendor-specific adapters
+
+Real A2A deployments may use Agent Cards, SSE streaming, or different path layouts. Wrap those details in a custom `A2ATransport` implementation and inject it into `A2ADelegateExecutor({ transport })` while preserving `delegateCorrelationId` / `externalTaskId` on delegate results.

--- a/docs/user/host-mediated-activities.md
+++ b/docs/user/host-mediated-activities.md
@@ -42,9 +42,9 @@ Expected response: `status: "awaiting_activity"` with `node_id: "classify"` (fir
 
 For each activity boundary the engine yields **`awaiting_activity`**. The host loop is:
 
-1. **Read pending context** — from the tool result or `workflow_status`: `execution_id`, `node_id`, optional `parallel_span`, and workflow `state`.
-2. **Resolve the node** — look up `node_id` in the same `definition` object passed to `workflow_start` (type: `step`, `llm_call`, or `tool_call`; `config` holds model, tool, handler URN, etc.).
-3. **Perform work out of band** — invoke the host's LLM API, MCP `tools/call`, or registered step handler. Credentials and side effects stay on the host; the engine does not call your tools in this mode.
+1. **Read pending context** — from the tool result or `workflow_status`: `execution_id`, `node_id`, optional `parallel_span`, workflow `state`, and for **`agent_delegate`** nodes also `agent_id`, `protocol`, `delegate_input`, and `delegate_correlation_id`.
+2. **Resolve the node** — look up `node_id` in the same `definition` object passed to `workflow_start` (type: `step`, `llm_call`, `tool_call`, or `agent_delegate`; `config` holds model, tool, handler URN, or delegate target).
+3. **Perform work out of band** — invoke the host's LLM API, MCP `tools/call`, registered step handler, or external agent runtime (A2A/MCP/SDK per `agent_delegate` `protocol`). Credentials and side effects stay on the host; the engine does not call your tools or agents in this mode.
 4. **Submit the outcome** — call `workflow_submit_activity` with the **same** `definition` and `input` as the original start, matching `node_id`, and a typed `outcome`.
 5. **Repeat** — until status is `completed`, `failed`, or `interrupted` (then use `workflow_resume` for interrupt nodes).
 
@@ -65,6 +65,24 @@ For each activity boundary the engine yields **`awaiting_activity`**. The host l
 ```
 
 Success outcomes use `{ "ok": true, "result": { ... } }` (merged into workflow state per node completion). Failures use `{ "ok": false, "error": "...", "code": "..." }`.
+
+For **`agent_delegate`** nodes, include the **`delegate_correlation_id`** from the pending `ActivityRequested` (also exposed on start/status responses). Optionally pass **`external_task_id`** for the host-side agent task reference. The engine validates that the submitted correlation id matches the pending request before recording `ActivityCompleted`.
+
+```json
+{
+  "execution_id": "multi-agent-1",
+  "definition": "<same object as workflow_start>",
+  "input": { "task": "implement feature X" },
+  "node_id": "implement",
+  "activity_execution_mode": "host_mediated",
+  "outcome": {
+    "ok": true,
+    "delegate_correlation_id": "multi-agent-1:delegate:implement",
+    "external_task_id": "a2a-task-abc123",
+    "result": { "patch": "// agent output", "delegate_status": "completed" }
+  }
+}
+```
 
 Under **`parallel`**, include the same **`parallel_span`** the engine returned when submitting for a branch activity (see [MCP stdio host smoke runbook](../architecture/arc42-assets/runbooks/mcp-stdio-host-smoke.md)).
 
@@ -124,6 +142,20 @@ Fixture: `examples/lighthouse-customer-routing.workflow.json`.
 | 3. Complete `open_ticket` (`tool_call`) | Host calls `support-mcp` / `create_ticket`; submit tool result | `completed` with mapped intent/confidence |
 
 Conformance parity vector `parity.r2.host_mediated_lighthouse_classify` exercises the billing path (`classify` → `open_ticket` → `finish`) with simulated host submits.
+
+## `agent_delegate` host loop
+
+Fixture: `examples/conformance-agent-delegate-linear.workflow.json` (start → `implement` agent_delegate → end).
+
+| Step | Host action | Expected engine status |
+|------|-------------|------------------------|
+| 1. `workflow_start` with `host_mediated` | Pass `{ task }` input | `awaiting_activity`, `node_id: "implement"`, `agent_id: "coder"`, `protocol: "a2a"`, `delegate_input`, `delegate_correlation_id` |
+| 2. Invoke external agent | Host runs A2A/MCP/SDK agent using `delegate_input`; no engine delegate port call | (out of band) |
+| 3. `workflow_submit_activity` | Submit `result` plus matching `delegate_correlation_id` (and optional `external_task_id`) | `completed` with delegate output merged into state |
+
+The engine records `ActivityRequested` with `agentId`, `protocol`, `delegateInput`, and `delegateCorrelationId` in history. Replay with a prefix that already includes `ActivityCompleted` for the delegate node does **not** re-invoke the host or delegate port.
+
+Conformance vectors: `parity.r3.host_mediated_delegate_submit` (port/MCP parity) and `replay.delegate.prefix_requested_submit_tail` (prefix + submit replay tail).
 
 ## Related documentation
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ Golden definitions and **trace companions** for the engine profile ([docs/engine
 | [r2-research-parallel.workflow.json](./r2-research-parallel.workflow.json) | Parallel research branches with `join: all`. |
 | [r2-parallel-join-any.workflow.json](./r2-parallel-join-any.workflow.json) | Parallel join `any` policy. |
 | [r2-parallel-join-n2-of-3.workflow.json](./r2-parallel-join-n2-of-3.workflow.json) | Parallel join `n_of_m` policy. |
-| [r3-multi-agent-coding.workflow.json](./r3-multi-agent-coding.workflow.json) | Multi-agent coding with `agent_delegate`. |
+| [r3-multi-agent-coding.workflow.json](./r3-multi-agent-coding.workflow.json) | Multi-agent coding with `agent_delegate`. Default engine uses mock A2A; opt-in production path: [A2A delegate mapping](../docs/user/a2a-delegate-mapping.md) and `npm test -- --test-name-pattern "r3-multi-agent-coding implement"`. |
 | [r3-unit-tests-child.workflow.json](./r3-unit-tests-child.workflow.json) | Child workflow for subworkflow demos. |
 | [conformance-agent-delegate-linear.workflow.json](./conformance-agent-delegate-linear.workflow.json) | Conformance: delegate linear path. |
 | [conformance-subworkflow-parent.workflow.json](./conformance-subworkflow-parent.workflow.json) | Conformance: subworkflow parent. |

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -154,6 +154,35 @@ Pass the composite (or any custom `ActivityExecutor`) to `createWorkflowApplicat
 
 When **none** of these are set, the MCP adapter omits `activityExecutor` and the walker uses **`StubActivityExecutor`** (demo/local only). Set **`WORKFLOW_ENGINE_PROFILE=demo`** to add stub **fallback** inside a partial composite (unconfigured node types return `{}` instead of `COMPOSITE_EXECUTOR_NOT_CONFIGURED`). Do **not** rely on stub fallback in production deployments.
 
+### Delegate routing (`CompositeDelegateExecutor`)
+
+**`agent_delegate`** nodes run through a **`DelegateExecutor`** port (`executeDelegate(ctx)`). Omit `delegateExecutor` to use **`MockA2ADelegateExecutor`** (offline demos). Production adapters:
+
+| Executor | Protocol | Wiring |
+|----------|----------|--------|
+| `A2ADelegateExecutor` | `a2a` | HTTP submit + poll (`operatorConfig.baseUrl`, `apiKeyEnv`) |
+| `McpDelegateExecutor` | `mcp` | Operator manifest `delegateAgents` → MCP stdio `tools/call` |
+| `SdkDelegateExecutor` | `sdk` | In-process `Map<agent_id, handler>` (extension point for embedded agents) |
+
+Route multiple protocols with **`buildCompositeDelegateExecutor({ a2a, mcp, sdk })`**. Stable failure codes include **`DELEGATE_AGENT_NOT_FOUND`**, **`DELEGATE_PROTOCOL_ERROR`**, and **`DELEGATE_PROTOCOL_UNSUPPORTED`**. See [A2A delegate mapping](../../docs/user/a2a-delegate-mapping.md) and [MCP operator manifest](../../docs/architecture/arc42-assets/contracts/mcp-operator-manifest.md).
+
+```js
+import {
+  buildCompositeDelegateExecutor,
+  McpDelegateExecutor,
+  SdkDelegateExecutor,
+} from "@agent-workflow/engine";
+
+const delegateExecutor = buildCompositeDelegateExecutor({
+  mcp: new McpDelegateExecutor({ manifest }),
+  sdk: new SdkDelegateExecutor({
+    handlers: {
+      "urn:my-app:agents:local": async (input) => ({ patch: input.task }),
+    },
+  }),
+});
+```
+
 ### Host compatibility constraints for no-install use
 
 - **Node runtime:** Node.js `>=22.5.0` is required (uses `node:sqlite`).

--- a/packages/engine/schemas/mcp-operator-manifest.json
+++ b/packages/engine/schemas/mcp-operator-manifest.json
@@ -10,9 +10,22 @@
       "type": "object",
       "minProperties": 1,
       "additionalProperties": { "$ref": "#/$defs/stdioTransport" }
+    },
+    "delegateAgents": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/delegateAgentBinding" }
     }
   },
   "$defs": {
+    "delegateAgentBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["server", "tool"],
+      "properties": {
+        "server": { "type": "string", "minLength": 1 },
+        "tool": { "type": "string", "minLength": 1 }
+      }
+    },
     "stdioTransport": {
       "type": "object",
       "additionalProperties": false,

--- a/packages/engine/src/adapters/mcp/contracts.mjs
+++ b/packages/engine/src/adapters/mcp/contracts.mjs
@@ -36,6 +36,8 @@ export const workflowParallelSpanSchema = z.object({
 const activityOutcomeSuccessSchema = z.object({
   ok: z.literal(true),
   result: z.object({}).passthrough().optional(),
+  delegate_correlation_id: z.string().optional(),
+  external_task_id: z.string().optional(),
 });
 
 const activityOutcomeFailureSchema = z.object({
@@ -68,6 +70,10 @@ export const workflowStartResultSchema = z.object({
   node_id: z.string().optional(),
   state: z.object({}).passthrough().optional(),
   parallel_span: workflowParallelSpanSchema.optional(),
+  agent_id: z.string().optional(),
+  protocol: z.string().optional(),
+  delegate_input: z.object({}).passthrough().optional(),
+  delegate_correlation_id: z.string().optional(),
 });
 
 export const workflowStatusResultSchema = z.object({
@@ -78,6 +84,9 @@ export const workflowStatusResultSchema = z.object({
   delegate_correlation_id: z.string().optional(),
   child_execution_id: z.string().optional(),
   parent_execution_id: z.string().optional(),
+  agent_id: z.string().optional(),
+  protocol: z.string().optional(),
+  delegate_input: z.object({}).passthrough().optional(),
 });
 
 export const workflowResumeResultSchema = z.object({
@@ -89,6 +98,10 @@ export const workflowResumeResultSchema = z.object({
   node_id: z.string().optional(),
   state: z.object({}).passthrough().optional(),
   parallel_span: workflowParallelSpanSchema.optional(),
+  agent_id: z.string().optional(),
+  protocol: z.string().optional(),
+  delegate_input: z.object({}).passthrough().optional(),
+  delegate_correlation_id: z.string().optional(),
 });
 
 export const workflowSubmitActivityResultSchema = z.object({
@@ -101,4 +114,8 @@ export const workflowSubmitActivityResultSchema = z.object({
   state: z.object({}).passthrough().optional(),
   parallel_span: workflowParallelSpanSchema.optional(),
   code: z.string().optional(),
+  agent_id: z.string().optional(),
+  protocol: z.string().optional(),
+  delegate_input: z.object({}).passthrough().optional(),
+  delegate_correlation_id: z.string().optional(),
 });

--- a/packages/engine/src/adapters/mcp/workflow-tools.mjs
+++ b/packages/engine/src/adapters/mcp/workflow-tools.mjs
@@ -61,6 +61,20 @@ function withStructuredJsonInText(headline, structured) {
   return `${headline}\n\nStructured result (JSON):\n${JSON.stringify(structured, null, 2)}`;
 }
 
+/**
+ * @param {Record<string, unknown>} parsed
+ */
+function awaitingDelegateFieldsFromPort(parsed) {
+  return {
+    ...(parsed.agentId !== undefined ? { agent_id: parsed.agentId } : {}),
+    ...(parsed.protocol !== undefined ? { protocol: parsed.protocol } : {}),
+    ...(parsed.delegateInput !== undefined ? { delegate_input: parsed.delegateInput } : {}),
+    ...(parsed.delegateCorrelationId !== undefined
+      ? { delegate_correlation_id: parsed.delegateCorrelationId }
+      : {}),
+  };
+}
+
 function startResponseFromPort(parsed) {
   const parallelSpan = parsed.parallelSpan;
   const response = {
@@ -81,6 +95,7 @@ function startResponseFromPort(parsed) {
           },
         }
       : {}),
+    ...awaitingDelegateFieldsFromPort(parsed),
   };
   return workflowStartResultSchema.parse(response);
 }
@@ -99,6 +114,9 @@ function statusResponseFromPort(parsed) {
       : {}),
     ...(parsed.childExecutionId !== undefined ? { child_execution_id: parsed.childExecutionId } : {}),
     ...(parsed.parentExecutionId !== undefined ? { parent_execution_id: parsed.parentExecutionId } : {}),
+    ...(parsed.agentId !== undefined ? { agent_id: parsed.agentId } : {}),
+    ...(parsed.protocol !== undefined ? { protocol: parsed.protocol } : {}),
+    ...(parsed.delegateInput !== undefined ? { delegate_input: parsed.delegateInput } : {}),
   };
   return workflowStatusResultSchema.parse(response);
 }
@@ -126,6 +144,7 @@ function resumeResponseFromPort(parsed) {
           },
         }
       : {}),
+    ...awaitingDelegateFieldsFromPort(parsed),
   };
   return workflowResumeResultSchema.parse(response);
 }
@@ -154,6 +173,7 @@ function submitActivityResponseFromPort(parsed) {
           },
         }
       : {}),
+    ...awaitingDelegateFieldsFromPort(parsed),
   };
   return workflowSubmitActivityResultSchema.parse(response);
 }
@@ -305,7 +325,19 @@ export function createMcpWorkflowToolHandlers(workflowPort) {
           definition: parsed.definition,
           input: parsed.input,
           nodeId: parsed.node_id,
-          outcome: parsed.outcome,
+          outcome:
+            parsed.outcome.ok === true
+              ? {
+                  ok: true,
+                  ...(parsed.outcome.result !== undefined ? { result: parsed.outcome.result } : {}),
+                  ...(parsed.outcome.delegate_correlation_id !== undefined
+                    ? { delegateCorrelationId: parsed.outcome.delegate_correlation_id }
+                    : {}),
+                  ...(parsed.outcome.external_task_id !== undefined
+                    ? { externalTaskId: parsed.outcome.external_task_id }
+                    : {}),
+                }
+              : parsed.outcome,
           ...(expectedParallelSpan ? { expectedParallelSpan } : {}),
           ...(parsed.activity_execution_mode ? { activityExecutionMode: parsed.activity_execution_mode } : {}),
         });

--- a/packages/engine/src/application/workflow-application-port.mjs
+++ b/packages/engine/src/application/workflow-application-port.mjs
@@ -373,6 +373,7 @@ export function createWorkflowApplicationPort(deps) {
         executionId,
         store,
         ...(activityExecutor ? { activityExecutor } : {}),
+        ...(delegateExecutor ? { delegateExecutor } : {}),
         ...(request.activityExecutionMode ? { activityExecutionMode: request.activityExecutionMode } : {}),
       });
 
@@ -505,6 +506,7 @@ export function createWorkflowApplicationPort(deps) {
         ...(request.stubActivityOutputs ? { stubActivityOutputs: request.stubActivityOutputs } : {}),
         ...(request.activityExecutor ? { activityExecutor: request.activityExecutor } : {}),
         ...(!request.activityExecutor && activityExecutor ? { activityExecutor } : {}),
+        ...(delegateExecutor ? { delegateExecutor } : {}),
       });
 
       return {

--- a/packages/engine/src/application/workflow-application-port.mjs
+++ b/packages/engine/src/application/workflow-application-port.mjs
@@ -42,7 +42,7 @@ const PRIMARY_EVENT_NAMES = new Set(["ExecutionCompleted", "ExecutionFailed", "I
  * @property {object} definition
  * @property {Record<string, unknown>} input
  * @property {string} nodeId
- * @property {{ ok: true; result?: Record<string, unknown> } | { ok: false; error: string; code?: string }} outcome
+ * @property {{ ok: true; result?: Record<string, unknown>; delegateCorrelationId?: string; externalTaskId?: string } | { ok: false; error: string; code?: string }} outcome
  * @property {WorkflowParallelSpan} [expectedParallelSpan]
  * @property {"in_process" | "host_mediated"} [activityExecutionMode]
  * @property {Record<string, Record<string, unknown>>} [stubActivityOutputs]
@@ -59,6 +59,10 @@ const PRIMARY_EVENT_NAMES = new Set(["ExecutionCompleted", "ExecutionFailed", "I
  * @property {string | undefined} nodeId
  * @property {Record<string, unknown>} [state] Latest workflow state when status is `awaiting_activity`
  * @property {WorkflowParallelSpan} [parallelSpan] When the pending activity runs under a `parallel` branch
+ * @property {string} [agentId] Pending `agent_delegate` target agent id
+ * @property {string} [protocol] Pending `agent_delegate` protocol (`a2a`, `mcp`, `sdk`)
+ * @property {Record<string, unknown>} [delegateInput] Resolved delegate input from `input_mapping`
+ * @property {string} [delegateCorrelationId] Pending delegate correlation id
  */
 
 /**
@@ -70,6 +74,9 @@ const PRIMARY_EVENT_NAMES = new Set(["ExecutionCompleted", "ExecutionFailed", "I
  * @property {string | undefined} [delegateCorrelationId] Latest agent_delegate activity correlation
  * @property {string | undefined} [childExecutionId] Active or latest nested child execution id
  * @property {string | undefined} [parentExecutionId] Parent execution when nested or subworkflow context exists
+ * @property {string | undefined} [agentId] Pending `agent_delegate` target agent id when phase is `awaiting_activity`
+ * @property {string | undefined} [protocol] Pending delegate protocol when phase is `awaiting_activity`
+ * @property {Record<string, unknown>} [delegateInput] Resolved delegate input when phase is `awaiting_activity`
  */
 
 /**
@@ -83,6 +90,10 @@ const PRIMARY_EVENT_NAMES = new Set(["ExecutionCompleted", "ExecutionFailed", "I
  * @property {string | undefined} nodeId
  * @property {Record<string, unknown>} [state]
  * @property {WorkflowParallelSpan} [parallelSpan]
+ * @property {string} [agentId]
+ * @property {string} [protocol]
+ * @property {Record<string, unknown>} [delegateInput]
+ * @property {string} [delegateCorrelationId]
  */
 
 /**
@@ -96,7 +107,30 @@ const PRIMARY_EVENT_NAMES = new Set(["ExecutionCompleted", "ExecutionFailed", "I
  * @property {Record<string, unknown>} [state]
  * @property {WorkflowParallelSpan} [parallelSpan]
  * @property {string | undefined} [code] Stable machine code when `status` is `failed` from submit validation
+ * @property {string} [agentId]
+ * @property {string} [protocol]
+ * @property {Record<string, unknown>} [delegateInput]
+ * @property {string} [delegateCorrelationId]
  */
+
+/**
+ * @param {{
+ *   agentId?: string;
+ *   protocol?: string;
+ *   delegateInput?: Record<string, unknown>;
+ *   delegateCorrelationId?: string;
+ * }} runResult
+ */
+function awaitingDelegateFromRunResult(runResult) {
+  return {
+    ...(runResult.agentId !== undefined ? { agentId: runResult.agentId } : {}),
+    ...(runResult.protocol !== undefined ? { protocol: runResult.protocol } : {}),
+    ...(runResult.delegateInput !== undefined ? { delegateInput: runResult.delegateInput } : {}),
+    ...(runResult.delegateCorrelationId !== undefined
+      ? { delegateCorrelationId: runResult.delegateCorrelationId }
+      : {}),
+  };
+}
 
 /**
  * @param {import("../persistence/types.mjs").HistoryRow[]} rows
@@ -213,14 +247,62 @@ function latestSubworkflowCorrelation(rows, executionId) {
 
 /**
  * @param {import("../persistence/types.mjs").HistoryRow[]} rows
+ * @returns {Pick<WorkflowStatusResponse, "agentId" | "protocol" | "delegateInput" | "delegateCorrelationId">}
+ */
+function latestAwaitingDelegateContext(rows) {
+  const last = findLatestNonCheckpointEvent(rows);
+  if (!last || last.kind !== "event" || last.name !== "ActivityRequested") {
+    return {};
+  }
+  if (last.payload?.nodeType !== "agent_delegate") {
+    return {};
+  }
+  /** @type {Pick<WorkflowStatusResponse, "agentId" | "protocol" | "delegateInput" | "delegateCorrelationId">} */
+  const ctx = {};
+  if (typeof last.payload?.agentId === "string") {
+    ctx.agentId = last.payload.agentId;
+  }
+  if (typeof last.payload?.protocol === "string") {
+    ctx.protocol = last.payload.protocol;
+  }
+  if (
+    last.payload?.delegateInput &&
+    typeof last.payload.delegateInput === "object" &&
+    !Array.isArray(last.payload.delegateInput)
+  ) {
+    ctx.delegateInput = /** @type {Record<string, unknown>} */ (
+      JSON.parse(JSON.stringify(last.payload.delegateInput))
+    );
+  }
+  if (typeof last.payload?.delegateCorrelationId === "string") {
+    ctx.delegateCorrelationId = last.payload.delegateCorrelationId;
+  }
+  return ctx;
+}
+
+/**
+ * @param {import("../persistence/types.mjs").HistoryRow[]} rows
  * @param {string} executionId
  */
 function projectStatusCorrelation(rows, executionId) {
-  /** @type {Pick<WorkflowStatusResponse, "delegateCorrelationId" | "childExecutionId" | "parentExecutionId">} */
+  /** @type {Pick<WorkflowStatusResponse, "delegateCorrelationId" | "childExecutionId" | "parentExecutionId" | "agentId" | "protocol" | "delegateInput">} */
   const correlation = {};
   const delegateCorrelationId = latestDelegateCorrelationId(rows);
   if (delegateCorrelationId) {
     correlation.delegateCorrelationId = delegateCorrelationId;
+  }
+  const awaitingDelegate = latestAwaitingDelegateContext(rows);
+  if (awaitingDelegate.agentId) {
+    correlation.agentId = awaitingDelegate.agentId;
+  }
+  if (awaitingDelegate.protocol) {
+    correlation.protocol = awaitingDelegate.protocol;
+  }
+  if (awaitingDelegate.delegateInput) {
+    correlation.delegateInput = awaitingDelegate.delegateInput;
+  }
+  if (awaitingDelegate.delegateCorrelationId && !correlation.delegateCorrelationId) {
+    correlation.delegateCorrelationId = awaitingDelegate.delegateCorrelationId;
   }
   const subworkflow = latestSubworkflowCorrelation(rows, executionId);
   if (subworkflow?.childExecutionId) {
@@ -310,6 +392,7 @@ export function createWorkflowApplicationPort(deps) {
               nodeId: runResult.nodeId,
               state: runResult.state,
               ...(runResult.parallelSpan ? { parallelSpan: runResult.parallelSpan } : {}),
+              ...awaitingDelegateFromRunResult(runResult),
             }
           : {}),
       };
@@ -399,6 +482,7 @@ export function createWorkflowApplicationPort(deps) {
               nodeId: runResult.nodeId,
               state: runResult.state,
               ...(runResult.parallelSpan ? { parallelSpan: runResult.parallelSpan } : {}),
+              ...awaitingDelegateFromRunResult(runResult),
             }
           : {}),
       };
@@ -434,6 +518,7 @@ export function createWorkflowApplicationPort(deps) {
               nodeId: result.nodeId,
               ...(result.state ? { state: result.state } : {}),
               ...(result.parallelSpan ? { parallelSpan: result.parallelSpan } : {}),
+              ...awaitingDelegateFromRunResult(result),
             }
           : {}),
       };

--- a/packages/engine/src/config/mcp-operator-manifest.mjs
+++ b/packages/engine/src/config/mcp-operator-manifest.mjs
@@ -11,7 +11,8 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /** @typedef {{ command: string, args: string[], env: Record<string, string> }} McpStdioServerDefinition */
-/** @typedef {{ mcpServers: Record<string, McpStdioServerDefinition> }} NormalizedMcpOperatorManifest */
+/** @typedef {{ server: string, tool: string }} DelegateAgentBinding */
+/** @typedef {{ mcpServers: Record<string, McpStdioServerDefinition>, delegateAgents?: Record<string, DelegateAgentBinding> }} NormalizedMcpOperatorManifest */
 
 /**
  * @returns {string}
@@ -74,7 +75,22 @@ export function normalizeMcpOperatorManifest(data) {
       env: s.env && typeof s.env === "object" && !Array.isArray(s.env) ? { ...s.env } : {},
     };
   }
-  return { mcpServers };
+  /** @type {Record<string, DelegateAgentBinding> | undefined} */
+  let delegateAgents;
+  const rawAgents = data.delegateAgents;
+  if (rawAgents && typeof rawAgents === "object" && !Array.isArray(rawAgents)) {
+    delegateAgents = {};
+    for (const agentId of Object.keys(rawAgents)) {
+      const binding = rawAgents[agentId];
+      if (binding && typeof binding === "object") {
+        delegateAgents[agentId] = {
+          server: binding.server,
+          tool: binding.tool,
+        };
+      }
+    }
+  }
+  return delegateAgents ? { mcpServers, delegateAgents } : { mcpServers };
 }
 
 /**

--- a/packages/engine/src/index.mjs
+++ b/packages/engine/src/index.mjs
@@ -41,6 +41,19 @@ export {
   resolveA2AApiKey,
 } from "./orchestrator/a2a-delegate-executor.mjs";
 export {
+  buildCompositeDelegateExecutor,
+  CompositeDelegateExecutor,
+} from "./orchestrator/composite-delegate-executor.mjs";
+export {
+  mapMcpActivityResultToDelegateResult,
+  McpDelegateExecutor,
+  resolveDelegateAgentBinding,
+} from "./orchestrator/mcp-delegate-executor.mjs";
+export {
+  normalizeSdkDelegateHandlers,
+  SdkDelegateExecutor,
+} from "./orchestrator/sdk-delegate-executor.mjs";
+export {
   callMcpToolStdio,
   DEFAULT_MCP_ACTIVITY_TOOL_TIMEOUT_MS,
   mapMcpCallToolResultToActivityResult,

--- a/packages/engine/src/index.mjs
+++ b/packages/engine/src/index.mjs
@@ -33,6 +33,14 @@ export {
   mintDelegateCorrelationId,
 } from "./orchestrator/delegate-executor.mjs";
 export {
+  A2ADelegateExecutor,
+  HttpA2ATransport,
+  parseA2AOperatorConfig,
+  parseA2ATaskResponse,
+  pollA2ATaskUntilTerminal,
+  resolveA2AApiKey,
+} from "./orchestrator/a2a-delegate-executor.mjs";
+export {
   callMcpToolStdio,
   DEFAULT_MCP_ACTIVITY_TOOL_TIMEOUT_MS,
   mapMcpCallToolResultToActivityResult,

--- a/packages/engine/src/orchestrator/a2a-delegate-executor.mjs
+++ b/packages/engine/src/orchestrator/a2a-delegate-executor.mjs
@@ -1,0 +1,348 @@
+/**
+ * Production A2A delegate executor for `agent_delegate` nodes with `protocol: "a2a"`.
+ *
+ * Credentials and A2A base URL come from operator config (env / future vault refs), not workflow JSON (RFC-07 §7.3).
+ * Full `apiKeySecretRef` vault resolution is deferred to BEN-103.
+ *
+ * @see docs/user/a2a-delegate-mapping.md
+ */
+
+import { mintDelegateCorrelationId } from "./delegate-executor.mjs";
+
+/** @typedef {"A2A_CONFIG_INVALID" | "A2A_CREDENTIALS_MISSING" | "A2A_TASK_FAILED" | "A2A_PROVIDER_ERROR" | "DELEGATE_PROTOCOL_UNSUPPORTED"} A2ADelegateErrorCode */
+
+/**
+ * @typedef {object} A2AOperatorConfig
+ * @property {string} [baseUrl] A2A HTTP API base URL (required for production executor).
+ * @property {string} [apiKeyEnv] Env var name holding the Bearer token.
+ * @property {string} [apiKeySecretRef] Vault secret ref (full resolver in BEN-103).
+ * @property {number} [pollIntervalMs] Poll interval when task is not terminal (default 500).
+ * @property {number} [pollTimeoutMs] Max wait for terminal task status (default 120_000).
+ */
+
+/**
+ * @typedef {object} A2ATaskSubmitRequest
+ * @property {string} apiKey
+ * @property {string} agentId
+ * @property {string} correlationId
+ * @property {Record<string, unknown>} input
+ */
+
+/**
+ * @typedef {object} A2ATaskRecord
+ * @property {string} id
+ * @property {"submitted" | "working" | "input-required" | "completed" | "failed"} status
+ * @property {Record<string, unknown>} [output]
+ * @property {string} [error]
+ */
+
+/**
+ * Injectable A2A HTTP transport (mock in tests; default uses fetch).
+ *
+ * @typedef {object} A2ATransport
+ * @property {(req: A2ATaskSubmitRequest) => Promise<A2ATaskRecord>} submitTask
+ * @property {(apiKey: string, taskId: string) => Promise<A2ATaskRecord>} getTask
+ */
+
+/**
+ * @param {A2AOperatorConfig | undefined} operatorConfig
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {{ ok: true, apiKey: string } | { ok: false, error: string, code: "A2A_CREDENTIALS_MISSING" }}
+ */
+export function resolveA2AApiKey(operatorConfig, env = process.env) {
+  const cfg = operatorConfig && typeof operatorConfig === "object" ? operatorConfig : {};
+  const apiKeyEnv = typeof cfg.apiKeyEnv === "string" ? cfg.apiKeyEnv.trim() : "";
+  if (apiKeyEnv) {
+    const value = env[apiKeyEnv];
+    if (typeof value === "string" && value.trim() !== "") {
+      return { ok: true, apiKey: value };
+    }
+    return {
+      ok: false,
+      error: `A2A API key env var "${apiKeyEnv}" is unset or empty`,
+      code: "A2A_CREDENTIALS_MISSING",
+    };
+  }
+  const secretRef = typeof cfg.apiKeySecretRef === "string" ? cfg.apiKeySecretRef.trim() : "";
+  if (secretRef) {
+    return {
+      ok: false,
+      error: `apiKeySecretRef "${secretRef}" requires vault resolution (planned in BEN-103); set apiKeyEnv for now`,
+      code: "A2A_CREDENTIALS_MISSING",
+    };
+  }
+  return {
+    ok: false,
+    error: "A2A operator config requires apiKeyEnv or apiKeySecretRef",
+    code: "A2A_CREDENTIALS_MISSING",
+  };
+}
+
+/**
+ * @param {A2AOperatorConfig | undefined} operatorConfig
+ * @returns {{ ok: true, baseUrl: string, pollIntervalMs: number, pollTimeoutMs: number } | { ok: false, error: string, code: "A2A_CONFIG_INVALID" }}
+ */
+export function parseA2AOperatorConfig(operatorConfig) {
+  const cfg = operatorConfig && typeof operatorConfig === "object" ? operatorConfig : {};
+  const baseUrl = typeof cfg.baseUrl === "string" ? cfg.baseUrl.trim().replace(/\/$/, "") : "";
+  if (!baseUrl) {
+    return { ok: false, error: "A2A operator config requires baseUrl", code: "A2A_CONFIG_INVALID" };
+  }
+  const pollIntervalMs =
+    typeof cfg.pollIntervalMs === "number" && cfg.pollIntervalMs > 0 ? cfg.pollIntervalMs : 500;
+  const pollTimeoutMs =
+    typeof cfg.pollTimeoutMs === "number" && cfg.pollTimeoutMs > 0 ? cfg.pollTimeoutMs : 120_000;
+  return { ok: true, baseUrl, pollIntervalMs, pollTimeoutMs };
+}
+
+/**
+ * @param {unknown} body
+ * @returns {A2ATaskRecord}
+ */
+export function parseA2ATaskResponse(body) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error("A2A response body must be a JSON object");
+  }
+  const record = /** @type {Record<string, unknown>} */ (body);
+  const id = typeof record.id === "string" ? record.id.trim() : "";
+  const status = typeof record.status === "string" ? record.status.trim() : "";
+  if (!id) {
+    throw new Error("A2A response missing task id");
+  }
+  if (
+    status !== "submitted" &&
+    status !== "working" &&
+    status !== "input-required" &&
+    status !== "completed" &&
+    status !== "failed"
+  ) {
+    throw new Error(`A2A response has unsupported status "${status}"`);
+  }
+  const output =
+    record.output && typeof record.output === "object" && !Array.isArray(record.output)
+      ? /** @type {Record<string, unknown>} */ ({ .../** @type {object} */ (record.output) })
+      : undefined;
+  const error = typeof record.error === "string" ? record.error : undefined;
+  return {
+    id,
+    status: /** @type {A2ATaskRecord["status"]} */ (status),
+    ...(output ? { output } : {}),
+    ...(error ? { error } : {}),
+  };
+}
+
+/**
+ * Default fetch-based A2A HTTP client (POST /tasks, GET /tasks/:id).
+ *
+ * @implements {A2ATransport}
+ */
+export class HttpA2ATransport {
+  /**
+   * @param {{ baseUrl: string; fetchImpl?: typeof fetch }} opts
+   */
+  constructor(opts) {
+    this.baseUrl = opts.baseUrl.replace(/\/$/, "");
+    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  }
+
+  /**
+   * @param {A2ATaskSubmitRequest} req
+   * @returns {Promise<A2ATaskRecord>}
+   */
+  async submitTask(req) {
+    if (typeof this.fetchImpl !== "function") {
+      throw new Error("fetch is not available; inject fetchImpl on HttpA2ATransport");
+    }
+    const res = await this.fetchImpl(`${this.baseUrl}/tasks`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${req.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        agent_id: req.agentId,
+        correlation_id: req.correlationId,
+        input: req.input,
+      }),
+    });
+    const rawText = await res.text();
+    if (!res.ok) {
+      throw new Error(`A2A submit HTTP ${res.status}: ${rawText.slice(0, 500)}`);
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(rawText);
+    } catch {
+      throw new Error("A2A submit returned non-JSON response body");
+    }
+    return parseA2ATaskResponse(parsed);
+  }
+
+  /**
+   * @param {string} apiKey
+   * @param {string} taskId
+   * @returns {Promise<A2ATaskRecord>}
+   */
+  async getTask(apiKey, taskId) {
+    if (typeof this.fetchImpl !== "function") {
+      throw new Error("fetch is not available; inject fetchImpl on HttpA2ATransport");
+    }
+    const res = await this.fetchImpl(`${this.baseUrl}/tasks/${encodeURIComponent(taskId)}`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+    const rawText = await res.text();
+    if (!res.ok) {
+      throw new Error(`A2A poll HTTP ${res.status}: ${rawText.slice(0, 500)}`);
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(rawText);
+    } catch {
+      throw new Error("A2A poll returned non-JSON response body");
+    }
+    return parseA2ATaskResponse(parsed);
+  }
+}
+
+/**
+ * @param {A2ATransport} transport
+ * @param {string} apiKey
+ * @param {string} taskId
+ * @param {number} pollIntervalMs
+ * @param {number} pollTimeoutMs
+ * @returns {Promise<A2ATaskRecord>}
+ */
+export async function pollA2ATaskUntilTerminal(transport, apiKey, taskId, pollIntervalMs, pollTimeoutMs) {
+  const deadline = Date.now() + pollTimeoutMs;
+  /** @type {A2ATaskRecord | undefined} */
+  let latest;
+  while (Date.now() <= deadline) {
+    latest = await transport.getTask(apiKey, taskId);
+    if (latest.status === "completed" || latest.status === "failed") {
+      return latest;
+    }
+    if (latest.status === "input-required") {
+      throw new Error(
+        `A2A task "${taskId}" requires host input (input-required); use host_mediated activity mode for interactive delegates`
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+  const status = latest?.status ?? "unknown";
+  throw new Error(`A2A task "${taskId}" did not reach a terminal status within ${pollTimeoutMs}ms (last status: ${status})`);
+}
+
+/**
+ * Production delegate executor: submit A2A task, poll until completed/failed.
+ *
+ * @implements {import("./delegate-executor.mjs").DelegateExecutor}
+ */
+export class A2ADelegateExecutor {
+  /**
+   * @param {{
+   *   operatorConfig?: A2AOperatorConfig;
+   *   transport?: A2ATransport;
+   *   env?: NodeJS.ProcessEnv;
+   * }} [opts]
+   */
+  constructor(opts = {}) {
+    this.operatorConfig = opts.operatorConfig ?? {};
+    this.env = opts.env ?? process.env;
+    this.transport = opts.transport;
+  }
+
+  /**
+   * @param {import("./delegate-executor.mjs").DelegateExecutorContext} ctx
+   * @returns {Promise<import("./delegate-executor.mjs").DelegateExecutorResult>}
+   */
+  async executeDelegate(ctx) {
+    const { executionId, node, delegateInput, protocol } = ctx;
+    const delegateCorrelationId = mintDelegateCorrelationId(executionId, node.id);
+
+    if (protocol !== "a2a") {
+      return {
+        ok: false,
+        error: `A2ADelegateExecutor only supports protocol "a2a" (got "${protocol}")`,
+        code: "DELEGATE_PROTOCOL_UNSUPPORTED",
+      };
+    }
+
+    const parsedCfg = parseA2AOperatorConfig(this.operatorConfig);
+    if (!parsedCfg.ok) {
+      return { ok: false, error: parsedCfg.error, code: parsedCfg.code };
+    }
+
+    const keyResult = resolveA2AApiKey(this.operatorConfig, this.env);
+    if (!keyResult.ok) {
+      return { ok: false, error: keyResult.error, code: keyResult.code };
+    }
+
+    const cfg =
+      node.config && typeof node.config === "object"
+        ? /** @type {{ agent_id?: string }} */ (node.config)
+        : {};
+    const agentId = typeof cfg.agent_id === "string" ? cfg.agent_id.trim() : "";
+    if (!agentId) {
+      return { ok: false, error: `agent_delegate "${node.id}": agent_id is required`, code: "A2A_CONFIG_INVALID" };
+    }
+
+    const transport =
+      this.transport ??
+      new HttpA2ATransport({
+        baseUrl: parsedCfg.baseUrl,
+      });
+
+    let submitted;
+    try {
+      submitted = await transport.submitTask({
+        apiKey: keyResult.apiKey,
+        agentId,
+        correlationId: delegateCorrelationId,
+        input: delegateInput,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: message, code: "A2A_PROVIDER_ERROR" };
+    }
+
+    const externalTaskId = submitted.id;
+    let terminal = submitted;
+    if (submitted.status !== "completed" && submitted.status !== "failed") {
+      try {
+        terminal = await pollA2ATaskUntilTerminal(
+          transport,
+          keyResult.apiKey,
+          externalTaskId,
+          parsedCfg.pollIntervalMs,
+          parsedCfg.pollTimeoutMs
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { ok: false, error: message, code: "A2A_PROVIDER_ERROR" };
+      }
+    }
+
+    if (terminal.status === "failed") {
+      return {
+        ok: false,
+        error: terminal.error ?? `A2A task "${externalTaskId}" failed`,
+        code: "A2A_TASK_FAILED",
+      };
+    }
+
+    const output =
+      terminal.output && typeof terminal.output === "object" && !Array.isArray(terminal.output)
+        ? /** @type {Record<string, unknown>} */ ({ ...terminal.output })
+        : { delegate_status: "completed" };
+
+    return {
+      ok: true,
+      output,
+      delegateCorrelationId,
+      externalTaskId,
+    };
+  }
+}

--- a/packages/engine/src/orchestrator/composite-delegate-executor.mjs
+++ b/packages/engine/src/orchestrator/composite-delegate-executor.mjs
@@ -1,0 +1,80 @@
+/**
+ * Routes delegate execution by protocol to configured sub-executors (`a2a`, `mcp`, `sdk`).
+ */
+
+/** @typedef {"a2a" | "mcp" | "sdk"} RoutedDelegateProtocol */
+
+/** @type {ReadonlySet<string>} */
+const ROUTED_DELEGATE_PROTOCOLS = new Set(["a2a", "mcp", "sdk"]);
+
+/**
+ * @typedef {import("./delegate-executor.mjs").DelegateExecutor} DelegateExecutor
+ * @typedef {import("./delegate-executor.mjs").DelegateExecutorContext} DelegateExecutorContext
+ * @typedef {import("./delegate-executor.mjs").DelegateExecutorResult} DelegateExecutorResult
+ */
+
+/**
+ * @param {{
+ *   a2a?: DelegateExecutor;
+ *   mcp?: DelegateExecutor;
+ *   sdk?: DelegateExecutor;
+ *   fallback?: DelegateExecutor;
+ * }} subExecutors
+ */
+export function buildCompositeDelegateExecutor(subExecutors = {}) {
+  return new CompositeDelegateExecutor(subExecutors);
+}
+
+/**
+ * Composite {@link DelegateExecutor} that dispatches by `ctx.protocol`.
+ *
+ * @implements {DelegateExecutor}
+ */
+export class CompositeDelegateExecutor {
+  /**
+   * @param {{
+   *   a2a?: DelegateExecutor;
+   *   mcp?: DelegateExecutor;
+   *   sdk?: DelegateExecutor;
+   *   fallback?: DelegateExecutor;
+   * }} subExecutors
+   */
+  constructor(subExecutors = {}) {
+    /** @type {Partial<Record<RoutedDelegateProtocol, DelegateExecutor>>} */
+    this._executors = {
+      ...(subExecutors.a2a ? { a2a: subExecutors.a2a } : {}),
+      ...(subExecutors.mcp ? { mcp: subExecutors.mcp } : {}),
+      ...(subExecutors.sdk ? { sdk: subExecutors.sdk } : {}),
+    };
+    this._fallback = subExecutors.fallback;
+  }
+
+  /**
+   * @param {DelegateExecutorContext} ctx
+   * @returns {Promise<DelegateExecutorResult>}
+   */
+  async executeDelegate(ctx) {
+    const protocol = ctx.protocol;
+    if (!ROUTED_DELEGATE_PROTOCOLS.has(protocol)) {
+      return {
+        ok: false,
+        error: `CompositeDelegateExecutor does not route protocol "${protocol}"`,
+        code: "DELEGATE_PROTOCOL_UNSUPPORTED",
+      };
+    }
+    const executor = /** @type {RoutedDelegateProtocol} */ (protocol) in this._executors
+      ? this._executors[/** @type {RoutedDelegateProtocol} */ (protocol)]
+      : undefined;
+    if (executor) {
+      return executor.executeDelegate(ctx);
+    }
+    if (this._fallback) {
+      return this._fallback.executeDelegate(ctx);
+    }
+    return {
+      ok: false,
+      error: `No delegate executor configured for protocol "${protocol}"`,
+      code: "DELEGATE_PROTOCOL_UNSUPPORTED",
+    };
+  }
+}

--- a/packages/engine/src/orchestrator/delegate-runtime.mjs
+++ b/packages/engine/src/orchestrator/delegate-runtime.mjs
@@ -31,11 +31,20 @@ function unpackReplayDelegateResult(stored) {
  * @param {ReplayHydrationResult} args.replay
  * @param {DelegateExecutor} args.delegateExecutor
  * @param {boolean} [args.assertNoDelegateExecutorInvocation]
+ * @param {"in_process" | "host_mediated"} [args.activityExecutionMode]
  * @param {(name: string, payload: Record<string, unknown>) => number} args.appendEvt
  * @param {{ json: (data: unknown, query: string) => Promise<unknown> }} args.jq
  * @returns {Promise<
  *   | { kind: "completed"; output: Record<string, unknown> }
  *   | { kind: "failed"; error: string; code?: string }
+ *   | {
+ *       kind: "awaiting_activity";
+ *       nodeId: string;
+ *       agentId: string;
+ *       protocol: string;
+ *       delegateCorrelationId: string;
+ *       delegateInput: Record<string, unknown>;
+ *     }
  * >}
  */
 export async function executeDelegateNode(args) {
@@ -47,6 +56,7 @@ export async function executeDelegateNode(args) {
     replay,
     delegateExecutor,
     assertNoDelegateExecutorInvocation = false,
+    activityExecutionMode = "in_process",
     appendEvt,
     jq,
   } = args;
@@ -89,8 +99,54 @@ export async function executeDelegateNode(args) {
     return { kind: "completed", output };
   }
 
-  if (assertNoDelegateExecutorInvocation) {
-    return { kind: "failed", error: "agent_delegate invocation not allowed in this run" };
+  if (activityExecutionMode === "host_mediated") {
+    for (let i = replay.events.length - 1; i >= 0; i -= 1) {
+      const row = replay.events[i];
+      if (row.name !== "ActivityRequested" || row.payload?.nodeId !== node.id) {
+        continue;
+      }
+      if (row.payload?.nodeType !== "agent_delegate") {
+        break;
+      }
+      const hasLaterCompletion = replay.events.some(
+        (later) =>
+          later.seq > row.seq &&
+          later.name === "ActivityCompleted" &&
+          later.payload?.nodeId === node.id
+      );
+      if (hasLaterCompletion) {
+        break;
+      }
+      const pendingAgentId = typeof row.payload?.agentId === "string" ? row.payload.agentId : agentId;
+      const pendingProtocol = typeof row.payload?.protocol === "string" ? row.payload.protocol : protocol;
+      const pendingCorrelationId =
+        typeof row.payload?.delegateCorrelationId === "string"
+          ? row.payload.delegateCorrelationId
+          : mintDelegateCorrelationId(executionId, node.id);
+      const pendingInput =
+        row.payload?.delegateInput &&
+        typeof row.payload.delegateInput === "object" &&
+        !Array.isArray(row.payload.delegateInput)
+          ? /** @type {Record<string, unknown>} */ (JSON.parse(JSON.stringify(row.payload.delegateInput)))
+          : undefined;
+      let resolvedInput = pendingInput;
+      if (!resolvedInput) {
+        try {
+          resolvedInput = await applyInputMapping(state, inputMapping, jq);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          return { kind: "failed", error: msg };
+        }
+      }
+      return {
+        kind: "awaiting_activity",
+        nodeId: node.id,
+        agentId: pendingAgentId,
+        protocol: pendingProtocol,
+        delegateCorrelationId: pendingCorrelationId,
+        delegateInput: resolvedInput,
+      };
+    }
   }
 
   let delegateInput;
@@ -108,7 +164,23 @@ export async function executeDelegateNode(args) {
     agentId,
     protocol,
     delegateCorrelationId: preCorrelationId,
+    delegateInput: JSON.parse(JSON.stringify(delegateInput)),
   });
+
+  if (activityExecutionMode === "host_mediated") {
+    return {
+      kind: "awaiting_activity",
+      nodeId: node.id,
+      agentId,
+      protocol,
+      delegateCorrelationId: preCorrelationId,
+      delegateInput: JSON.parse(JSON.stringify(delegateInput)),
+    };
+  }
+
+  if (assertNoDelegateExecutorInvocation) {
+    return { kind: "failed", error: "agent_delegate invocation not allowed in this run" };
+  }
 
   const delegateResult = await delegateExecutor.executeDelegate({
     executionId,

--- a/packages/engine/src/orchestrator/mcp-delegate-executor.mjs
+++ b/packages/engine/src/orchestrator/mcp-delegate-executor.mjs
@@ -1,0 +1,155 @@
+/**
+ * Production MCP delegate executor for `agent_delegate` nodes with `protocol: "mcp"`.
+ *
+ * Routes workflow `agent_id` to `{ server, tool }` bindings in the operator manifest
+ * (`delegateAgents`), then invokes the MCP tool via stdio (`callMcpToolStdio`).
+ *
+ * @see docs/architecture/arc42-assets/contracts/mcp-operator-manifest.md
+ */
+
+import { mintDelegateCorrelationId } from "./delegate-executor.mjs";
+import {
+  callMcpToolStdio,
+  DEFAULT_MCP_ACTIVITY_TOOL_TIMEOUT_MS,
+} from "./mcp-stdio-activity-executor.mjs";
+
+/** @typedef {"DELEGATE_AGENT_NOT_FOUND" | "DELEGATE_PROTOCOL_ERROR" | "DELEGATE_PROTOCOL_UNSUPPORTED"} McpDelegateErrorCode */
+
+/**
+ * @typedef {object} DelegateAgentBinding
+ * @property {string} server MCP server label in `manifest.mcpServers`
+ * @property {string} tool MCP tool name
+ */
+
+/**
+ * @param {import("../config/mcp-operator-manifest.mjs").NormalizedMcpOperatorManifest} manifest
+ * @param {string} agentId
+ * @returns {{ ok: true; binding: DelegateAgentBinding } | { ok: false; error: string; code: "DELEGATE_AGENT_NOT_FOUND" }}
+ */
+export function resolveDelegateAgentBinding(manifest, agentId) {
+  const agents = manifest.delegateAgents;
+  if (!agents || typeof agents !== "object") {
+    return {
+      ok: false,
+      error: `No delegateAgents section in operator manifest (agent_id "${agentId}")`,
+      code: "DELEGATE_AGENT_NOT_FOUND",
+    };
+  }
+  const raw = agents[agentId];
+  if (!raw || typeof raw !== "object") {
+    return {
+      ok: false,
+      error: `No MCP delegate binding for agent_id "${agentId}"`,
+      code: "DELEGATE_AGENT_NOT_FOUND",
+    };
+  }
+  const server = typeof raw.server === "string" ? raw.server.trim() : "";
+  const tool = typeof raw.tool === "string" ? raw.tool.trim() : "";
+  if (!server || !tool) {
+    return {
+      ok: false,
+      error: `Delegate binding for agent_id "${agentId}" requires server and tool strings`,
+      code: "DELEGATE_AGENT_NOT_FOUND",
+    };
+  }
+  return { ok: true, binding: { server, tool } };
+}
+
+/**
+ * @param {import("./activity-executor.mjs").ActivityExecutorResult} activityResult
+ * @returns {import("./delegate-executor.mjs").DelegateExecutorResult}
+ */
+export function mapMcpActivityResultToDelegateResult(activityResult, delegateCorrelationId, externalTaskId) {
+  if (!activityResult.ok) {
+    return {
+      ok: false,
+      error: activityResult.error,
+      code: "DELEGATE_PROTOCOL_ERROR",
+    };
+  }
+  return {
+    ok: true,
+    output: activityResult.output,
+    delegateCorrelationId,
+    externalTaskId,
+  };
+}
+
+/**
+ * @implements {import("./delegate-executor.mjs").DelegateExecutor}
+ */
+export class McpDelegateExecutor {
+  /**
+   * @param {{
+   *   manifest: import("../config/mcp-operator-manifest.mjs").NormalizedMcpOperatorManifest;
+   *   defaultTimeoutMs?: number;
+   *   clientName?: string;
+   *   clientVersion?: string;
+   * }} opts
+   */
+  constructor(opts) {
+    this.manifest = opts.manifest;
+    this.defaultTimeoutMs = opts.defaultTimeoutMs ?? DEFAULT_MCP_ACTIVITY_TOOL_TIMEOUT_MS;
+    this.clientName = opts.clientName;
+    this.clientVersion = opts.clientVersion;
+  }
+
+  /**
+   * @param {import("./delegate-executor.mjs").DelegateExecutorContext} ctx
+   * @returns {Promise<import("./delegate-executor.mjs").DelegateExecutorResult>}
+   */
+  async executeDelegate(ctx) {
+    const { executionId, node, delegateInput, protocol } = ctx;
+    const delegateCorrelationId = mintDelegateCorrelationId(executionId, node.id);
+
+    if (protocol !== "mcp") {
+      return {
+        ok: false,
+        error: `McpDelegateExecutor only supports protocol "mcp" (got "${protocol}")`,
+        code: "DELEGATE_PROTOCOL_UNSUPPORTED",
+      };
+    }
+
+    const cfg =
+      node.config && typeof node.config === "object"
+        ? /** @type {{ agent_id?: string }} */ (node.config)
+        : {};
+    const agentId = typeof cfg.agent_id === "string" ? cfg.agent_id.trim() : "";
+    if (!agentId) {
+      return {
+        ok: false,
+        error: `agent_delegate "${node.id}": agent_id is required`,
+        code: "DELEGATE_AGENT_NOT_FOUND",
+      };
+    }
+
+    const bindingResult = resolveDelegateAgentBinding(this.manifest, agentId);
+    if (!bindingResult.ok) {
+      return bindingResult;
+    }
+    const { server: serverKey, tool: toolName } = bindingResult.binding;
+
+    const serverDef = this.manifest.mcpServers[serverKey];
+    if (!serverDef) {
+      return {
+        ok: false,
+        error: `Delegate agent "${agentId}" references MCP server "${serverKey}" which is not in mcpServers`,
+        code: "DELEGATE_AGENT_NOT_FOUND",
+      };
+    }
+
+    const externalTaskId = `mcp-task-${delegateCorrelationId.replace(/:/g, "-")}`;
+    const toolArguments =
+      delegateInput && typeof delegateInput === "object" && !Array.isArray(delegateInput)
+        ? /** @type {Record<string, unknown>} */ ({ ...delegateInput })
+        : {};
+
+    const activityResult = await callMcpToolStdio(serverDef, toolName, toolArguments, {
+      timeoutMs: this.defaultTimeoutMs,
+      clientName: this.clientName,
+      clientVersion: this.clientVersion,
+    });
+
+    return mapMcpActivityResultToDelegateResult(activityResult, delegateCorrelationId, externalTaskId);
+  }
+}

--- a/packages/engine/src/orchestrator/sdk-delegate-executor.mjs
+++ b/packages/engine/src/orchestrator/sdk-delegate-executor.mjs
@@ -1,0 +1,120 @@
+/**
+ * In-process SDK delegate executor for `agent_delegate` nodes with `protocol: "sdk"`.
+ *
+ * Operators register agent handlers in a `Map` (or plain object) keyed by `agent_id`.
+ * Each handler receives the resolved `delegateInput` and returns workflow output.
+ * Use this as the extension point for embedding trusted in-process agent bridges
+ * without MCP or A2A wire protocols.
+ */
+
+import { mintDelegateCorrelationId } from "./delegate-executor.mjs";
+
+/** @typedef {"DELEGATE_AGENT_NOT_FOUND" | "DELEGATE_PROTOCOL_ERROR" | "DELEGATE_PROTOCOL_UNSUPPORTED"} SdkDelegateErrorCode */
+
+/**
+ * @typedef {(delegateInput: Record<string, unknown>) => Promise<Record<string, unknown>> | Record<string, unknown>} SdkDelegateHandler
+ */
+
+/**
+ * @param {Map<string, SdkDelegateHandler> | Record<string, SdkDelegateHandler> | undefined} handlers
+ * @returns {Map<string, SdkDelegateHandler>}
+ */
+export function normalizeSdkDelegateHandlers(handlers) {
+  if (handlers instanceof Map) {
+    return new Map(handlers);
+  }
+  if (handlers && typeof handlers === "object") {
+    return new Map(Object.entries(handlers));
+  }
+  return new Map();
+}
+
+/**
+ * @implements {import("./delegate-executor.mjs").DelegateExecutor}
+ */
+export class SdkDelegateExecutor {
+  /**
+   * @param {{
+   *   handlers?: Map<string, SdkDelegateHandler> | Record<string, SdkDelegateHandler>;
+   * }} [opts]
+   */
+  constructor(opts = {}) {
+    this.handlers = normalizeSdkDelegateHandlers(opts.handlers);
+  }
+
+  /**
+   * Register or replace a handler for an agent_id (extension point for host wiring).
+   *
+   * @param {string} agentId
+   * @param {SdkDelegateHandler} handler
+   */
+  registerHandler(agentId, handler) {
+    this.handlers.set(agentId, handler);
+  }
+
+  /**
+   * @param {import("./delegate-executor.mjs").DelegateExecutorContext} ctx
+   * @returns {Promise<import("./delegate-executor.mjs").DelegateExecutorResult>}
+   */
+  async executeDelegate(ctx) {
+    const { executionId, node, delegateInput, protocol } = ctx;
+    const delegateCorrelationId = mintDelegateCorrelationId(executionId, node.id);
+
+    if (protocol !== "sdk") {
+      return {
+        ok: false,
+        error: `SdkDelegateExecutor only supports protocol "sdk" (got "${protocol}")`,
+        code: "DELEGATE_PROTOCOL_UNSUPPORTED",
+      };
+    }
+
+    const cfg =
+      node.config && typeof node.config === "object"
+        ? /** @type {{ agent_id?: string }} */ (node.config)
+        : {};
+    const agentId = typeof cfg.agent_id === "string" ? cfg.agent_id.trim() : "";
+    if (!agentId) {
+      return {
+        ok: false,
+        error: `agent_delegate "${node.id}": agent_id is required`,
+        code: "DELEGATE_AGENT_NOT_FOUND",
+      };
+    }
+
+    const handler = this.handlers.get(agentId);
+    if (!handler) {
+      return {
+        ok: false,
+        error: `No SDK delegate handler registered for agent_id "${agentId}"`,
+        code: "DELEGATE_AGENT_NOT_FOUND",
+      };
+    }
+
+    const externalTaskId = `sdk-task-${delegateCorrelationId.replace(/:/g, "-")}`;
+
+    try {
+      const raw = await handler(
+        delegateInput && typeof delegateInput === "object" && !Array.isArray(delegateInput)
+          ? /** @type {Record<string, unknown>} */ ({ ...delegateInput })
+          : {}
+      );
+      const output =
+        raw && typeof raw === "object" && !Array.isArray(raw)
+          ? /** @type {Record<string, unknown>} */ ({ ...raw })
+          : { delegate_status: "completed" };
+      return {
+        ok: true,
+        output,
+        delegateCorrelationId,
+        externalTaskId,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        ok: false,
+        error: message,
+        code: "DELEGATE_PROTOCOL_ERROR",
+      };
+    }
+  }
+}

--- a/packages/engine/src/orchestrator/workflow-graph-walker-support.mjs
+++ b/packages/engine/src/orchestrator/workflow-graph-walker-support.mjs
@@ -193,8 +193,43 @@ export function findLatestNonCheckpointEvent(rows) {
   return undefined;
 }
 
-/** Node types completed via host `submitActivityOutcome` (step / llm_call / tool_call). */
-const HOST_ACTIVITY_NODE_TYPES = new Set(["step", "llm_call", "tool_call"]);
+/**
+ * Latest `ActivityRequested` that has no later `ActivityCompleted` for the same node (host submit target).
+ *
+ * @param {import("../persistence/types.mjs").HistoryRow[]} rows
+ * @returns {import("../persistence/types.mjs").HistoryRow | undefined}
+ */
+export function findPendingActivityRequest(rows) {
+  const last = findLatestNonCheckpointEvent(rows);
+  if (last?.kind === "event" && last.name === "ActivityRequested") {
+    return last;
+  }
+  for (let i = rows.length - 1; i >= 0; i -= 1) {
+    const row = rows[i];
+    if (row.kind !== "event" || row.name !== "ActivityRequested") {
+      continue;
+    }
+    const nodeId = typeof row.payload?.nodeId === "string" ? row.payload.nodeId : "";
+    if (!nodeId) {
+      continue;
+    }
+    const hasLaterCompletion = rows.some(
+      (later) =>
+        later.seq > row.seq &&
+        later.kind === "event" &&
+        later.name === "ActivityCompleted" &&
+        later.payload?.nodeId === nodeId
+    );
+    if (!hasLaterCompletion) {
+      return row;
+    }
+    break;
+  }
+  return undefined;
+}
+
+/** Node types completed via host `submitActivityOutcome` (step / llm_call / tool_call / agent_delegate). */
+const HOST_ACTIVITY_NODE_TYPES = new Set(["step", "llm_call", "tool_call", "agent_delegate"]);
 
 /**
  * Host-mediated submit (or in-process crash recovery for placeholder activities) left

--- a/packages/engine/src/orchestrator/workflow-graph-walker.mjs
+++ b/packages/engine/src/orchestrator/workflow-graph-walker.mjs
@@ -37,6 +37,7 @@ import {
   commandIdentity,
   expectedCommandIdentity,
   findLatestNonCheckpointEvent,
+  findPendingActivityRequest,
   isParallelSpanPayload,
   isPendingActivityCompletionContinuation,
   latestPrimaryEvent,
@@ -56,6 +57,7 @@ function loadJq() {
 }
 
 const PLACEHOLDER_TYPES = new Set(["step", "llm_call", "tool_call"]);
+const HOST_SUBMIT_NODE_TYPES = new Set([...PLACEHOLDER_TYPES, "agent_delegate"]);
 
 /**
  * @typedef {import("./workflow-node-execution.mjs").ParallelSpanPayload} ParallelSpanPayload
@@ -80,7 +82,7 @@ const PLACEHOLDER_TYPES = new Set(["step", "llm_call", "tool_call"]);
  *   | { status: "completed"; finalState: Record<string, unknown>; result?: unknown }
  *   | { status: "failed"; error: string; finalState?: Record<string, unknown> }
  *   | { status: "interrupted"; executionId: string; nodeId: string; state: Record<string, unknown> }
- *   | { status: "awaiting_activity"; executionId: string; nodeId: string; state: Record<string, unknown>; parallelSpan?: ParallelSpanPayload }
+ *   | { status: "awaiting_activity"; executionId: string; nodeId: string; state: Record<string, unknown>; parallelSpan?: ParallelSpanPayload; agentId?: string; protocol?: string; delegateInput?: Record<string, unknown>; delegateCorrelationId?: string }
  * >}
  */
 export async function runGraphWorkflow(options) {
@@ -330,7 +332,7 @@ export async function runGraphWorkflow(options) {
       const activityNodeId =
         lastCompleted && typeof lastCompleted.payload?.nodeId === "string" ? lastCompleted.payload.nodeId : "";
       const activityNode = activityNodeId ? byId.get(activityNodeId) : undefined;
-      if (!activityNode || !PLACEHOLDER_TYPES.has(activityNode.type)) {
+      if (!activityNode || !HOST_SUBMIT_NODE_TYPES.has(activityNode.type)) {
         throw new Error(`Cannot continue: pending activity node "${activityNodeId}" is missing or invalid.`);
       }
 
@@ -573,9 +575,22 @@ export async function runGraphWorkflow(options) {
           replay,
           delegateExecutor: delegatePort,
           assertNoDelegateExecutorInvocation,
+          activityExecutionMode,
           appendEvt,
           jq,
         });
+        if (del.kind === "awaiting_activity") {
+          return {
+            status: "awaiting_activity",
+            executionId,
+            nodeId: del.nodeId,
+            state: JSON.parse(JSON.stringify(state)),
+            agentId: del.agentId,
+            protocol: del.protocol,
+            delegateInput: del.delegateInput,
+            delegateCorrelationId: del.delegateCorrelationId,
+          };
+        }
         if (del.kind === "failed") {
           appendCmd("FailNode", {
             nodeId: current,
@@ -728,7 +743,7 @@ export async function runGraphWorkflow(options) {
  *   | { status: "completed"; finalState: Record<string, unknown>; result?: unknown }
  *   | { status: "failed"; error: string; finalState?: Record<string, unknown> }
  *   | { status: "interrupted"; executionId: string; nodeId: string; state: Record<string, unknown> }
- *   | { status: "awaiting_activity"; executionId: string; nodeId: string; state: Record<string, unknown>; parallelSpan?: ParallelSpanPayload }
+ *   | { status: "awaiting_activity"; executionId: string; nodeId: string; state: Record<string, unknown>; parallelSpan?: ParallelSpanPayload; agentId?: string; protocol?: string; delegateInput?: Record<string, unknown>; delegateCorrelationId?: string }
  * >}
  */
 export async function resumeGraphWorkflow(options) {
@@ -1236,9 +1251,22 @@ export async function resumeGraphWorkflow(options) {
           replay: /** @type {import("./replay-loader.mjs").ReplayHydrationResult} */ (emptyReplay),
           delegateExecutor: delegatePort,
           assertNoDelegateExecutorInvocation,
+          activityExecutionMode,
           appendEvt,
           jq,
         });
+        if (del.kind === "awaiting_activity") {
+          return {
+            status: "awaiting_activity",
+            executionId,
+            nodeId: del.nodeId,
+            state: JSON.parse(JSON.stringify(state)),
+            agentId: del.agentId,
+            protocol: del.protocol,
+            delegateInput: del.delegateInput,
+            delegateCorrelationId: del.delegateCorrelationId,
+          };
+        }
         if (del.kind === "failed") {
           appendCmd("FailNode", {
             nodeId: current,
@@ -1365,7 +1393,7 @@ export async function resumeGraphWorkflow(options) {
  * @property {import("../persistence/types.mjs").ExecutionHistoryStore} store
  * @property {Record<string, unknown>} input Same `input` as the initial `runGraphWorkflow` / `startWorkflow` call (replay reconstruction requires it).
  * @property {string} nodeId Activity node id matching the pending `ActivityRequested` event.
- * @property {{ ok: true; result?: Record<string, unknown> } | { ok: false; error: string; code?: string }} outcome
+ * @property {{ ok: true; result?: Record<string, unknown>; delegateCorrelationId?: string; externalTaskId?: string } | { ok: false; error: string; code?: string }} outcome
  * @property {ParallelSpanPayload} [expectedParallelSpan] Required when the pending request carries `parallelSpan` (parallel branches); must match exactly.
  * @property {"in_process" | "host_mediated"} [activityExecutionMode] Continuation mode for any further activities (default `host_mediated`).
  * @property {Record<string, Record<string, unknown>>} [stubActivityOutputs]
@@ -1383,7 +1411,7 @@ export async function resumeGraphWorkflow(options) {
  *   | { status: "completed"; finalState: Record<string, unknown>; result?: unknown }
  *   | { status: "failed"; error: string; finalState?: Record<string, unknown>; code?: string }
  *   | { status: "interrupted"; executionId: string; nodeId: string; state: Record<string, unknown> }
- *   | { status: "awaiting_activity"; executionId: string; nodeId: string; state: Record<string, unknown>; parallelSpan?: ParallelSpanPayload }
+ *   | { status: "awaiting_activity"; executionId: string; nodeId: string; state: Record<string, unknown>; parallelSpan?: ParallelSpanPayload; agentId?: string; protocol?: string; delegateInput?: Record<string, unknown>; delegateCorrelationId?: string }
  * >}
  */
 export async function submitActivityOutcome(options) {
@@ -1454,7 +1482,7 @@ export async function submitActivityOutcome(options) {
     return { status: "failed", error: definitionBind.error, code: "SUBMIT_VALIDATION_ERROR" };
   }
 
-  const last = findLatestNonCheckpointEvent(rows);
+  const last = findPendingActivityRequest(rows);
   if (!last || last.kind !== "event" || last.name !== "ActivityRequested") {
     return {
       status: "failed",
@@ -1522,6 +1550,49 @@ export async function submitActivityOutcome(options) {
   const completedNode = validateWorkflowDefinition(definition).ok
     ? /** @type {{ nodes?: Array<{ id: string; type: string }> }} */ (definition).nodes?.find((n) => n.id === nodeId)
     : undefined;
+  const pendingNodeType =
+    typeof last.payload?.nodeType === "string"
+      ? last.payload.nodeType
+      : completedNode?.type;
+  const isDelegateSubmit = pendingNodeType === "agent_delegate";
+  const expectedDelegateCorrelationId =
+    typeof last.payload?.delegateCorrelationId === "string" ? last.payload.delegateCorrelationId : undefined;
+  const submittedDelegateCorrelationId =
+    typeof outcome.delegateCorrelationId === "string"
+      ? outcome.delegateCorrelationId
+      : typeof resultObj.delegateCorrelationId === "string"
+        ? resultObj.delegateCorrelationId
+        : undefined;
+  const submittedExternalTaskId =
+    typeof outcome.externalTaskId === "string"
+      ? outcome.externalTaskId
+      : typeof resultObj.externalTaskId === "string"
+        ? resultObj.externalTaskId
+        : undefined;
+
+  if (isDelegateSubmit) {
+    if (!expectedDelegateCorrelationId) {
+      return {
+        status: "failed",
+        error: "Pending agent_delegate ActivityRequested is missing delegateCorrelationId.",
+        code: "SUBMIT_VALIDATION_ERROR",
+      };
+    }
+    if (submittedDelegateCorrelationId !== expectedDelegateCorrelationId) {
+      return {
+        status: "failed",
+        error: `Activity submit delegateCorrelationId "${submittedDelegateCorrelationId ?? ""}" does not match pending "${expectedDelegateCorrelationId}".`,
+        code: "SUBMIT_VALIDATION_ERROR",
+      };
+    }
+  }
+
+  const storedResult = JSON.parse(JSON.stringify(resultObj));
+  if (isDelegateSubmit) {
+    delete storedResult.delegateCorrelationId;
+    delete storedResult.externalTaskId;
+  }
+
   const pendingSpan = isParallelSpanPayload(reqSpan) ? reqSpan : undefined;
   store.append(executionId, {
     kind: "event",
@@ -1531,7 +1602,11 @@ export async function submitActivityOutcome(options) {
       nodeId,
       ...(completedNode?.type ? { nodeType: completedNode.type } : {}),
       ...(pendingSpan ? { parallelSpan: { ...pendingSpan } } : {}),
-      result: resultObj,
+      result: storedResult,
+      ...(isDelegateSubmit && expectedDelegateCorrelationId
+        ? { delegateCorrelationId: expectedDelegateCorrelationId }
+        : {}),
+      ...(isDelegateSubmit && submittedExternalTaskId ? { externalTaskId: submittedExternalTaskId } : {}),
     },
   });
 

--- a/packages/engine/test/a2a-delegate-executor.test.mjs
+++ b/packages/engine/test/a2a-delegate-executor.test.mjs
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+import { findWorkflowRepoRoot } from "../src/validate.mjs";
+import { MemoryExecutionHistoryStore } from "../src/persistence/memory-history-store.mjs";
+import { runGraphWorkflow } from "../src/orchestrator/workflow-graph-walker.mjs";
+import { mintDelegateCorrelationId } from "../src/orchestrator/delegate-executor.mjs";
+import {
+  A2ADelegateExecutor,
+  HttpA2ATransport,
+  parseA2AOperatorConfig,
+  parseA2ATaskResponse,
+  pollA2ATaskUntilTerminal,
+  resolveA2AApiKey,
+} from "../src/orchestrator/a2a-delegate-executor.mjs";
+import {
+  clearWorkflowRefs,
+  registerWorkflowRef,
+} from "../src/orchestrator/workflow-ref-resolver.mjs";
+import { createA2AMockHttpServer } from "./helpers/a2a-mock-http-server.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = findWorkflowRepoRoot(__dirname);
+
+function loadJson(rel) {
+  return JSON.parse(readFileSync(path.join(repoRoot, rel), "utf8"));
+}
+
+/**
+ * @param {import("./helpers/a2a-mock-http-server.mjs").ReturnType<typeof createA2AMockHttpServer>} mock
+ */
+async function withMockA2AServer(mock, fn) {
+  const { baseUrl, close } = await mock.listen();
+  try {
+    await fn(baseUrl);
+  } finally {
+    await close();
+  }
+}
+
+describe("resolveA2AApiKey", () => {
+  it("reads api key from apiKeyEnv", () => {
+    const r = resolveA2AApiKey({ apiKeyEnv: "A2A_API_KEY" }, { A2A_API_KEY: "token-1" });
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.apiKey, "token-1");
+  });
+
+  it("fails when env var is missing", () => {
+    const r = resolveA2AApiKey({ apiKeyEnv: "MISSING_A2A_KEY" }, {});
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "A2A_CREDENTIALS_MISSING");
+  });
+});
+
+describe("parseA2AOperatorConfig", () => {
+  it("requires baseUrl", () => {
+    const r = parseA2AOperatorConfig({});
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "A2A_CONFIG_INVALID");
+  });
+
+  it("normalizes baseUrl and defaults poll settings", () => {
+    const r = parseA2AOperatorConfig({ baseUrl: "http://a2a.example/" });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.baseUrl, "http://a2a.example");
+      assert.equal(r.pollIntervalMs, 500);
+      assert.equal(r.pollTimeoutMs, 120_000);
+    }
+  });
+});
+
+describe("parseA2ATaskResponse", () => {
+  it("parses completed task with output", () => {
+    const task = parseA2ATaskResponse({
+      id: "task-1",
+      status: "completed",
+      output: { patch: "// done" },
+    });
+    assert.equal(task.id, "task-1");
+    assert.equal(task.status, "completed");
+    assert.deepEqual(task.output, { patch: "// done" });
+  });
+});
+
+describe("A2ADelegateExecutor", () => {
+  it("rejects non-a2a protocols", async () => {
+    const ex = new A2ADelegateExecutor({
+      operatorConfig: { baseUrl: "http://example", apiKeyEnv: "K" },
+      env: { K: "token" },
+    });
+    const r = await ex.executeDelegate({
+      executionId: "e1",
+      node: { id: "n1", type: "agent_delegate", config: { agent_id: "coder" } },
+      state: {},
+      delegateInput: {},
+      protocol: "mcp",
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "DELEGATE_PROTOCOL_UNSUPPORTED");
+  });
+
+  it("fails when credentials are missing", async () => {
+    const ex = new A2ADelegateExecutor({
+      operatorConfig: { baseUrl: "http://example", apiKeyEnv: "MISSING" },
+      env: {},
+    });
+    const r = await ex.executeDelegate({
+      executionId: "e1",
+      node: { id: "implement", type: "agent_delegate", config: { agent_id: "coder" } },
+      state: {},
+      delegateInput: { task: "x" },
+      protocol: "a2a",
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "A2A_CREDENTIALS_MISSING");
+  });
+
+  it("submits task, polls working, and returns completed output", async () => {
+    const mock = createA2AMockHttpServer({ workingPolls: 1 });
+    await withMockA2AServer(mock, async (baseUrl) => {
+      const ex = new A2ADelegateExecutor({
+        operatorConfig: {
+          baseUrl,
+          apiKeyEnv: "A2A_TEST_KEY",
+          pollIntervalMs: 10,
+          pollTimeoutMs: 5_000,
+        },
+        env: { A2A_TEST_KEY: "secret" },
+      });
+      const executionId = "a2a-exec-1";
+      const r = await ex.executeDelegate({
+        executionId,
+        node: { id: "implement", type: "agent_delegate", config: { agent_id: "coder" } },
+        state: { task: "fix bug" },
+        delegateInput: { task: "fix bug" },
+        protocol: "a2a",
+      });
+      assert.equal(r.ok, true);
+      if (r.ok) {
+        assert.equal(r.delegateCorrelationId, mintDelegateCorrelationId(executionId, "implement"));
+        assert.equal(r.externalTaskId, "a2a-task-1");
+        assert.match(String(r.output.patch), /fix bug/);
+        assert.equal(r.output.delegate_status, "completed");
+      }
+      assert.equal(mock.tasks.size, 1);
+    });
+  });
+
+  it("returns A2A_TASK_FAILED when server reports failed status", async () => {
+    const mock = createA2AMockHttpServer({ workingPolls: 0, failTaskId: "a2a-task-1", failError: "agent crashed" });
+    await withMockA2AServer(mock, async (baseUrl) => {
+      const ex = new A2ADelegateExecutor({
+        operatorConfig: { baseUrl, apiKeyEnv: "A2A_TEST_KEY", pollIntervalMs: 5, pollTimeoutMs: 2_000 },
+        env: { A2A_TEST_KEY: "secret" },
+      });
+      const r = await ex.executeDelegate({
+        executionId: "e-fail",
+        node: { id: "implement", type: "agent_delegate", config: { agent_id: "coder" } },
+        state: {},
+        delegateInput: { task: "fail me" },
+        protocol: "a2a",
+      });
+      assert.equal(r.ok, false);
+      if (!r.ok) {
+        assert.equal(r.code, "A2A_TASK_FAILED");
+        assert.match(r.error, /agent crashed/);
+      }
+    });
+  });
+
+  it("runs conformance linear workflow with correlation fields on activity events", async () => {
+    const definition = loadJson("examples/conformance-agent-delegate-linear.workflow.json");
+    const mock = createA2AMockHttpServer();
+    await withMockA2AServer(mock, async (baseUrl) => {
+      const store = new MemoryExecutionHistoryStore();
+      const executionId = "a2a-linear-wf";
+      const out = await runGraphWorkflow({
+        definition,
+        input: { task: "implement feature X" },
+        executionId,
+        store,
+        delegateExecutor: new A2ADelegateExecutor({
+          operatorConfig: { baseUrl, apiKeyEnv: "A2A_TEST_KEY", pollIntervalMs: 10, pollTimeoutMs: 5_000 },
+          env: { A2A_TEST_KEY: "secret" },
+        }),
+      });
+      assert.equal(out.status, "completed");
+      const rows = store.listByExecution(executionId);
+      const requested = rows.find((r) => r.name === "ActivityRequested" && r.payload?.nodeId === "implement");
+      const completed = rows.find((r) => r.name === "ActivityCompleted" && r.payload?.nodeId === "implement");
+      assert.ok(requested);
+      assert.equal(requested.payload?.delegateCorrelationId, mintDelegateCorrelationId(executionId, "implement"));
+      assert.ok(completed);
+      assert.equal(completed.payload?.externalTaskId, "a2a-task-1");
+      assert.equal(completed.payload?.delegateCorrelationId, requested.payload?.delegateCorrelationId);
+    });
+  });
+
+  it("runs r3-multi-agent-coding implement step via A2A against mock server", async () => {
+    clearWorkflowRefs();
+    registerWorkflowRef("urn:awp:wf:unit-tests", loadJson("examples/r3-unit-tests-child.workflow.json"));
+    const parent = loadJson("examples/r3-multi-agent-coding.workflow.json");
+    const mock = createA2AMockHttpServer();
+    await withMockA2AServer(mock, async (baseUrl) => {
+      const store = new MemoryExecutionHistoryStore();
+      const executionId = "r3-a2a-multi-agent";
+      const run = await runGraphWorkflow({
+        definition: parent,
+        input: { task: "fix bug", repo: "acme/app" },
+        executionId,
+        store,
+        delegateExecutor: new A2ADelegateExecutor({
+          operatorConfig: { baseUrl, apiKeyEnv: "A2A_TEST_KEY", pollIntervalMs: 10, pollTimeoutMs: 5_000 },
+          env: { A2A_TEST_KEY: "secret" },
+        }),
+        stubActivityOutputs: {
+          run_tests: { tests_passed: true },
+        },
+      });
+      assert.equal(run.status, "interrupted");
+      assert.equal(typeof run.state?.patch, "string");
+      const rows = store.listByExecution(executionId);
+      const completed = rows.find((r) => r.name === "ActivityCompleted" && r.payload?.nodeId === "implement");
+      assert.ok(completed);
+      assert.equal(completed.payload?.externalTaskId, "a2a-task-1");
+    });
+  });
+});
+
+describe("HttpA2ATransport + pollA2ATaskUntilTerminal", () => {
+  it("uses injectable fetch against mock server", async () => {
+    const mock = createA2AMockHttpServer({ workingPolls: 2 });
+    await withMockA2AServer(mock, async (baseUrl) => {
+      const transport = new HttpA2ATransport({ baseUrl });
+      const submitted = await transport.submitTask({
+        apiKey: "tok",
+        agentId: "coder",
+        correlationId: "c1",
+        input: { task: "hello" },
+      });
+      assert.equal(submitted.status, "submitted");
+      const terminal = await pollA2ATaskUntilTerminal(transport, "tok", submitted.id, 5, 2_000);
+      assert.equal(terminal.status, "completed");
+      assert.ok(terminal.output?.patch);
+    });
+  });
+});

--- a/packages/engine/test/agent-delegate.test.mjs
+++ b/packages/engine/test/agent-delegate.test.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { describe, it } from "node:test";
 import { findWorkflowRepoRoot, validateWorkflowDefinition } from "../src/validate.mjs";
 import { MemoryExecutionHistoryStore } from "../src/persistence/memory-history-store.mjs";
-import { runGraphWorkflow, resumeGraphWorkflow } from "../src/orchestrator/workflow-graph-walker.mjs";
+import { runGraphWorkflow, resumeGraphWorkflow, submitActivityOutcome } from "../src/orchestrator/workflow-graph-walker.mjs";
 import { hydrateReplayContext } from "../src/orchestrator/replay-loader.mjs";
 import {
   RejectingDelegateExecutor,
@@ -66,6 +66,92 @@ describe("agent_delegate", () => {
     assert.ok(completed);
     assert.equal(completed.payload?.delegateCorrelationId, requested.payload?.delegateCorrelationId);
     assert.equal(typeof completed.payload?.externalTaskId, "string");
+  });
+
+  it("host_mediated yields awaiting_activity with delegate context without invoking delegate port", async () => {
+    const definition = loadJson("examples/conformance-agent-delegate-linear.workflow.json");
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "test-delegate-host-mediated";
+    const correlationId = mintDelegateCorrelationId(executionId, "implement");
+
+    const out = await runGraphWorkflow({
+      definition,
+      input: { task: "host delegate task" },
+      executionId,
+      store,
+      activityExecutionMode: "host_mediated",
+      delegateExecutor: new RejectingDelegateExecutor(),
+    });
+
+    assert.equal(out.status, "awaiting_activity");
+    assert.equal(out.nodeId, "implement");
+    assert.equal(out.agentId, "coder");
+    assert.equal(out.protocol, "a2a");
+    assert.equal(out.delegateCorrelationId, correlationId);
+    assert.deepEqual(out.delegateInput, { task: "host delegate task" });
+
+    const rows = store.listByExecution(executionId);
+    const requested = rows.find((r) => r.name === "ActivityRequested" && r.payload?.nodeId === "implement");
+    assert.ok(requested);
+    assert.deepEqual(requested.payload?.delegateInput, { task: "host delegate task" });
+    assert.equal(requested.payload?.delegateCorrelationId, correlationId);
+  });
+
+  it("submitActivityOutcome completes host_mediated agent_delegate with correlation validation", async () => {
+    const definition = loadJson("examples/conformance-agent-delegate-linear.workflow.json");
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "test-delegate-host-submit";
+    const correlationId = mintDelegateCorrelationId(executionId, "implement");
+
+    const pending = await runGraphWorkflow({
+      definition,
+      input: { task: "submit path" },
+      executionId,
+      store,
+      activityExecutionMode: "host_mediated",
+      delegateExecutor: new RejectingDelegateExecutor(),
+    });
+    assert.equal(pending.status, "awaiting_activity");
+
+    const badCorrelation = await submitActivityOutcome({
+      definition,
+      executionId,
+      store,
+      input: { task: "submit path" },
+      nodeId: "implement",
+      outcome: {
+        ok: true,
+        delegateCorrelationId: "wrong-correlation",
+        result: { patch: "// bad" },
+      },
+    });
+    assert.equal(badCorrelation.status, "failed");
+    assert.equal(badCorrelation.code, "SUBMIT_VALIDATION_ERROR");
+
+    const done = await submitActivityOutcome({
+      definition,
+      executionId,
+      store,
+      input: { task: "submit path" },
+      nodeId: "implement",
+      outcome: {
+        ok: true,
+        delegateCorrelationId: correlationId,
+        externalTaskId: "a2a-task-host-submit",
+        result: { patch: "// host patch", delegate_status: "completed" },
+      },
+      activityExecutionMode: "host_mediated",
+    });
+
+    assert.equal(done.status, "completed");
+    assert.equal(done.finalState?.patch, "// host patch");
+
+    const completed = store
+      .listByExecution(executionId)
+      .find((r) => r.name === "ActivityCompleted" && r.payload?.nodeId === "implement" && r.payload?.replayed !== true);
+    assert.ok(completed);
+    assert.equal(completed.payload?.delegateCorrelationId, correlationId);
+    assert.equal(completed.payload?.externalTaskId, "a2a-task-host-submit");
   });
 
   it("replay with ActivityCompleted prefix does not invoke delegate port", async () => {
@@ -159,13 +245,15 @@ describe("agent_delegate", () => {
       1,
       "replay must not append a second ActivityRequested for agent_delegate"
     );
-    const replayedCompleted = rows.filter(
-      (r) =>
-        r.name === "ActivityCompleted" &&
-        r.payload?.nodeId === "implement" &&
-        r.payload?.replayed === true
+    assert.ok(
+      rows.some(
+        (r) =>
+          r.kind === "command" &&
+          r.name === "CompleteNode" &&
+          r.payload?.nodeId === "implement"
+      ),
+      "continuation must CompleteNode after historical ActivityCompleted"
     );
-    assert.equal(replayedCompleted.length, 1);
   });
 
   it("r3 multi-agent coding workflow runs implement as agent_delegate then subworkflow", async () => {

--- a/packages/engine/test/composite-delegate-executor.test.mjs
+++ b/packages/engine/test/composite-delegate-executor.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildCompositeDelegateExecutor,
+  CompositeDelegateExecutor,
+} from "../src/orchestrator/composite-delegate-executor.mjs";
+
+/**
+ * @param {string} tag
+ * @returns {import("../src/orchestrator/delegate-executor.mjs").DelegateExecutor}
+ */
+function mockDelegateExecutor(tag) {
+  return {
+    async executeDelegate(ctx) {
+      return {
+        ok: true,
+        output: { routed: tag, nodeId: ctx.node.id },
+        delegateCorrelationId: `${ctx.executionId}:delegate:${ctx.node.id}`,
+        externalTaskId: `${tag}-task-1`,
+      };
+    },
+  };
+}
+
+describe("CompositeDelegateExecutor", () => {
+  it("routes a2a, mcp, and sdk to configured sub-executors", async () => {
+    const composite = new CompositeDelegateExecutor({
+      a2a: mockDelegateExecutor("a2a"),
+      mcp: mockDelegateExecutor("mcp"),
+      sdk: mockDelegateExecutor("sdk"),
+    });
+
+    for (const protocol of ["a2a", "mcp", "sdk"]) {
+      const r = await composite.executeDelegate({
+        executionId: "e1",
+        node: { id: `${protocol}-node`, type: "agent_delegate", config: { agent_id: "x" } },
+        state: {},
+        delegateInput: {},
+        protocol,
+      });
+      assert.equal(r.ok, true);
+      if (r.ok) assert.deepEqual(r.output, { routed: protocol, nodeId: `${protocol}-node` });
+    }
+  });
+
+  it("returns DELEGATE_PROTOCOL_UNSUPPORTED when sub-executor is missing", async () => {
+    const composite = buildCompositeDelegateExecutor({ mcp: mockDelegateExecutor("mcp") });
+    const r = await composite.executeDelegate({
+      executionId: "e1",
+      node: { id: "d1", type: "agent_delegate", config: { agent_id: "x" } },
+      state: {},
+      delegateInput: {},
+      protocol: "sdk",
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.code, "DELEGATE_PROTOCOL_UNSUPPORTED");
+      assert.match(r.error, /sdk/);
+    }
+  });
+
+  it("uses fallback when explicitly configured", async () => {
+    const composite = buildCompositeDelegateExecutor({
+      mcp: mockDelegateExecutor("mcp"),
+      fallback: mockDelegateExecutor("fallback"),
+    });
+    const r = await composite.executeDelegate({
+      executionId: "e1",
+      node: { id: "d1", type: "agent_delegate", config: { agent_id: "x" } },
+      state: {},
+      delegateInput: {},
+      protocol: "a2a",
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.output.routed, "fallback");
+  });
+
+  it("rejects unknown protocols", async () => {
+    const composite = buildCompositeDelegateExecutor({ mcp: mockDelegateExecutor("mcp") });
+    const r = await composite.executeDelegate({
+      executionId: "e1",
+      node: { id: "d1", type: "agent_delegate", config: { agent_id: "x" } },
+      state: {},
+      delegateInput: {},
+      protocol: "unknown",
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "DELEGATE_PROTOCOL_UNSUPPORTED");
+  });
+});

--- a/packages/engine/test/fixtures/mcp-manifest/with-delegate-agents.json
+++ b/packages/engine/test/fixtures/mcp-manifest/with-delegate-agents.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "echoSrv": {
+      "command": "node",
+      "args": ["./mcp-echo-server.mjs"]
+    }
+  },
+  "delegateAgents": {
+    "urn:test:agents:echo": {
+      "server": "echoSrv",
+      "tool": "echo"
+    }
+  }
+}

--- a/packages/engine/test/helpers/a2a-mock-http-server.mjs
+++ b/packages/engine/test/helpers/a2a-mock-http-server.mjs
@@ -1,0 +1,154 @@
+import http from "node:http";
+
+/**
+ * In-process A2A HTTP mock for tests and conformance (submit → working → completed).
+ *
+ * Endpoints:
+ * - POST /tasks — create task (`{ agent_id, correlation_id, input }`)
+ * - GET /tasks/:id — poll status (`submitted` | `working` | `completed` | `failed`)
+ */
+
+/**
+ * @typedef {object} A2AMockTask
+ * @property {string} id
+ * @property {string} agentId
+ * @property {string} correlationId
+ * @property {Record<string, unknown>} input
+ * @property {"submitted" | "working" | "completed" | "failed"} status
+ * @property {number} pollCount
+ * @property {Record<string, unknown>} [output]
+ * @property {string} [error]
+ */
+
+/**
+ * @param {{
+ *   workingPolls?: number;
+ *   buildOutput?: (task: A2AMockTask) => Record<string, unknown>;
+ *   failTaskId?: string;
+ *   failError?: string;
+ * }} [opts]
+ */
+export function createA2AMockHttpServer(opts = {}) {
+  const workingPolls = opts.workingPolls ?? 1;
+  const buildOutput =
+    opts.buildOutput ??
+    ((task) => {
+      const taskText = typeof task.input.task === "string" ? task.input.task : "";
+      const patch =
+        taskText.length > 0
+          ? `// A2A patch for: ${taskText.slice(0, 120)}`
+          : "// A2A patch (no task in delegate input)";
+      return { patch, delegate_status: "completed" };
+    });
+
+  /** @type {Map<string, A2AMockTask>} */
+  const tasks = new Map();
+  let nextId = 1;
+
+  /** @type {http.Server} */
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    const auth = req.headers.authorization ?? "";
+    if (!auth.startsWith("Bearer ")) {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "missing or invalid Authorization header" }));
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/tasks") {
+      /** @type {string} */
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        let parsed;
+        try {
+          parsed = JSON.parse(body);
+        } catch {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "invalid JSON body" }));
+          return;
+        }
+        const agentId = typeof parsed.agent_id === "string" ? parsed.agent_id : "";
+        const correlationId = typeof parsed.correlation_id === "string" ? parsed.correlation_id : "";
+        const input =
+          parsed.input && typeof parsed.input === "object" && !Array.isArray(parsed.input)
+            ? /** @type {Record<string, unknown>} */ ({ ...parsed.input })
+            : {};
+        const id = `a2a-task-${nextId++}`;
+        /** @type {A2AMockTask} */
+        const task = {
+          id,
+          agentId,
+          correlationId,
+          input,
+          status: "submitted",
+          pollCount: 0,
+        };
+        tasks.set(id, task);
+        res.writeHead(201, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ id, status: task.status }));
+      });
+      return;
+    }
+
+    const taskMatch = url.pathname.match(/^\/tasks\/([^/]+)$/);
+    if (req.method === "GET" && taskMatch) {
+      const task = tasks.get(taskMatch[1]);
+      if (!task) {
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "task not found" }));
+        return;
+      }
+      task.pollCount += 1;
+      if (task.id === opts.failTaskId) {
+        task.status = "failed";
+        task.error = opts.failError ?? "mock A2A task failed";
+      } else if (task.pollCount <= workingPolls) {
+        task.status = "working";
+      } else {
+        task.status = "completed";
+        task.output = buildOutput(task);
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          id: task.id,
+          status: task.status,
+          ...(task.output ? { output: task.output } : {}),
+          ...(task.error ? { error: task.error } : {}),
+        })
+      );
+      return;
+    }
+
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not found" }));
+  });
+
+  /**
+   * @returns {Promise<{ baseUrl: string; close: () => Promise<void> }>}
+   */
+  function listen() {
+    return new Promise((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        if (!addr || typeof addr === "string") {
+          reject(new Error("mock A2A server failed to bind"));
+          return;
+        }
+        resolve({
+          baseUrl: `http://127.0.0.1:${addr.port}`,
+          close: () =>
+            new Promise((res, rej) => {
+              server.close((err) => (err ? rej(err) : res()));
+            }),
+        });
+      });
+    });
+  }
+
+  return { listen, tasks };
+}

--- a/packages/engine/test/host-continuation-support.test.mjs
+++ b/packages/engine/test/host-continuation-support.test.mjs
@@ -19,6 +19,19 @@ describe("host-mediated continuation support", () => {
     assert.equal(isPendingActivityCompletionContinuation(rows), true);
   });
 
+  it("detects pending completion when ActivityCompleted lacks CompleteNode for agent_delegate", () => {
+    const rows = [
+      { seq: 1, kind: "event", name: "ExecutionStarted", payload: { inputKeys: [] } },
+      {
+        seq: 2,
+        kind: "event",
+        name: "ActivityCompleted",
+        payload: { nodeId: "implement", nodeType: "agent_delegate", result: { patch: "x" } },
+      },
+    ];
+    assert.equal(isPendingActivityCompletionContinuation(rows), true);
+  });
+
   it("returns false when CompleteNode already follows ActivityCompleted", () => {
     const rows = [
       { seq: 1, kind: "event", name: "ActivityCompleted", payload: { nodeId: "work" } },

--- a/packages/engine/test/mcp-delegate-executor.test.mjs
+++ b/packages/engine/test/mcp-delegate-executor.test.mjs
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+import { mintDelegateCorrelationId } from "../src/orchestrator/delegate-executor.mjs";
+import {
+  mapMcpActivityResultToDelegateResult,
+  McpDelegateExecutor,
+  resolveDelegateAgentBinding,
+} from "../src/orchestrator/mcp-delegate-executor.mjs";
+
+const echoServerPath = fileURLToPath(new URL("./fixtures/mcp-echo-stdio-server.mjs", import.meta.url));
+
+function echoManifest() {
+  return {
+    mcpServers: {
+      echoSrv: {
+        command: process.execPath,
+        args: [echoServerPath],
+        env: {},
+      },
+    },
+    delegateAgents: {
+      "urn:test:agents:echo": { server: "echoSrv", tool: "echo" },
+    },
+  };
+}
+
+describe("resolveDelegateAgentBinding", () => {
+  it("returns binding for known agent_id", () => {
+    const r = resolveDelegateAgentBinding(echoManifest(), "urn:test:agents:echo");
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.binding.server, "echoSrv");
+      assert.equal(r.binding.tool, "echo");
+    }
+  });
+
+  it("returns DELEGATE_AGENT_NOT_FOUND when agent is missing", () => {
+    const r = resolveDelegateAgentBinding(echoManifest(), "urn:missing");
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "DELEGATE_AGENT_NOT_FOUND");
+  });
+
+  it("returns DELEGATE_AGENT_NOT_FOUND when delegateAgents section is absent", () => {
+    const r = resolveDelegateAgentBinding({ mcpServers: echoManifest().mcpServers }, "any");
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "DELEGATE_AGENT_NOT_FOUND");
+  });
+});
+
+describe("mapMcpActivityResultToDelegateResult", () => {
+  it("maps activity failure to DELEGATE_PROTOCOL_ERROR", () => {
+    const r = mapMcpActivityResultToDelegateResult(
+      { ok: false, error: "tool failed", code: "MCP_TOOL_EXECUTION_ERROR" },
+      "corr-1",
+      "task-1"
+    );
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.code, "DELEGATE_PROTOCOL_ERROR");
+      assert.match(r.error, /tool failed/);
+    }
+  });
+
+  it("maps activity success to delegate output", () => {
+    const r = mapMcpActivityResultToDelegateResult(
+      { ok: true, output: { echoed: { x: 1 } } },
+      "corr-1",
+      "task-1"
+    );
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.deepEqual(r.output, { echoed: { x: 1 } });
+      assert.equal(r.delegateCorrelationId, "corr-1");
+      assert.equal(r.externalTaskId, "task-1");
+    }
+  });
+});
+
+describe("McpDelegateExecutor", () => {
+  it("rejects non-mcp protocols", async () => {
+    const ex = new McpDelegateExecutor({ manifest: echoManifest() });
+    const r = await ex.executeDelegate({
+      executionId: "e1",
+      node: { id: "d1", type: "agent_delegate", config: { agent_id: "urn:test:agents:echo" } },
+      state: {},
+      delegateInput: {},
+      protocol: "sdk",
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "DELEGATE_PROTOCOL_UNSUPPORTED");
+  });
+
+  it("returns DELEGATE_AGENT_NOT_FOUND for missing agent_id", async () => {
+    const ex = new McpDelegateExecutor({ manifest: echoManifest() });
+    const r = await ex.executeDelegate({
+      executionId: "e1",
+      node: { id: "d1", type: "agent_delegate", config: {} },
+      state: {},
+      delegateInput: {},
+      protocol: "mcp",
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "DELEGATE_AGENT_NOT_FOUND");
+  });
+
+  it("returns DELEGATE_AGENT_NOT_FOUND for unbound agent_id", async () => {
+    const ex = new McpDelegateExecutor({ manifest: echoManifest() });
+    const r = await ex.executeDelegate({
+      executionId: "e1",
+      node: { id: "d1", type: "agent_delegate", config: { agent_id: "urn:unknown" } },
+      state: {},
+      delegateInput: {},
+      protocol: "mcp",
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "DELEGATE_AGENT_NOT_FOUND");
+  });
+
+  it("invokes echo MCP tool via delegateAgents binding", async () => {
+    const ex = new McpDelegateExecutor({ manifest: echoManifest() });
+    const executionId = "mcp-delegate-exec-1";
+    const r = await ex.executeDelegate({
+      executionId,
+      node: { id: "delegate", type: "agent_delegate", config: { agent_id: "urn:test:agents:echo" } },
+      state: {},
+      delegateInput: { task: "hello delegate" },
+      protocol: "mcp",
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.delegateCorrelationId, mintDelegateCorrelationId(executionId, "delegate"));
+      assert.match(r.externalTaskId, /^mcp-task-/);
+      assert.deepEqual(r.output.echoed, { task: "hello delegate" });
+    }
+  });
+
+  it("returns DELEGATE_PROTOCOL_ERROR when MCP tool reports isError", async () => {
+    const manifest = {
+      mcpServers: echoManifest().mcpServers,
+      delegateAgents: {
+        "urn:test:agents:fail": { server: "echoSrv", tool: "fail_tool" },
+      },
+    };
+    const ex = new McpDelegateExecutor({ manifest });
+    const r = await ex.executeDelegate({
+      executionId: "e-fail",
+      node: { id: "d1", type: "agent_delegate", config: { agent_id: "urn:test:agents:fail" } },
+      state: {},
+      delegateInput: {},
+      protocol: "mcp",
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.code, "DELEGATE_PROTOCOL_ERROR");
+      assert.match(r.error, /intentional/);
+    }
+  });
+});

--- a/packages/engine/test/mcp-operator-manifest.test.mjs
+++ b/packages/engine/test/mcp-operator-manifest.test.mjs
@@ -27,6 +27,17 @@ describe("validateMcpOperatorManifest", () => {
     assert.equal(result.manifest.mcpServers["demo-tool"].env.EXAMPLE_TOKEN, "REDACTED_PLACEHOLDER");
   });
 
+  it("accepts delegateAgents and normalizes bindings", () => {
+    const data = JSON.parse(readFileSync(path.join(fixturesDir, "with-delegate-agents.json"), "utf8"));
+    const result = validateMcpOperatorManifest(data);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(result.manifest.delegateAgents?.["urn:test:agents:echo"], {
+      server: "echoSrv",
+      tool: "echo",
+    });
+  });
+
   it("rejects unknown top-level keys with actionable errors", () => {
     const data = JSON.parse(readFileSync(path.join(fixturesDir, "unknown-top-level.json"), "utf8"));
     const result = validateMcpOperatorManifest(data);

--- a/packages/engine/test/sdk-delegate-executor.test.mjs
+++ b/packages/engine/test/sdk-delegate-executor.test.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { mintDelegateCorrelationId } from "../src/orchestrator/delegate-executor.mjs";
+import {
+  normalizeSdkDelegateHandlers,
+  SdkDelegateExecutor,
+} from "../src/orchestrator/sdk-delegate-executor.mjs";
+
+describe("normalizeSdkDelegateHandlers", () => {
+  it("copies Map entries", () => {
+    const map = new Map([["a", async () => ({ x: 1 })]]);
+    const normalized = normalizeSdkDelegateHandlers(map);
+    assert.equal(normalized.get("a"), map.get("a"));
+    assert.notEqual(normalized, map);
+  });
+
+  it("builds Map from plain object", () => {
+    const handler = async () => ({ ok: true });
+    const normalized = normalizeSdkDelegateHandlers({ "urn:agent": handler });
+    assert.equal(normalized.get("urn:agent"), handler);
+  });
+});
+
+describe("SdkDelegateExecutor", () => {
+  it("rejects non-sdk protocols", async () => {
+    const ex = new SdkDelegateExecutor({ handlers: {} });
+    const r = await ex.executeDelegate({
+      executionId: "e1",
+      node: { id: "d1", type: "agent_delegate", config: { agent_id: "urn:agent" } },
+      state: {},
+      delegateInput: {},
+      protocol: "mcp",
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "DELEGATE_PROTOCOL_UNSUPPORTED");
+  });
+
+  it("returns DELEGATE_AGENT_NOT_FOUND when agent_id is missing", async () => {
+    const ex = new SdkDelegateExecutor({
+      handlers: { "urn:agent": async () => ({}) },
+    });
+    const r = await ex.executeDelegate({
+      executionId: "e1",
+      node: { id: "d1", type: "agent_delegate", config: {} },
+      state: {},
+      delegateInput: {},
+      protocol: "sdk",
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "DELEGATE_AGENT_NOT_FOUND");
+  });
+
+  it("returns DELEGATE_AGENT_NOT_FOUND when handler is not registered", async () => {
+    const ex = new SdkDelegateExecutor({ handlers: {} });
+    const r = await ex.executeDelegate({
+      executionId: "e1",
+      node: { id: "d1", type: "agent_delegate", config: { agent_id: "urn:missing" } },
+      state: {},
+      delegateInput: {},
+      protocol: "sdk",
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.equal(r.code, "DELEGATE_AGENT_NOT_FOUND");
+  });
+
+  it("invokes registered handler and returns output", async () => {
+    const ex = new SdkDelegateExecutor({
+      handlers: {
+        "urn:test:agents:local": async (input) => ({
+          patch: `// sdk patch for ${input.task}`,
+          delegate_status: "completed",
+        }),
+      },
+    });
+    const executionId = "sdk-exec-1";
+    const r = await ex.executeDelegate({
+      executionId,
+      node: { id: "implement", type: "agent_delegate", config: { agent_id: "urn:test:agents:local" } },
+      state: {},
+      delegateInput: { task: "refactor module" },
+      protocol: "sdk",
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.delegateCorrelationId, mintDelegateCorrelationId(executionId, "implement"));
+      assert.match(r.externalTaskId, /^sdk-task-/);
+      assert.match(String(r.output.patch), /refactor module/);
+      assert.equal(r.output.delegate_status, "completed");
+    }
+  });
+
+  it("supports registerHandler extension point", async () => {
+    const ex = new SdkDelegateExecutor();
+    ex.registerHandler("urn:dynamic", async (input) => ({ echoed: input.value }));
+    const r = await ex.executeDelegate({
+      executionId: "e2",
+      node: { id: "d2", type: "agent_delegate", config: { agent_id: "urn:dynamic" } },
+      state: {},
+      delegateInput: { value: 42 },
+      protocol: "sdk",
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) assert.deepEqual(r.output, { echoed: 42 });
+  });
+
+  it("returns DELEGATE_PROTOCOL_ERROR when handler throws", async () => {
+    const ex = new SdkDelegateExecutor({
+      handlers: {
+        "urn:throws": async () => {
+          throw new Error("handler exploded");
+        },
+      },
+    });
+    const r = await ex.executeDelegate({
+      executionId: "e3",
+      node: { id: "d3", type: "agent_delegate", config: { agent_id: "urn:throws" } },
+      state: {},
+      delegateInput: {},
+      protocol: "sdk",
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.code, "DELEGATE_PROTOCOL_ERROR");
+      assert.match(r.error, /handler exploded/);
+    }
+  });
+});

--- a/scripts/docs-user-manifest.mjs
+++ b/scripts/docs-user-manifest.mjs
@@ -6,6 +6,7 @@ export const USER_DOC_FILES = [
   "getting-started.md",
   "mcp-operator-guide.md",
   "host-mediated-activities.md",
+  "a2a-delegate-mapping.md",
   "authoring-workflows.md",
   "node-reference.md",
   "state-jq-reducers.md",

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
   - Getting started: getting-started.md
   - Run with MCP: mcp-operator-guide.md
   - Host-mediated activities: host-mediated-activities.md
+  - A2A delegate mapping: a2a-delegate-mapping.md
   - Author workflows:
       - Overview: authoring-workflows.md
       - Node reference: node-reference.md


### PR DESCRIPTION
## Summary

- Replace mock-only `agent_delegate` semantics with production delegation paths: host-mediated lifecycle (BEN-95), HTTP A2A executor with submit/poll lifecycle (BEN-94), and MCP/SDK delegate adapters with composite routing (BEN-96).
- Extend MCP submit/status to carry delegate correlation fields; add conformance vectors and user docs for A2A mapping and host-mediated delegation.
- Child epic of [BEN-81](https://linear.app/ben-van-den-bergh/issue/BEN-81) — second GA blocker epic after activity execution (BEN-82).

## Test plan

- [x] `npm test` — 189/189 pass
- [x] `npm run validate-workflows` — all golden fixtures pass
- [x] `npm run conformance` — 52/52 vectors pass (incl. new A2A + host-mediated delegate parity/replay)

## Roadmap alignment

- Linked issue: Linear [BEN-83](https://linear.app/ben-van-den-bergh/issue/BEN-83) (features BEN-94, BEN-95, BEN-96)
- Target release: `R3` / `R4` (R3 RC — Interop & delegation closure milestone)
- Type: `feature`
- RFC trace links:
  - RFC-06 §6.2 (A2A delegation composition)
  - RFC-05 §5.2 (MCP control plane / submit)
  - RFC-07 §7.3 (operator credentials outside workflow JSON)

## Spec and architecture traceability

- Spec artifact link: `docs/engine-profile.md` (agent_delegate correlation fields), `docs/user/a2a-delegate-mapping.md`, `docs/user/host-mediated-activities.md`
- Architecture decision link: ADR-0002 (host-mediated trust boundary)
- [x] Scope and constraints reviewed against `docs/engine-profile.md` and relevant `docs/RFC/*`
- [x] Behavior/contract docs updated in this PR

## Architecture runway impact

- [x] No runway impact (core GA blocker delivery)

## Validation

- [x] `npm run validate-workflows`
- [x] `npm run conformance`
- [x] `npm test`
- [x] Docs updated when behavior/contract changed

## Risk and rollback

- Risk level: `medium` (new delegate execution paths; mock A2A remains default when no executor injected)
- Rollback/fallback plan: revert PR; `MockA2ADelegateExecutor` still default in graph walker for backward-compatible demos
