### PR TITLE
feat(engine): GA 1.0 epic follow-ups — BEN-82/BEN-83 code review items

### DIFF
--- a/docs/architecture/arc42-assets/contracts/mcp-operator-manifest.md
+++ b/docs/architecture/arc42-assets/contracts/mcp-operator-manifest.md
@@ -1,6 +1,6 @@
 # MCP operator manifest (engine reference)
 
-Last updated: 2026-05-04
+Last updated: 2026-06-17
 
 ## Purpose
 
@@ -29,6 +29,8 @@ For **`agent_delegate`** nodes with `protocol: "mcp"`, the reference engine's **
 | `delegateAgents.<agent_id>.tool` | MCP tool name passed to `tools/call` |
 
 The resolved `input_mapping` payload is sent as the MCP tool `arguments` object. Stable failure codes: **`DELEGATE_AGENT_NOT_FOUND`** (unknown agent or server label), **`DELEGATE_PROTOCOL_ERROR`** (MCP wire/tool failure), **`DELEGATE_PROTOCOL_UNSUPPORTED`** (wrong protocol for the executor).
+
+**Single-shot semantics (vs A2A poll):** `McpDelegateExecutor` performs **one** MCP stdio `tools/call` per `agent_delegate` node and maps the tool result to delegate output. It does **not** implement an A2A-style submit + status poll loop — there is no engine-side wait for `working` → `completed`, and no handling of **`input-required`** mid-delegation. Contrast with **`A2ADelegateExecutor`** (`protocol: "a2a"`), which submits an HTTP task and polls until terminal status (default **`pollTimeoutMs` 120s**), blocking the calling control-plane operation for the duration. For long-running, interactive, or multi-turn delegates, operators should use **`activity_execution_mode: "host_mediated"`** and complete the delegate via `workflow_submit_activity` (see [A2A delegate mapping](../../../user/a2a-delegate-mapping.md) and [Host-mediated activities](../../../user/host-mediated-activities.md)).
 
 Example fragment:
 
@@ -69,6 +71,8 @@ Library helpers above apply when tooling calls `resolveMcpOperatorManifestPath()
 - CLI flag **`--mcp-config <path>`** after the bin name (overrides the env var when both are set).
 
 That startup path is **independent** of `AGENT_WORKFLOW_MCP_MANIFEST` and `<cwd>/.agent-workflow/mcp.json`. See `packages/engine/README.md` (engine-direct section) and [ADR-0003](../../adr/ADR-0003-engine-direct-mcp-activity-execution.md).
+
+For **`agent_delegate`** nodes with `protocol: "mcp"`, the same `WORKFLOW_ENGINE_MCP_CONFIG` / `--mcp-config` manifest is used to bootstrap **`McpDelegateExecutor`** when `delegateAgents` is present (`loadProductionDelegateExecutor` in `workflows-engine-mcp`). For `protocol: "a2a"`, set **`WORKFLOW_ENGINE_A2A_CONFIG`** (inline JSON or file path) with `baseUrl` and `apiKeyEnv` — see `packages/engine/README.md` (delegate routing section).
 
 ## CLI validation
 

--- a/docs/user/a2a-delegate-mapping.md
+++ b/docs/user/a2a-delegate-mapping.md
@@ -4,6 +4,8 @@ This guide describes how the reference engine's **`A2ADelegateExecutor`** maps `
 
 For host-driven delegation (no in-process HTTP client), see [Host-mediated activities](host-mediated-activities.md).
 
+> **Operator warning — in-process A2A blocks the control plane:** When a workflow uses **`A2ADelegateExecutor`** (in-process HTTP submit + poll), delegate execution runs **synchronously inside** `workflow_start`, `workflow_resume`, or any continuation that reaches an `agent_delegate` node. The poll loop may run for up to **`pollTimeoutMs`** (default **120 seconds**) before returning or failing. **MCP stdio hosts** (Cursor, Claude Desktop, and similar) often enforce shorter tool-call timeouts and will disconnect mid-poll. For **long-running**, **interactive**, or **`input-required`** A2A tasks, use **`activity_execution_mode: "host_mediated"`** from the first control-plane call so the engine yields `awaiting_activity` and the host delegates out of band. See [Migrating from in-process A2A when a task needs input](#migrating-from-in-process-a2a-when-a-task-needs-input) below.
+
 ## When to use
 
 | Mode | Delegate port | Use case |
@@ -98,11 +100,101 @@ Response `200`:
 Supported `status` values: `submitted`, `working`, `input-required`, `completed`, `failed`.
 
 - The executor polls until `completed` or `failed` (or timeout).
-- `input-required` is **not** handled in-process; use [host-mediated activities](host-mediated-activities.md) so the host can satisfy A2A input prompts and submit via `workflow_submit_activity`.
+- `input-required` is **not** handled in-process — the poll loop **throws** instead of yielding. Use [host-mediated activities](host-mediated-activities.md) so the host can satisfy A2A input prompts and submit via `workflow_submit_activity` (see [Migrating from in-process A2A when a task needs input](#migrating-from-in-process-a2a-when-a-task-needs-input)).
 
 ### Authentication
 
 All requests send `Authorization: Bearer {apiKey}` where `apiKey` is resolved from operator config.
+
+## Migrating from in-process A2A when a task needs input
+
+**Symptom:** A workflow started with in-process `A2ADelegateExecutor` (default MCP stdio path when a custom delegate port is wired, or library use with `activity_execution_mode: "in_process"`) fails or stalls when the A2A runtime returns **`input-required`** on poll — for example:
+
+```
+A2A task "a2a-task-abc123" requires host input (input-required); use host_mediated activity mode for interactive delegates
+```
+
+Or the MCP host times out while `workflow_start` is still inside the poll loop (up to **`pollTimeoutMs`**, default 120s).
+
+**Fix:** Treat interactive delegates as **host-mediated from the start**. Do not rely on in-process poll to bridge human-in-the-loop or multi-turn agent prompts.
+
+### 1. Start with `host_mediated`
+
+Fixture: `examples/conformance-agent-delegate-linear.workflow.json`.
+
+```json
+{
+  "execution_id": "multi-agent-interactive-1",
+  "definition": { "...": "conformance-agent-delegate-linear.workflow.json" },
+  "input": { "task": "implement feature X" },
+  "activity_execution_mode": "host_mediated"
+}
+```
+
+Response (engine yields immediately — no in-process HTTP poll):
+
+```json
+{
+  "status": "awaiting_activity",
+  "node_id": "implement",
+  "agent_id": "coder",
+  "protocol": "a2a",
+  "delegate_input": { "task": "implement feature X" },
+  "delegate_correlation_id": "multi-agent-interactive-1:delegate:implement"
+}
+```
+
+### 2. Host submits A2A task and polls out of band
+
+The host (not the engine) calls `POST {baseUrl}/tasks` with `delegate_input`, then polls `GET {baseUrl}/tasks/{id}` using its own timeout policy.
+
+When the first poll returns **`input-required`**, the host satisfies the prompt (user message, form, tool result) via the A2A runtime's input API, then continues polling until `completed` or `failed` — without holding an MCP stdio tool call open.
+
+Example non-terminal poll (host-side):
+
+```json
+{
+  "id": "a2a-task-abc123",
+  "status": "input-required",
+  "output": { "prompt": "Which API style should the patch use?" }
+}
+```
+
+After the host supplies input and the task reaches **`completed`**:
+
+```json
+{
+  "id": "a2a-task-abc123",
+  "status": "completed",
+  "output": { "patch": "// …", "delegate_status": "completed" }
+}
+```
+
+### 3. Submit delegate outcome to the engine
+
+```json
+{
+  "execution_id": "multi-agent-interactive-1",
+  "definition": "<same object as workflow_start>",
+  "input": { "task": "implement feature X" },
+  "node_id": "implement",
+  "activity_execution_mode": "host_mediated",
+  "outcome": {
+    "ok": true,
+    "delegate_correlation_id": "multi-agent-interactive-1:delegate:implement",
+    "external_task_id": "a2a-task-abc123",
+    "result": { "patch": "// …", "delegate_status": "completed" }
+  }
+}
+```
+
+| In-process A2A | Host-mediated A2A |
+|----------------|-------------------|
+| Poll runs inside `workflow_start` / resume (blocks MCP stdio) | Engine returns `awaiting_activity` immediately |
+| `input-required` → executor throws | Host handles `input-required` and multi-turn poll |
+| Host timeout risk on long delegates | Host controls poll interval and timeouts |
+
+Full host loop: [Host-mediated activities — `agent_delegate` host loop](host-mediated-activities.md#agent_delegate-host-loop).
 
 ## Workflow history correlation
 

--- a/docs/user/host-mediated-activities.md
+++ b/docs/user/host-mediated-activities.md
@@ -13,6 +13,20 @@ Assistant-class MCP hosts (Cursor, Claude Desktop, Codex-style clients) already 
 
 The runtime default is **`in_process`** for backward-compatible smoke tests. Assistant hosts **must opt in** to `host_mediated` on every control-plane call that can continue execution (see [ADR-0002](../architecture/adr/ADR-0002-host-mediated-activity-execution.md)).
 
+## Templated `llm_call` prompts: host-mediated vs engine-direct
+
+The reference engine's **`LlmActivityExecutor`** (engine-direct / `in_process`) resolves `llm_call` prompts as **literal strings** from `config.system_prompt` and `config.user_prompt` / `config.prompt`. It does **not** evaluate jq expressions or substitute state into prompt text. If `user_prompt` is omitted, the user message is `JSON.stringify(state)` when state has keys, or the fixed fallback `"Respond according to the system instructions."` when state is empty.
+
+| Need | Recommended mode |
+|------|------------------|
+| Static prompts only | Either mode; engine-direct is fine when operator config supplies provider credentials |
+| jq or custom templating from workflow state | **`host_mediated`** — read `node.config` and `state` from the pending `awaiting_activity` / `workflow_status` response, build the provider request in the host, then `workflow_submit_activity` |
+| Engine-side state shaping without host templating | **`in_process`** with a preceding **`set_state`** node, then literal prompts or omit `user_prompt` to rely on the JSON.stringify(state) fallback |
+
+**Contrast with `agent_delegate`:** delegate nodes resolve `config.input_mapping` with jq (same machinery as `subworkflow` and engine-direct `tool_call`). `llm_call` has no `input_mapping` field in the current profile.
+
+**Lighthouse example:** `classify` sets only `system_prompt` and omits `user_prompt`. Engine-direct execution sends the serialized workflow state (for example `{ "ticket_text": "…" }`) as the user message. A host-mediated integration **may** instead format `ticket_text` into a richer prompt before calling its LLM.
+
 ## Opt-in: `activity_execution_mode`
 
 Pass **`activity_execution_mode: "host_mediated"`** on:
@@ -67,6 +81,8 @@ For each activity boundary the engine yields **`awaiting_activity`**. The host l
 Success outcomes use `{ "ok": true, "result": { ... } }` (merged into workflow state per node completion). Failures use `{ "ok": false, "error": "...", "code": "..." }`.
 
 For **`agent_delegate`** nodes, include the **`delegate_correlation_id`** from the pending `ActivityRequested` (also exposed on start/status responses). Optionally pass **`external_task_id`** for the host-side agent task reference. The engine validates that the submitted correlation id matches the pending request before recording `ActivityCompleted`.
+
+**Interactive A2A delegates (`input-required`):** In-process **`A2ADelegateExecutor`** poll throws when the A2A task status is `input-required` — it cannot yield mid-poll. Assistant hosts **must** use `host_mediated` from the first control-plane call for delegates that may need human input or multi-turn agent prompts, and poll the A2A task **out of band** before submitting the final outcome. See [A2A delegate mapping — migrating from in-process A2A](a2a-delegate-mapping.md#migrating-from-in-process-a2a-when-a-task-needs-input).
 
 ```json
 {
@@ -159,6 +175,7 @@ Conformance vectors: `parity.r3.host_mediated_delegate_submit` (port/MCP parity)
 
 ## Related documentation
 
+- [A2A delegate mapping](a2a-delegate-mapping.md) — HTTP task API, in-process poll constraints, and **`input-required`** migration path
 - [Run with MCP](mcp-operator-guide.md) — package install, tool reference, development setup
 - [ADR-0002: Host-mediated activity execution](../architecture/adr/ADR-0002-host-mediated-activity-execution.md)
 - [Engine package README](https://github.com/benvdbergh/workflows/blob/main/packages/engine/README.md) — library API and MCP tool schemas

--- a/docs/user/mcp-operator-guide.md
+++ b/docs/user/mcp-operator-guide.md
@@ -62,8 +62,34 @@ Replace `0.1.4` with your target version or `@alpha`.
 |----------|---------|
 | `WORKFLOW_ENGINE_MCP_CONFIG` | JSON config for engine-direct activity manifests |
 | `WORKFLOW_ENGINE_MCP_ALLOW_COMMANDS` | Extend allowed command basenames for engine-direct `tool_call` |
+| `WORKFLOW_ENGINE_LLM_CONFIG` | Inline JSON or file path for `llm_call` operator credentials |
+| `WORKFLOW_ENGINE_STEP_HANDLERS` | Inline JSON or file path: **static** handler URN → output map (see below) |
+| `WORKFLOW_ENGINE_PROFILE` | Set to `demo` for stub fallback on unconfigured node types inside a partial composite |
 
-See the [engine package README](https://github.com/benvdbergh/workflows/blob/main/packages/engine/README.md) for engine-direct manifests.
+See the [engine package README](https://github.com/benvdbergh/workflows/blob/main/packages/engine/README.md) for engine-direct manifests and composite routing.
+
+### `step` handlers via environment (static outputs only)
+
+`WORKFLOW_ENGINE_STEP_HANDLERS` bootstraps `StepActivityExecutor` for `workflows-engine-mcp`. The value is inline JSON or a path to a JSON file whose **keys are handler URNs** and **values are fixed output objects** — the same shape as conformance `stepHandlers` vectors.
+
+**This env var does not register programmatic handlers.** Each URN is wired to an async function that returns the configured JSON object as-is. You cannot run custom code, read workflow state, call external APIs, or branch on inputs through this mechanism. It is intended for smoke tests, demos, and fixture replay — not production step logic.
+
+For programmatic `step` handlers, use the library API at bootstrap:
+
+```js
+import { StepActivityExecutor, StepHandlerRegistry, createWorkflowApplicationPort } from "@agent-workflow/engine";
+
+const registry = new StepHandlerRegistry();
+registry.register("urn:my-app:handlers:lookup-customer", async (ctx) => {
+  // ctx.executionId, ctx.node, ctx.state available
+  return { customerId: "c-1", name: "Ada" };
+});
+
+const activityExecutor = new StepActivityExecutor({ registry: registry.createFrozenCopy() });
+const port = createWorkflowApplicationPort({ store, activityExecutor });
+```
+
+See [`StepHandlerRegistry.register`](https://github.com/benvdbergh/workflows/blob/main/packages/engine/src/orchestrator/step-activity-executor.mjs) in `packages/engine/src/orchestrator/step-activity-executor.mjs` and the [Engine-direct `step` execution](https://github.com/benvdbergh/workflows/blob/main/packages/engine/README.md#engine-direct-step-execution-stepactivityexecutor) section of the engine README.
 
 ## MCP tools
 

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -105,6 +105,22 @@ const activityExecutor = new LlmActivityExecutor({
 
 Inject a custom **`LlmProvider`** for tests or non-OpenAI backends; the default uses fetch against `/chat/completions` with no extra SDK. Structured outputs are validated with AJV when `output_schema` is set. Failures return stable codes: `LLM_CONFIG_INVALID`, `LLM_CREDENTIALS_MISSING`, `LLM_PROVIDER_ERROR`, `LLM_OUTPUT_VALIDATION_FAILED` (surfaced as `ActivityFailed` in execution history).
 
+#### Prompt resolution (`buildLlmChatMessages`)
+
+`LlmActivityExecutor` builds the provider chat payload from `node.config` and the current workflow **`state`** via `buildLlmChatMessages`:
+
+| Message | Source |
+|---------|--------|
+| `system` | `config.system_prompt` when present — passed through as a **literal string** |
+| `user` | `config.user_prompt` or `config.prompt` (alias) when present — **literal string**; otherwise `JSON.stringify(state)` when state has keys; otherwise the fixed fallback `"Respond according to the system instructions."` |
+
+**No jq or state templating.** Unlike `agent_delegate`, `subworkflow`, and engine-direct `tool_call` nodes (which resolve `config.input_mapping` with jq), `llm_call` prompts are **not** evaluated against workflow state. Placeholders in `system_prompt` or `user_prompt` are sent to the provider unchanged.
+
+When prompts must be derived from state (for example inserting `ticket_text` into a user message), use one of:
+
+- A preceding **`set_state`** node to shape state, then omit `user_prompt` so the executor serializes state into the user message (lighthouse `classify` uses this pattern).
+- **`activity_execution_mode: "host_mediated"`** so the host templates prompts from `node.config` and `state` before calling its LLM and submitting the outcome (see [`docs/user/host-mediated-activities.md`](../../docs/user/host-mediated-activities.md)).
+
 ### Engine-direct `step` execution (`StepActivityExecutor`)
 
 `StepActivityExecutor` implements the **`ActivityExecutor`** port for **`step`** nodes. It reads `node.config.handler` (a string URN) and looks up the implementation in an operator-provided **`StepHandlerRegistry`** registered at bootstrap — not in workflow JSON.
@@ -120,6 +136,8 @@ const activityExecutor = new StepActivityExecutor({ registry: registry.createFro
 ```
 
 **v1 sandboxing:** handlers run in the **same Node.js process** as the engine (in-process dispatch). There is no worker isolation, VM sandbox, or resource cap in this profile milestone — treat registered handlers as trusted operator code. Isolated worker processes are deferred to a later release.
+
+**`WORKFLOW_ENGINE_STEP_HANDLERS` is static output only.** The MCP stdio bin reads this env var as a JSON map of handler URN → **fixed output object**. Each entry is wrapped as an async handler that **returns that object unchanged** — there is no way to supply programmatic logic (no I/O, no state inspection, no side effects). Use this for smoke tests and conformance-style fixtures. For real handler code, register async functions via `StepHandlerRegistry.register` at library bootstrap (see example above) and pass the frozen registry to `StepActivityExecutor` / `createWorkflowApplicationPort`.
 
 Stable failure codes: `STEP_CONFIG_INVALID` (missing/invalid `handler`), `HANDLER_NOT_FOUND` (URN not registered), `HANDLER_ERROR` (handler threw). Success merges handler output into workflow state per `state_schema` reducers.
 
@@ -150,9 +168,18 @@ Pass the composite (or any custom `ActivityExecutor`) to `createWorkflowApplicat
 |---------|----------------|
 | `WORKFLOW_ENGINE_MCP_CONFIG` / `--mcp-config` | `tool_call` → `McpManifestActivityExecutor` |
 | `WORKFLOW_ENGINE_LLM_CONFIG` (inline JSON or file path) | `llm_call` → `LlmActivityExecutor` |
-| `WORKFLOW_ENGINE_STEP_HANDLERS` (inline JSON or file path; URN → static output map) | `step` → `StepActivityExecutor` |
+| `WORKFLOW_ENGINE_STEP_HANDLERS` (inline JSON or file path; **static** URN → output map only — not programmatic handlers) | `step` → `StepActivityExecutor` |
 
 When **none** of these are set, the MCP adapter omits `activityExecutor` and the walker uses **`StubActivityExecutor`** (demo/local only). Set **`WORKFLOW_ENGINE_PROFILE=demo`** to add stub **fallback** inside a partial composite (unconfigured node types return `{}` instead of `COMPOSITE_EXECUTOR_NOT_CONFIGURED`). Do **not** rely on stub fallback in production deployments.
+
+On successful startup, `workflows-engine-mcp` writes a structured **activity routing** summary to stderr so operators can see which node types are production-configured vs missing before workflows fail at runtime:
+
+```
+[engine-mcp-stdio] activity routing: llm_call=production, tool_call=missing, step=missing
+[engine-mcp-stdio] demo stub fallback: inactive
+```
+
+Route values: **`production`** (env/config present), **`missing`** (partial composite, no demo fallback — hits `COMPOSITE_EXECUTOR_NOT_CONFIGURED` at runtime), **`stub(demo)`** (unconfigured but covered by `WORKFLOW_ENGINE_PROFILE=demo` fallback), **`stub(default)`** (no operator activity config; full in-process stub mode).
 
 ### Delegate routing (`CompositeDelegateExecutor`)
 
@@ -165,6 +192,8 @@ When **none** of these are set, the MCP adapter omits `activityExecutor` and the
 | `SdkDelegateExecutor` | `sdk` | In-process `Map<agent_id, handler>` (extension point for embedded agents) |
 
 Route multiple protocols with **`buildCompositeDelegateExecutor({ a2a, mcp, sdk })`**. Stable failure codes include **`DELEGATE_AGENT_NOT_FOUND`**, **`DELEGATE_PROTOCOL_ERROR`**, and **`DELEGATE_PROTOCOL_UNSUPPORTED`**. See [A2A delegate mapping](../../docs/user/a2a-delegate-mapping.md) and [MCP operator manifest](../../docs/architecture/arc42-assets/contracts/mcp-operator-manifest.md).
+
+> **Operator constraints:** **`A2ADelegateExecutor`** runs submit + poll **inside** the control-plane call (`workflow_start`, resume, or in-process continuation). Poll may block up to **`pollTimeoutMs`** (default **120s**); MCP stdio hosts often timeout sooner. Poll **throws** on A2A **`input-required`** — it does not yield. **`McpDelegateExecutor`** is **single-shot** (one stdio `tools/call`; no status poll loop). For long-running, interactive, or **`input-required`** delegates, pass **`activity_execution_mode: "host_mediated"`** and complete via **`workflow_submit_activity`** ([host-mediated guide](../../docs/user/host-mediated-activities.md), [A2A input-required migration](../../docs/user/a2a-delegate-mapping.md#migrating-from-in-process-a2a-when-a-task-needs-input)).
 
 ```js
 import {
@@ -182,6 +211,17 @@ const delegateExecutor = buildCompositeDelegateExecutor({
   }),
 });
 ```
+
+**`workflows-engine-mcp` wiring:** when any operator config is present, the stdio bin loads a composite via `loadProductionDelegateExecutor`:
+
+| Env var | Sub-executor |
+|---------|----------------|
+| `WORKFLOW_ENGINE_A2A_CONFIG` (inline JSON or file path) | `a2a` → `A2ADelegateExecutor` |
+| `WORKFLOW_ENGINE_MCP_CONFIG` / `--mcp-config` (`delegateAgents` in manifest) | `mcp` → `McpDelegateExecutor` |
+
+When **none** of these are set, the MCP adapter omits `delegateExecutor` and the walker uses **`MockA2ADelegateExecutor`** (demo/local only). Set **`WORKFLOW_ENGINE_PROFILE=demo`** to add mock **fallback** inside a partial composite (unconfigured protocols succeed with in-process mock output instead of `DELEGATE_PROTOCOL_UNSUPPORTED`). Do **not** rely on mock fallback in production deployments.
+
+Invalid `WORKFLOW_ENGINE_A2A_CONFIG` (missing `baseUrl`) or an invalid operator manifest fails **at MCP stdio startup** with readable stderr messages (same pattern as activity bootstrap).
 
 ### Host compatibility constraints for no-install use
 

--- a/packages/engine/src/adapters/mcp/stdio-server-config.mjs
+++ b/packages/engine/src/adapters/mcp/stdio-server-config.mjs
@@ -11,10 +11,20 @@ import { fileURLToPath } from "node:url";
 import { readAndValidateMcpOperatorManifestFile } from "../../config/mcp-operator-manifest.mjs";
 import { StubActivityExecutor } from "../../orchestrator/activity-executor.mjs";
 import {
+  A2ADelegateExecutor,
+  parseA2AOperatorConfig,
+} from "../../orchestrator/a2a-delegate-executor.mjs";
+import {
   buildCompositeActivityExecutor,
   CompositeActivityExecutor,
 } from "../../orchestrator/composite-activity-executor.mjs";
+import {
+  buildCompositeDelegateExecutor,
+  CompositeDelegateExecutor,
+} from "../../orchestrator/composite-delegate-executor.mjs";
+import { MockA2ADelegateExecutor } from "../../orchestrator/delegate-executor.mjs";
 import { LlmActivityExecutor } from "../../orchestrator/llm-activity-executor.mjs";
+import { McpDelegateExecutor } from "../../orchestrator/mcp-delegate-executor.mjs";
 import { McpManifestActivityExecutor } from "../../orchestrator/mcp-stdio-activity-executor.mjs";
 import {
   StepActivityExecutor,
@@ -90,9 +100,32 @@ export function resolveLlmOperatorConfigFromEnv(env = process.env, cwd = process
 }
 
 /**
+ * Reads A2A operator config from `WORKFLOW_ENGINE_A2A_CONFIG` (inline JSON or file path).
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @param {string} [cwd]
+ * @returns {import("../../orchestrator/a2a-delegate-executor.mjs").A2AOperatorConfig | null}
+ */
+export function resolveA2AOperatorConfigFromEnv(env = process.env, cwd = process.cwd()) {
+  const raw = env.WORKFLOW_ENGINE_A2A_CONFIG;
+  if (!raw || String(raw).trim() === "") {
+    return null;
+  }
+  const parsed = parseJsonEnvOrFilePath(raw, cwd, "WORKFLOW_ENGINE_A2A_CONFIG");
+  return /** @type {import("../../orchestrator/a2a-delegate-executor.mjs").A2AOperatorConfig} */ (parsed);
+}
+
+/**
  * Loads a frozen {@link StepHandlerRegistry} from `WORKFLOW_ENGINE_STEP_HANDLERS`.
- * Value is inline JSON or a file path. Each key is a handler URN; each value is the static handler output
- * (same shape as conformance `stepHandlers` vectors).
+ *
+ * **Static-output bootstrap only** — not programmatic handler registration. The env value is inline JSON
+ * or a file path to a JSON object. Each key is a handler URN; each value is a **fixed output object**
+ * (same shape as conformance `stepHandlers` vectors). Every entry is registered as
+ * `async () => output` — the returned object is never computed from workflow state, node config, or I/O.
+ *
+ * For async handler functions that inspect {@link import("../../orchestrator/step-activity-executor.mjs").StepHandlerContext}
+ * or perform side effects, use {@link StepHandlerRegistry#register} at library bootstrap and pass the
+ * frozen registry to {@link StepActivityExecutor} (see `packages/engine/README.md`).
  *
  * @param {NodeJS.ProcessEnv} [env]
  * @param {string} [cwd]
@@ -132,6 +165,59 @@ export function formatMcpManifestValidationErrors(errors) {
   return lines.join("\n");
 }
 
+/** @typedef {"production" | "stub(demo)" | "missing" | "stub(default)"} ActivityRouteStatus */
+
+/**
+ * @typedef {{
+ *   llm_call: ActivityRouteStatus;
+ *   tool_call: ActivityRouteStatus;
+ *   step: ActivityRouteStatus;
+ *   demoStubFallback: boolean;
+ * }} ActivityRoutingSummary
+ */
+
+/**
+ * @param {{
+ *   hasLlm: boolean;
+ *   hasTool: boolean;
+ *   hasStep: boolean;
+ *   demoStubFallback: boolean;
+ *   compositeMode: boolean;
+ * }} params
+ * @returns {ActivityRoutingSummary}
+ */
+export function buildActivityRoutingSummary(params) {
+  /** @param {boolean} configured */
+  const status = (configured) => {
+    if (configured) {
+      return /** @type {ActivityRouteStatus} */ ("production");
+    }
+    if (!params.compositeMode) {
+      return /** @type {ActivityRouteStatus} */ ("stub(default)");
+    }
+    if (params.demoStubFallback) {
+      return /** @type {ActivityRouteStatus} */ ("stub(demo)");
+    }
+    return /** @type {ActivityRouteStatus} */ ("missing");
+  };
+  return {
+    llm_call: status(params.hasLlm),
+    tool_call: status(params.hasTool),
+    step: status(params.hasStep),
+    demoStubFallback: params.demoStubFallback,
+  };
+}
+
+/**
+ * @param {ActivityRoutingSummary} summary
+ * @returns {string}
+ */
+export function formatActivityRoutingSummaryLog(summary) {
+  const routes = [`llm_call=${summary.llm_call}`, `tool_call=${summary.tool_call}`, `step=${summary.step}`].join(", ");
+  const fallback = summary.demoStubFallback ? "active" : "inactive";
+  return `[engine-mcp-stdio] activity routing: ${routes}\n[engine-mcp-stdio] demo stub fallback: ${fallback}\n`;
+}
+
 /**
  * @param {string} manifestPath
  * @param {{ cwd?: string }} [options]
@@ -163,7 +249,7 @@ export async function loadEngineDirectActivityExecutor(manifestPath, options = {
  *   profile?: string | null;
  * }} [options]
  * @returns {Promise<
- *   | { ok: true; executor: CompositeActivityExecutor | undefined }
+ *   | { ok: true; executor: CompositeActivityExecutor | undefined; routingSummary: ActivityRoutingSummary }
  *   | { ok: false; errors: ReadonlyArray<{ instancePath?: string; keyword: string; message?: string }> }
  *   | { ok: false; error: string }
  * >}
@@ -180,37 +266,144 @@ export async function loadProductionActivityExecutor(options = {}) {
   const manifestPath =
     options.manifestPath !== undefined ? options.manifestPath : resolveWorkflowEngineMcpConfigPath(process.argv, cwd);
 
+  let hasTool = false;
   if (manifestPath) {
     const loaded = await loadEngineDirectActivityExecutor(manifestPath, { cwd });
     if (!loaded.ok) {
       return loaded;
     }
     subExecutors.tool_call = loaded.executor;
+    hasTool = true;
   }
 
   const llmConfig =
     options.llmConfig !== undefined ? options.llmConfig : resolveLlmOperatorConfigFromEnv(env, cwd);
+  let hasLlm = false;
   if (llmConfig) {
     subExecutors.llm_call = new LlmActivityExecutor({ operatorConfig: llmConfig, env });
+    hasLlm = true;
   }
 
   const stepRegistry =
     options.stepHandlerRegistry !== undefined
       ? options.stepHandlerRegistry
       : loadStepHandlerRegistryFromEnv(env, cwd);
+  let hasStep = false;
   if (stepRegistry) {
     subExecutors.step = new StepActivityExecutor({ registry: stepRegistry });
+    hasStep = true;
   }
 
-  if (!subExecutors.step && !subExecutors.llm_call && !subExecutors.tool_call) {
-    return { ok: true, executor: undefined };
+  if (!hasStep && !hasLlm && !hasTool) {
+    return {
+      ok: true,
+      executor: undefined,
+      routingSummary: buildActivityRoutingSummary({
+        hasLlm: false,
+        hasTool: false,
+        hasStep: false,
+        demoStubFallback: demoProfile,
+        compositeMode: false,
+      }),
+    };
   }
 
   if (demoProfile) {
     subExecutors.fallback = new StubActivityExecutor();
   }
 
-  return { ok: true, executor: buildCompositeActivityExecutor(subExecutors) };
+  return {
+    ok: true,
+    executor: buildCompositeActivityExecutor(subExecutors),
+    routingSummary: buildActivityRoutingSummary({
+      hasLlm,
+      hasTool,
+      hasStep,
+      demoStubFallback: demoProfile,
+      compositeMode: true,
+    }),
+  };
+}
+
+/**
+ * @param {string} manifestPath
+ * @param {{ cwd?: string }} [options]
+ * @returns {Promise<
+ *   | { ok: true; executor: import("../../orchestrator/mcp-delegate-executor.mjs").McpDelegateExecutor | undefined }
+ *   | { ok: false; errors: ReadonlyArray<{ instancePath?: string; keyword: string; message?: string }> }
+ * >}
+ */
+export async function loadEngineDirectMcpDelegateExecutor(manifestPath, options = {}) {
+  const result = await readAndValidateMcpOperatorManifestFile(manifestPath, options);
+  if (!result.ok) {
+    return { ok: false, errors: result.errors };
+  }
+  if (!result.manifest.delegateAgents) {
+    return { ok: true, executor: undefined };
+  }
+  const executor = new McpDelegateExecutor({
+    manifest: result.manifest,
+    clientName: "@agent-workflow/workflows-engine-mcp",
+    clientVersion: enginePackageVersion,
+  });
+  return { ok: true, executor };
+}
+
+/**
+ * @param {{
+ *   manifestPath?: string | null;
+ *   a2aConfig?: import("../../orchestrator/a2a-delegate-executor.mjs").A2AOperatorConfig | null;
+ *   env?: NodeJS.ProcessEnv;
+ *   cwd?: string;
+ *   profile?: string | null;
+ * }} [options]
+ * @returns {Promise<
+ *   | { ok: true; executor: CompositeDelegateExecutor | undefined }
+ *   | { ok: false; errors: ReadonlyArray<{ instancePath?: string; keyword: string; message?: string }> }
+ *   | { ok: false; error: string }
+ * >}
+ */
+export async function loadProductionDelegateExecutor(options = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  const env = options.env ?? process.env;
+  const profile = options.profile ?? env.WORKFLOW_ENGINE_PROFILE ?? null;
+  const demoProfile = profile === "demo";
+
+  /** @type {Partial<{ a2a: import("../../orchestrator/delegate-executor.mjs").DelegateExecutor; mcp: import("../../orchestrator/delegate-executor.mjs").DelegateExecutor; fallback?: import("../../orchestrator/delegate-executor.mjs").DelegateExecutor }>} */
+  const subExecutors = {};
+
+  const manifestPath =
+    options.manifestPath !== undefined ? options.manifestPath : resolveWorkflowEngineMcpConfigPath(process.argv, cwd);
+
+  if (manifestPath) {
+    const loaded = await loadEngineDirectMcpDelegateExecutor(manifestPath, { cwd });
+    if (!loaded.ok) {
+      return loaded;
+    }
+    if (loaded.executor) {
+      subExecutors.mcp = loaded.executor;
+    }
+  }
+
+  const a2aConfig =
+    options.a2aConfig !== undefined ? options.a2aConfig : resolveA2AOperatorConfigFromEnv(env, cwd);
+  if (a2aConfig) {
+    const parsed = parseA2AOperatorConfig(a2aConfig);
+    if (!parsed.ok) {
+      return { ok: false, error: parsed.error };
+    }
+    subExecutors.a2a = new A2ADelegateExecutor({ operatorConfig: a2aConfig, env });
+  }
+
+  if (!subExecutors.a2a && !subExecutors.mcp) {
+    return { ok: true, executor: undefined };
+  }
+
+  if (demoProfile) {
+    subExecutors.fallback = new MockA2ADelegateExecutor();
+  }
+
+  return { ok: true, executor: buildCompositeDelegateExecutor(subExecutors) };
 }
 
 export { enginePackageVersion };

--- a/packages/engine/src/mcp-stdio-server.mjs
+++ b/packages/engine/src/mcp-stdio-server.mjs
@@ -2,8 +2,10 @@
 import { createWorkflowApplicationPort } from "./application/workflow-application-port.mjs";
 import { createMcpWorkflowStdioServer } from "./adapters/mcp/stdio-server.mjs";
 import {
+  formatActivityRoutingSummaryLog,
   formatMcpManifestValidationErrors,
   loadProductionActivityExecutor,
+  loadProductionDelegateExecutor,
   resolveWorkflowEngineMcpConfigPath,
 } from "./adapters/mcp/stdio-server-config.mjs";
 import { MemoryExecutionHistoryStore } from "./persistence/memory-history-store.mjs";
@@ -18,9 +20,16 @@ async function main() {
         "Production activity execution (composite router):\n" +
         "  WORKFLOW_ENGINE_MCP_CONFIG — operator MCP manifest for tool_call (or --mcp-config <path>).\n" +
         "  WORKFLOW_ENGINE_LLM_CONFIG — inline JSON or file path for llm_call operator credentials.\n" +
-        "  WORKFLOW_ENGINE_STEP_HANDLERS — inline JSON or file path mapping handler URNs to static outputs.\n" +
+        "  WORKFLOW_ENGINE_STEP_HANDLERS — inline JSON or file path: URN → static output object (not programmatic handlers).\n" +
+        "    For custom handler code, use StepHandlerRegistry.register at library bootstrap (see engine README).\n" +
         "  When none are set, activities use StubActivityExecutor (local demo only; set WORKFLOW_ENGINE_PROFILE=demo\n" +
         "  to enable stub fallback for unconfigured node types inside a partial composite).\n" +
+        "\n" +
+        "Production delegate execution (composite router):\n" +
+        "  WORKFLOW_ENGINE_A2A_CONFIG — inline JSON or file path for a2a operator credentials (baseUrl, apiKeyEnv).\n" +
+        "  WORKFLOW_ENGINE_MCP_CONFIG — operator manifest delegateAgents for mcp protocol (same path as tool_call).\n" +
+        "  When none are set, agent_delegate uses MockA2ADelegateExecutor (local demo only; set\n" +
+        "  WORKFLOW_ENGINE_PROFILE=demo to enable mock fallback for unconfigured protocols inside a partial composite).\n" +
         "  Manifest schema: same as `workflows-engine mcp-manifest validate` (mcpServers stdio subset).\n"
     );
     return;
@@ -28,23 +37,41 @@ async function main() {
 
   const manifestPath = resolveWorkflowEngineMcpConfigPath(process.argv);
   let activityExecutor = undefined;
+  let delegateExecutor = undefined;
   try {
-    const loaded = await loadProductionActivityExecutor({ manifestPath });
-    if (!loaded.ok) {
-      if ("errors" in loaded && loaded.errors) {
+    const [activityLoaded, delegateLoaded] = await Promise.all([
+      loadProductionActivityExecutor({ manifestPath }),
+      loadProductionDelegateExecutor({ manifestPath }),
+    ]);
+    if (!activityLoaded.ok) {
+      if ("errors" in activityLoaded && activityLoaded.errors) {
         process.stderr.write(
-          `[engine-mcp-stdio] Invalid operator manifest at ${manifestPath}:\n${formatMcpManifestValidationErrors(loaded.errors)}\n`
+          `[engine-mcp-stdio] Invalid operator manifest at ${manifestPath}:\n${formatMcpManifestValidationErrors(activityLoaded.errors)}\n`
         );
       } else {
-        process.stderr.write(`[engine-mcp-stdio] Activity executor configuration failed: ${loaded.error}\n`);
+        process.stderr.write(`[engine-mcp-stdio] Activity executor configuration failed: ${activityLoaded.error}\n`);
       }
       process.exitCode = 1;
       return;
     }
-    activityExecutor = loaded.executor;
+    activityExecutor = activityLoaded.executor;
+
+    if (!delegateLoaded.ok) {
+      if ("errors" in delegateLoaded && delegateLoaded.errors) {
+        process.stderr.write(
+          `[engine-mcp-stdio] Invalid operator manifest at ${manifestPath}:\n${formatMcpManifestValidationErrors(delegateLoaded.errors)}\n`
+        );
+      } else {
+        process.stderr.write(`[engine-mcp-stdio] Delegate executor configuration failed: ${delegateLoaded.error}\n`);
+      }
+      process.exitCode = 1;
+      return;
+    }
+    delegateExecutor = delegateLoaded.executor;
+    process.stderr.write(formatActivityRoutingSummaryLog(activityLoaded.routingSummary));
   } catch (err) {
     process.stderr.write(
-      `[engine-mcp-stdio] Activity executor configuration failed: ${err instanceof Error ? err.message : String(err)}\n`
+      `[engine-mcp-stdio] Executor configuration failed: ${err instanceof Error ? err.message : String(err)}\n`
     );
     process.exitCode = 1;
     return;
@@ -54,6 +81,7 @@ async function main() {
   const workflowPort = createWorkflowApplicationPort({
     store,
     ...(activityExecutor ? { activityExecutor } : {}),
+    ...(delegateExecutor ? { delegateExecutor } : {}),
   });
   const server = createMcpWorkflowStdioServer(workflowPort);
 

--- a/packages/engine/test/mcp-stdio-entrypoint.test.mjs
+++ b/packages/engine/test/mcp-stdio-entrypoint.test.mjs
@@ -16,4 +16,24 @@ describe("MCP stdio entrypoint", () => {
     assert.match(run.stdout, /workflow_start\/workflow_status\/workflow_resume/i);
     assert.equal(run.stderr, "");
   });
+
+  it("logs activity routing summary on startup for partial operator config", () => {
+    const scriptPath = path.resolve(__dirname, "../src/mcp-stdio-server.mjs");
+    const run = spawnSync(process.execPath, [scriptPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        WORKFLOW_ENGINE_LLM_CONFIG: '{"apiKeyEnv":"TEST_LLM_KEY"}',
+        TEST_LLM_KEY: "sk-test",
+        WORKFLOW_ENGINE_MCP_CONFIG: "",
+      },
+      timeout: 2000,
+    });
+
+    assert.match(
+      run.stderr,
+      /\[engine-mcp-stdio\] activity routing: llm_call=production, tool_call=missing, step=missing/
+    );
+    assert.match(run.stderr, /\[engine-mcp-stdio\] demo stub fallback: inactive/);
+  });
 });

--- a/packages/engine/test/mcp-stdio-server-config.test.mjs
+++ b/packages/engine/test/mcp-stdio-server-config.test.mjs
@@ -5,21 +5,34 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, it } from "node:test";
 import {
+  buildActivityRoutingSummary,
+  formatActivityRoutingSummaryLog,
   formatMcpManifestValidationErrors,
   loadEngineDirectActivityExecutor,
+  loadEngineDirectMcpDelegateExecutor,
   loadProductionActivityExecutor,
+  loadProductionDelegateExecutor,
   loadStepHandlerRegistryFromEnv,
+  resolveA2AOperatorConfigFromEnv,
   resolveLlmOperatorConfigFromEnv,
   resolveWorkflowEngineMcpConfigPath,
 } from "../src/adapters/mcp/stdio-server-config.mjs";
 import { createWorkflowApplicationPort } from "../src/application/workflow-application-port.mjs";
 import { buildCompositeActivityExecutor } from "../src/orchestrator/composite-activity-executor.mjs";
+import { buildCompositeDelegateExecutor } from "../src/orchestrator/composite-delegate-executor.mjs";
+import { A2ADelegateExecutor, HttpA2ATransport } from "../src/orchestrator/a2a-delegate-executor.mjs";
 import { LlmActivityExecutor } from "../src/orchestrator/llm-activity-executor.mjs";
 import { StepActivityExecutor } from "../src/orchestrator/step-activity-executor.mjs";
 import { MemoryExecutionHistoryStore } from "../src/persistence/memory-history-store.mjs";
+import { findWorkflowRepoRoot } from "../src/validate.mjs";
+import { createA2AMockHttpServer } from "./helpers/a2a-mock-http-server.mjs";
 
 const echoServerPath = fileURLToPath(new URL("./fixtures/mcp-echo-stdio-server.mjs", import.meta.url));
 const linearFixturePath = fileURLToPath(new URL("./fixtures/linear.workflow.json", import.meta.url));
+const delegateFixturePath = path.join(
+  findWorkflowRepoRoot(path.dirname(fileURLToPath(import.meta.url))),
+  "examples/conformance-agent-delegate-linear.workflow.json"
+);
 
 describe("resolveWorkflowEngineMcpConfigPath", () => {
   it("prefers --mcp-config over env", () => {
@@ -175,6 +188,87 @@ describe("loadProductionActivityExecutor", () => {
     assert.equal(r.ok, true);
     if (r.ok) assert.ok(r.executor);
   });
+
+  it("returns routingSummary with missing routes for partial config without demo profile", async () => {
+    const r = await loadProductionActivityExecutor({
+      manifestPath: null,
+      llmConfig: { apiKeyEnv: "TEST_LLM_KEY" },
+      stepHandlerRegistry: null,
+      env: { TEST_LLM_KEY: "sk-test" },
+      profile: null,
+    });
+    assert.equal(r.ok, true);
+    if (!r.ok) return;
+    assert.deepEqual(r.routingSummary, {
+      llm_call: "production",
+      tool_call: "missing",
+      step: "missing",
+      demoStubFallback: false,
+    });
+    assert.match(
+      formatActivityRoutingSummaryLog(r.routingSummary),
+      /activity routing: llm_call=production, tool_call=missing, step=missing/
+    );
+    assert.match(formatActivityRoutingSummaryLog(r.routingSummary), /demo stub fallback: inactive/);
+  });
+
+  it("returns routingSummary with stub(demo) for unconfigured routes when demo profile is active", async () => {
+    const r = await loadProductionActivityExecutor({
+      manifestPath: null,
+      llmConfig: { apiKeyEnv: "TEST_LLM_KEY" },
+      stepHandlerRegistry: null,
+      env: { TEST_LLM_KEY: "sk-test", WORKFLOW_ENGINE_PROFILE: "demo" },
+      profile: "demo",
+    });
+    assert.equal(r.ok, true);
+    if (!r.ok) return;
+    assert.deepEqual(r.routingSummary, {
+      llm_call: "production",
+      tool_call: "stub(demo)",
+      step: "stub(demo)",
+      demoStubFallback: true,
+    });
+    assert.match(
+      formatActivityRoutingSummaryLog(r.routingSummary),
+      /activity routing: llm_call=production, tool_call=stub\(demo\), step=stub\(demo\)/
+    );
+    assert.match(formatActivityRoutingSummaryLog(r.routingSummary), /demo stub fallback: active/);
+  });
+
+  it("returns stub(default) routes when no operator config is present", async () => {
+    const r = await loadProductionActivityExecutor({
+      manifestPath: null,
+      llmConfig: null,
+      stepHandlerRegistry: null,
+      env: {},
+    });
+    assert.equal(r.ok, true);
+    if (!r.ok) return;
+    assert.deepEqual(r.routingSummary, {
+      llm_call: "stub(default)",
+      tool_call: "stub(default)",
+      step: "stub(default)",
+      demoStubFallback: false,
+    });
+  });
+});
+
+describe("buildActivityRoutingSummary", () => {
+  it("maps configured and unconfigured composite routes", () => {
+    const summary = buildActivityRoutingSummary({
+      hasLlm: true,
+      hasTool: false,
+      hasStep: false,
+      demoStubFallback: false,
+      compositeMode: true,
+    });
+    assert.deepEqual(summary, {
+      llm_call: "production",
+      tool_call: "missing",
+      step: "missing",
+      demoStubFallback: false,
+    });
+  });
 });
 
 describe("resolveLlmOperatorConfigFromEnv", () => {
@@ -275,5 +369,278 @@ describe("formatMcpManifestValidationErrors", () => {
     ]);
     assert.match(s, /instancePath: \/x/);
     assert.match(s, /must be object/);
+  });
+});
+
+describe("resolveA2AOperatorConfigFromEnv", () => {
+  it("parses inline JSON", () => {
+    const cfg = resolveA2AOperatorConfigFromEnv(
+      { WORKFLOW_ENGINE_A2A_CONFIG: '{"baseUrl":"http://a2a.example","apiKeyEnv":"A2A_KEY"}' },
+      process.cwd()
+    );
+    assert.deepEqual(cfg, { baseUrl: "http://a2a.example", apiKeyEnv: "A2A_KEY" });
+  });
+});
+
+describe("loadEngineDirectMcpDelegateExecutor", () => {
+  it("returns undefined executor when manifest has no delegateAgents", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-mcp-"));
+    const manifestPath = path.join(dir, "mcp.json");
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        mcpServers: {
+          echoSrv: {
+            command: process.execPath,
+            args: [echoServerPath],
+            env: {},
+          },
+        },
+      })
+    );
+    const r = await loadEngineDirectMcpDelegateExecutor(manifestPath);
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.executor, undefined);
+  });
+
+  it("loads McpDelegateExecutor when delegateAgents is present", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-mcp-"));
+    const manifestPath = path.join(dir, "mcp.json");
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        mcpServers: {
+          echoSrv: {
+            command: process.execPath,
+            args: [echoServerPath],
+            env: {},
+          },
+        },
+        delegateAgents: {
+          "urn:test:agents:echo": { server: "echoSrv", tool: "echo" },
+        },
+      })
+    );
+    const r = await loadEngineDirectMcpDelegateExecutor(manifestPath);
+    assert.equal(r.ok, true);
+    if (r.ok) assert.ok(r.executor);
+  });
+});
+
+describe("loadProductionDelegateExecutor", () => {
+  it("returns undefined executor when no operator config is present", async () => {
+    const r = await loadProductionDelegateExecutor({
+      manifestPath: null,
+      a2aConfig: null,
+      env: {},
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.executor, undefined);
+  });
+
+  it("fails fast on invalid A2A config", async () => {
+    const r = await loadProductionDelegateExecutor({
+      manifestPath: null,
+      a2aConfig: { apiKeyEnv: "K" },
+      env: { K: "token" },
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok && "error" in r) assert.match(r.error, /baseUrl/);
+  });
+
+  it("builds composite when A2A config is set", async () => {
+    const r = await loadProductionDelegateExecutor({
+      manifestPath: null,
+      a2aConfig: { baseUrl: "http://a2a.example", apiKeyEnv: "A2A_KEY" },
+      env: { A2A_KEY: "token" },
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) assert.ok(r.executor);
+  });
+
+  it("builds composite when manifest has delegateAgents", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-mcp-"));
+    const manifestPath = path.join(dir, "mcp.json");
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        mcpServers: {
+          echoSrv: {
+            command: process.execPath,
+            args: [echoServerPath],
+            env: {},
+          },
+        },
+        delegateAgents: {
+          "urn:test:agents:echo": { server: "echoSrv", tool: "echo" },
+        },
+      })
+    );
+    const r = await loadProductionDelegateExecutor({ manifestPath, env: {} });
+    assert.equal(r.ok, true);
+    if (r.ok) assert.ok(r.executor);
+  });
+
+  it("adds MockA2ADelegateExecutor fallback when WORKFLOW_ENGINE_PROFILE=demo", async () => {
+    const r = await loadProductionDelegateExecutor({
+      manifestPath: null,
+      a2aConfig: { baseUrl: "http://a2a.example", apiKeyEnv: "A2A_KEY" },
+      env: { A2A_KEY: "token", WORKFLOW_ENGINE_PROFILE: "demo" },
+    });
+    assert.equal(r.ok, true);
+    if (!r.ok) return;
+    const sdkResult = await r.executor.executeDelegate({
+      executionId: "demo-fallback-1",
+      node: { id: "d1", type: "agent_delegate", config: { agent_id: "local" } },
+      state: {},
+      delegateInput: { task: "demo" },
+      protocol: "sdk",
+    });
+    assert.equal(sdkResult.ok, true);
+  });
+});
+
+describe("createWorkflowApplicationPort + production delegate executor", () => {
+  it("workflow_start runs agent_delegate via MCP delegateAgents when configured", async () => {
+    const definition = JSON.parse(readFileSync(delegateFixturePath, "utf8"));
+    const delegateNode = definition.nodes.find((n) => n.id === "implement");
+    assert.ok(delegateNode);
+    delegateNode.config = {
+      agent_id: "urn:test:agents:echo",
+      protocol: "mcp",
+      input_mapping: { task: "${ .task }" },
+    };
+
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-mcp-"));
+    const manifestPath = path.join(dir, "manifest.json");
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        mcpServers: {
+          echoSrv: {
+            command: process.execPath,
+            args: [echoServerPath],
+            env: {},
+          },
+        },
+        delegateAgents: {
+          "urn:test:agents:echo": { server: "echoSrv", tool: "echo" },
+        },
+      })
+    );
+
+    const loaded = await loadProductionDelegateExecutor({ manifestPath, env: {} });
+    assert.equal(loaded.ok, true);
+    if (!loaded.ok) return;
+    assert.ok(loaded.executor);
+
+    const store = new MemoryExecutionHistoryStore();
+    const port = createWorkflowApplicationPort({ store, delegateExecutor: loaded.executor });
+    const out = await port.startWorkflow({
+      executionId: "port-delegate-mcp-1",
+      definition,
+      input: { task: "hello delegate" },
+    });
+
+    assert.equal(out.status, "completed");
+    const rows = store.listByExecution("port-delegate-mcp-1");
+    const completed = rows.filter((r) => r.name === "ActivityCompleted");
+    assert.ok(completed.length >= 1);
+    const last = completed[completed.length - 1];
+    assert.deepEqual(last.payload.result.echoed, { task: "hello delegate" });
+  });
+
+  it("workflow_start runs agent_delegate via A2A config when configured", async () => {
+    const definition = JSON.parse(readFileSync(delegateFixturePath, "utf8"));
+    const mock = createA2AMockHttpServer();
+    const { baseUrl, close } = await mock.listen();
+    try {
+      const loaded = await loadProductionDelegateExecutor({
+        manifestPath: null,
+        a2aConfig: { baseUrl, apiKeyEnv: "A2A_KEY", pollIntervalMs: 10, pollTimeoutMs: 5000 },
+        env: { A2A_KEY: "test-token" },
+      });
+      assert.equal(loaded.ok, true);
+      if (!loaded.ok) return;
+      assert.ok(loaded.executor);
+
+      const store = new MemoryExecutionHistoryStore();
+      const port = createWorkflowApplicationPort({ store, delegateExecutor: loaded.executor });
+      const out = await port.startWorkflow({
+        executionId: "port-delegate-a2a-1",
+        definition,
+        input: { task: "implement feature" },
+      });
+
+      assert.equal(out.status, "completed");
+      const rows = store.listByExecution("port-delegate-a2a-1");
+      const completed = rows.filter((r) => r.name === "ActivityCompleted");
+      assert.ok(completed.length >= 1);
+      const last = completed[completed.length - 1];
+      assert.match(String(last.payload.result.patch), /implement feature/);
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe("CompositeDelegateExecutor integration", () => {
+  it("routes a2a to A2ADelegateExecutor and mcp to manifest delegateAgents", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-mcp-"));
+    const manifestPath = path.join(dir, "manifest.json");
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        mcpServers: {
+          echoSrv: {
+            command: process.execPath,
+            args: [echoServerPath],
+            env: {},
+          },
+        },
+        delegateAgents: {
+          "urn:test:agents:echo": { server: "echoSrv", tool: "echo" },
+        },
+      })
+    );
+
+    const mcpLoaded = await loadEngineDirectMcpDelegateExecutor(manifestPath);
+    assert.equal(mcpLoaded.ok, true);
+    if (!mcpLoaded.ok || !mcpLoaded.executor) return;
+
+    const mock = createA2AMockHttpServer();
+    const { baseUrl, close } = await mock.listen();
+    try {
+      const composite = buildCompositeDelegateExecutor({
+        a2a: new A2ADelegateExecutor({
+          operatorConfig: { baseUrl, apiKeyEnv: "K", pollIntervalMs: 10, pollTimeoutMs: 5000 },
+          env: { K: "token" },
+          transport: new HttpA2ATransport({ baseUrl }),
+        }),
+        mcp: mcpLoaded.executor,
+      });
+
+      const a2a = await composite.executeDelegate({
+        executionId: "composite-delegate-1",
+        node: { id: "a2a-node", type: "agent_delegate", config: { agent_id: "coder" } },
+        state: {},
+        delegateInput: { task: "a2a task" },
+        protocol: "a2a",
+      });
+      assert.equal(a2a.ok, true);
+      if (a2a.ok) assert.match(String(a2a.output.patch), /a2a task/);
+
+      const mcp = await composite.executeDelegate({
+        executionId: "composite-delegate-1",
+        node: { id: "mcp-node", type: "agent_delegate", config: { agent_id: "urn:test:agents:echo" } },
+        state: {},
+        delegateInput: { task: "mcp task" },
+        protocol: "mcp",
+      });
+      assert.equal(mcp.ok, true);
+      if (mcp.ok) assert.deepEqual(mcp.output.echoed, { task: "mcp task" });
+    } finally {
+      await close();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- **BEN-114**: Add loadProductionDelegateExecutor and wire production delegate routing into workflows-engine-mcp (A2A config + manifest delegateAgents, demo mock fallback only).
- **BEN-116**: Emit structured stderr activity routing summary on MCP stdio startup for partial operator config diagnosis.
- **BEN-115, BEN-117, BEN-119**: Operator documentation for A2A blocking/input-required footguns, static WORKFLOW_ENGINE_STEP_HANDLERS limits, and LLM prompt jq templating gaps.

## Spec and architecture traceability

- Spec artifact link: docs/engine-profile.md, docs/user/a2a-delegate-mapping.md, docs/architecture/arc42-assets/contracts/mcp-operator-manifest.md
- Architecture decision link: ADR-0002 (host-mediated), ADR-0003 (engine-direct MCP)
- [x] Scope and constraints reviewed against docs/engine-profile.md and relevant RFC sections
- [x] Operator docs updated alongside behavior/contract clarifications

## Roadmap alignment

- Linked issues: BEN-114, BEN-115, BEN-116, BEN-117, BEN-119 (parent epics BEN-82, BEN-83 under BEN-81)
- Target release: R4 GA 1.0
- Type: feature + docs

## Validation

- [x] pm test (205 passed)
- [x] pm run conformance (52/52 passed)
- [x] pm run check-docs-nav-sync
- [x] Docs updated for operator constraints and MCP wiring

## Risk and rollback

- Risk level: low
- Rollback/fallback plan: revert PR; MCP stdio without new env vars retains prior stub/mock defaults

Made with [Cursor](https://cursor.com)