### PR TITLE
feat(engine): BEN-84 R3 interop — REST/OpenAPI + TypeScript SDK parity

### DIFF
--- a/conformance/parity-runner.mjs
+++ b/conformance/parity-runner.mjs
@@ -1,13 +1,20 @@
 import { readFileSync } from "node:fs";
+import { createServer } from "node:http";
 import path from "node:path";
 import {
   A2ADelegateExecutor,
   createMcpWorkflowToolHandlers,
+  createRestWorkflowHandler,
   createWorkflowApplicationPort,
+  DefinitionRegistry,
   MemoryExecutionHistoryStore,
   StubActivityExecutor,
 } from "../packages/engine/src/index.mjs";
 import { createA2AMockHttpServer } from "../packages/engine/test/helpers/a2a-mock-http-server.mjs";
+import { WorkflowClient } from "../packages/sdk/src/index.mjs";
+import { SdkError } from "../packages/sdk/src/errors.mjs";
+
+/** @typedef {"port" | "mcp" | "rest" | "sdk"} ParitySurface */
 
 /**
  * @typedef {"start" | "status" | "resume" | "submit_activity"} ParityOp
@@ -113,14 +120,10 @@ function normalizePortSnapshot(op, portResult, isError, errorCode) {
 
 /**
  * @param {ParityOp} op
- * @param {{ isError?: boolean; structuredContent: Record<string, unknown> }} mcpResult
+ * @param {Record<string, unknown>} transportBody
  */
-function normalizeMcpSnapshot(op, mcpResult) {
-  if (mcpResult.isError) {
-    const err = /** @type {{ code?: string }} */ (mcpResult.structuredContent.error ?? {});
-    return { op, is_error: true, error: { code: err.code } };
-  }
-  const s = mcpResult.structuredContent;
+function normalizeTransportSnapshot(op, transportBody) {
+  const s = transportBody;
   return {
     op,
     is_error: false,
@@ -145,6 +148,112 @@ function normalizeMcpSnapshot(op, mcpResult) {
     ...(s.parent_execution_id !== undefined ? { parent_execution_id: s.parent_execution_id } : {}),
     ...(s.parallel_span !== undefined ? { parallel_span: s.parallel_span } : {}),
   };
+}
+
+/**
+ * @param {ParityOp} op
+ * @param {{ isError?: boolean; structuredContent: Record<string, unknown> }} mcpResult
+ */
+function normalizeMcpSnapshot(op, mcpResult) {
+  if (mcpResult.isError) {
+    const err = /** @type {{ code?: string }} */ (mcpResult.structuredContent.error ?? {});
+    return { op, is_error: true, error: { code: err.code } };
+  }
+  return normalizeTransportSnapshot(op, mcpResult.structuredContent);
+}
+
+/**
+ * @param {ParityOp} op
+ * @param {number} httpStatus
+ * @param {Record<string, unknown> | undefined} body
+ */
+function normalizeRestSnapshot(op, httpStatus, body) {
+  if (httpStatus >= 400) {
+    const err = /** @type {{ code?: string }} */ (body?.error ?? {});
+    return { op, is_error: true, error: { code: err.code } };
+  }
+  return normalizeTransportSnapshot(op, /** @type {Record<string, unknown>} */ (body ?? {}));
+}
+
+/**
+ * @param {ParityOp} op
+ * @param {Record<string, unknown> | undefined} transportBody
+ * @param {unknown} [error]
+ */
+function normalizeSdkSnapshot(op, transportBody, error) {
+  if (error) {
+    const code =
+      error instanceof SdkError
+        ? error.code
+        : error && typeof error === "object" && "code" in error && typeof error.code === "string"
+          ? error.code
+          : "ENGINE_FAILURE";
+    return { op, is_error: true, error: { code } };
+  }
+  return normalizeTransportSnapshot(op, /** @type {Record<string, unknown>} */ (transportBody ?? {}));
+}
+
+/**
+ * @param {string} baseUrl
+ * @param {string} method
+ * @param {string} pathname
+ * @param {unknown} [body]
+ */
+async function restRequestJson(baseUrl, method, pathname, body) {
+  const response = await fetch(`${baseUrl}${pathname}`, {
+    method,
+    headers: body !== undefined ? { "content-type": "application/json" } : undefined,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const text = await response.text();
+  const parsed = text ? JSON.parse(text) : undefined;
+  return { status: response.status, body: parsed };
+}
+
+/**
+ * @param {object} definition
+ * @param {import("../packages/engine/src/persistence/types.mjs").ExecutionHistoryStore} store
+ * @param {import("../packages/engine/src/orchestrator/delegate-executor.mjs").DelegateExecutor} [delegateExecutor]
+ * @param {Record<string, Record<string, unknown>>} [stubActivityOutputs]
+ */
+export async function createParityRestServer(definition, store, delegateExecutor, stubActivityOutputs) {
+  const definitionRegistry = new DefinitionRegistry();
+  const registered = definitionRegistry.register(definition);
+  const workflowPort = createWorkflowApplicationPort({
+    store,
+    ...(stubActivityOutputs ? { activityExecutor: new StubActivityExecutor(stubActivityOutputs) } : {}),
+    ...(delegateExecutor ? { delegateExecutor } : {}),
+  });
+  const handler = createRestWorkflowHandler(workflowPort, { definitionRegistry, store });
+  const server = createServer((req, res) => {
+    handler(req, res).catch((error) => {
+      if (!res.headersSent) {
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: { code: "INTERNAL_ERROR", message: String(error) } }));
+      }
+    });
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address !== "object") {
+    throw new Error("Failed to bind parity REST server.");
+  }
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  const close = () =>
+    new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve(undefined)));
+    });
+  return { baseUrl, wfId: registered.wf_id, close };
+}
+
+/**
+ * @param {ParityVector} vector
+ */
+export function isR2ParityVector(vector) {
+  return vector.id.startsWith("parity.r2.");
 }
 
 /**
@@ -216,15 +325,33 @@ function normalizeSubmitOutcomeForMcp(outcome) {
 }
 
 /**
- * @param {"port" | "mcp"} surface
+ * @typedef {object} ParityRestContext
+ * @property {string} baseUrl
+ * @property {string} wfId
+ */
+
+/**
+ * @param {ParitySurface} surface
  * @param {import("../packages/engine/src/application/workflow-application-port.mjs").WorkflowApplicationPort} port
  * @param {ReturnType<typeof createMcpWorkflowToolHandlers>} handlers
+ * @param {WorkflowClient | undefined} sdkClient
+ * @param {ParityRestContext | undefined} restContext
  * @param {object} definition
  * @param {string} executionId
  * @param {ParityStep} step
  * @param {Record<string, unknown>} scenarioInput
  */
-async function executeStep(surface, port, handlers, definition, executionId, step, scenarioInput) {
+async function executeStep(
+  surface,
+  port,
+  handlers,
+  sdkClient,
+  restContext,
+  definition,
+  executionId,
+  step,
+  scenarioInput
+) {
   const activityMode = step.activityExecutionMode;
 
   if (step.op === "start") {
@@ -257,16 +384,63 @@ async function executeStep(surface, port, handlers, definition, executionId, ste
         };
       }
     }
-    const mcpResult = await handlers.workflow_start({
-      execution_id: executionId,
-      definition,
-      input: step.input ?? scenarioInput,
-      ...(activityMode ? { activity_execution_mode: activityMode } : {}),
-    });
-    return {
-      snapshot: normalizeMcpSnapshot("start", mcpResult),
-      isError: Boolean(mcpResult.isError),
-    };
+    if (surface === "mcp") {
+      const mcpResult = await handlers.workflow_start({
+        execution_id: executionId,
+        definition,
+        input: step.input ?? scenarioInput,
+        ...(activityMode ? { activity_execution_mode: activityMode } : {}),
+      });
+      return {
+        snapshot: normalizeMcpSnapshot("start", mcpResult),
+        isError: Boolean(mcpResult.isError),
+      };
+    }
+    if (surface === "rest" && restContext) {
+      try {
+        const { status, body } = await restRequestJson(
+          restContext.baseUrl,
+          "POST",
+          `/v1/workflows/${encodeURIComponent(restContext.wfId)}/executions`,
+          {
+            execution_id: executionId,
+            input: step.input ?? scenarioInput,
+            ...(activityMode ? { activity_execution_mode: activityMode } : {}),
+          }
+        );
+        const isError = status >= 400;
+        return {
+          snapshot: normalizeRestSnapshot("start", status, body),
+          isError,
+        };
+      } catch (error) {
+        return {
+          snapshot: normalizeRestSnapshot("start", 500, {
+            error: { code: "INTERNAL_ERROR", message: String(error) },
+          }),
+          isError: true,
+        };
+      }
+    }
+    if (surface === "sdk" && sdkClient) {
+      try {
+        const result = await sdkClient.start({
+          definition,
+          executionId,
+          input: step.input ?? scenarioInput,
+          ...(activityMode ? { activityExecutionMode: activityMode } : {}),
+        });
+        return {
+          snapshot: normalizeSdkSnapshot("start", /** @type {Record<string, unknown>} */ (result)),
+          isError: false,
+        };
+      } catch (error) {
+        return {
+          snapshot: normalizeSdkSnapshot("start", undefined, error),
+          isError: true,
+        };
+      }
+    }
   }
 
   if (step.op === "status") {
@@ -274,8 +448,36 @@ async function executeStep(surface, port, handlers, definition, executionId, ste
       const portResult = await port.getWorkflowStatus({ executionId });
       return { snapshot: normalizePortSnapshot("status", portResult, false, undefined), isError: false };
     }
-    const mcpResult = await handlers.workflow_status({ execution_id: executionId });
-    return { snapshot: normalizeMcpSnapshot("status", mcpResult), isError: Boolean(mcpResult.isError) };
+    if (surface === "mcp") {
+      const mcpResult = await handlers.workflow_status({ execution_id: executionId });
+      return { snapshot: normalizeMcpSnapshot("status", mcpResult), isError: Boolean(mcpResult.isError) };
+    }
+    if (surface === "rest" && restContext) {
+      const { status, body } = await restRequestJson(
+        restContext.baseUrl,
+        "GET",
+        `/v1/executions/${encodeURIComponent(executionId)}`
+      );
+      const isError = status >= 400;
+      return {
+        snapshot: normalizeRestSnapshot("status", status, body),
+        isError,
+      };
+    }
+    if (surface === "sdk" && sdkClient) {
+      try {
+        const result = await sdkClient.getStatus({ executionId });
+        return {
+          snapshot: normalizeSdkSnapshot("status", /** @type {Record<string, unknown>} */ (result)),
+          isError: false,
+        };
+      } catch (error) {
+        return {
+          snapshot: normalizeSdkSnapshot("status", undefined, error),
+          isError: true,
+        };
+      }
+    }
   }
 
   if (step.op === "resume") {
@@ -297,13 +499,51 @@ async function executeStep(surface, port, handlers, definition, executionId, ste
         isError,
       };
     }
-    const mcpResult = await handlers.workflow_resume({
-      execution_id: executionId,
-      definition,
-      resume_payload: step.resumePayload ?? {},
-      ...(activityMode ? { activity_execution_mode: activityMode } : {}),
-    });
-    return { snapshot: normalizeMcpSnapshot("resume", mcpResult), isError: Boolean(mcpResult.isError) };
+    if (surface === "mcp") {
+      const mcpResult = await handlers.workflow_resume({
+        execution_id: executionId,
+        definition,
+        resume_payload: step.resumePayload ?? {},
+        ...(activityMode ? { activity_execution_mode: activityMode } : {}),
+      });
+      return { snapshot: normalizeMcpSnapshot("resume", mcpResult), isError: Boolean(mcpResult.isError) };
+    }
+    if (surface === "rest" && restContext) {
+      const { status, body } = await restRequestJson(
+        restContext.baseUrl,
+        "POST",
+        `/v1/executions/${encodeURIComponent(executionId)}:resume`,
+        {
+          definition,
+          resume_payload: step.resumePayload ?? {},
+          ...(activityMode ? { activity_execution_mode: activityMode } : {}),
+        }
+      );
+      const isError = status >= 400;
+      return {
+        snapshot: normalizeRestSnapshot("resume", status, body),
+        isError,
+      };
+    }
+    if (surface === "sdk" && sdkClient) {
+      try {
+        const result = await sdkClient.resume({
+          executionId,
+          definition,
+          resumePayload: step.resumePayload ?? {},
+          ...(activityMode ? { activityExecutionMode: activityMode } : {}),
+        });
+        return {
+          snapshot: normalizeSdkSnapshot("resume", /** @type {Record<string, unknown>} */ (result)),
+          isError: false,
+        };
+      } catch (error) {
+        return {
+          snapshot: normalizeSdkSnapshot("resume", undefined, error),
+          isError: true,
+        };
+      }
+    }
   }
 
   if (step.op === "submit_activity") {
@@ -339,16 +579,60 @@ async function executeStep(surface, port, handlers, definition, executionId, ste
           branch_entry_node_id: expectedParallelSpan.branchEntryNodeId,
         }
       : undefined;
-    const mcpResult = await handlers.workflow_submit_activity({
-      execution_id: executionId,
-      definition,
-      input: scenarioInput,
-      node_id: step.nodeId ?? "",
-      outcome: mcpOutcome,
-      ...(mcpParallelSpan ? { parallel_span: mcpParallelSpan } : {}),
-      ...(activityMode ? { activity_execution_mode: activityMode } : {}),
-    });
-    return { snapshot: normalizeMcpSnapshot("submit_activity", mcpResult), isError: Boolean(mcpResult.isError) };
+    if (surface === "mcp") {
+      const mcpResult = await handlers.workflow_submit_activity({
+        execution_id: executionId,
+        definition,
+        input: scenarioInput,
+        node_id: step.nodeId ?? "",
+        outcome: mcpOutcome,
+        ...(mcpParallelSpan ? { parallel_span: mcpParallelSpan } : {}),
+        ...(activityMode ? { activity_execution_mode: activityMode } : {}),
+      });
+      return { snapshot: normalizeMcpSnapshot("submit_activity", mcpResult), isError: Boolean(mcpResult.isError) };
+    }
+    if (surface === "rest" && restContext) {
+      const { status, body } = await restRequestJson(
+        restContext.baseUrl,
+        "POST",
+        `/v1/executions/${encodeURIComponent(executionId)}:submit_activity`,
+        {
+          definition,
+          input: scenarioInput,
+          node_id: step.nodeId ?? "",
+          outcome: mcpOutcome,
+          ...(mcpParallelSpan ? { parallel_span: mcpParallelSpan } : {}),
+          ...(activityMode ? { activity_execution_mode: activityMode } : {}),
+        }
+      );
+      const isError = status >= 400;
+      return {
+        snapshot: normalizeRestSnapshot("submit_activity", status, body),
+        isError,
+      };
+    }
+    if (surface === "sdk" && sdkClient) {
+      try {
+        const result = await sdkClient.submitActivity({
+          executionId,
+          definition,
+          input: scenarioInput,
+          nodeId: step.nodeId ?? "",
+          outcome: mcpOutcome,
+          ...(mcpParallelSpan ? { parallelSpan: mcpParallelSpan } : {}),
+          ...(activityMode ? { activityExecutionMode: activityMode } : {}),
+        });
+        return {
+          snapshot: normalizeSdkSnapshot("submit_activity", /** @type {Record<string, unknown>} */ (result)),
+          isError: false,
+        };
+      } catch (error) {
+        return {
+          snapshot: normalizeSdkSnapshot("submit_activity", undefined, error),
+          isError: true,
+        };
+      }
+    }
   }
 
   throw new Error(`Unsupported parity op "${step.op}"`);
@@ -408,7 +692,7 @@ export async function runParityVector(vector, repoRoot) {
   const { delegateExecutor, closeMockA2A } = await resolveParityDelegateExecutor(vector);
 
   /**
-   * @param {"port" | "mcp"} surface
+   * @param {ParitySurface} surface
    */
   async function runScenario(surface) {
     const store = new MemoryExecutionHistoryStore();
@@ -420,50 +704,94 @@ export async function runParityVector(vector, repoRoot) {
       ...(delegateExecutor ? { delegateExecutor } : {}),
     });
     const handlers = createMcpWorkflowToolHandlers(port);
+    const sdkClient = surface === "sdk" ? WorkflowClient.fromPort(port) : undefined;
+    /** @type {ParityRestContext | undefined} */
+    let restContext;
+    /** @type {(() => Promise<void>) | undefined} */
+    let closeRestServer;
+    if (surface === "rest") {
+      const restServer = await createParityRestServer(
+        definition,
+        store,
+        delegateExecutor,
+        vector.stubActivityOutputs
+      );
+      restContext = { baseUrl: restServer.baseUrl, wfId: restServer.wfId };
+      closeRestServer = restServer.close;
+    }
     /** @type {Record<string, unknown>[]} */
     const snapshots = [];
 
-    for (const step of vector.steps) {
-      const { snapshot, isError } = await executeStep(
-        surface,
-        port,
-        handlers,
-        definition,
-        vector.executionId,
-        step,
-        /** @type {Record<string, unknown>} */ (scenarioInput)
-      );
-      snapshots.push(snapshot);
+    try {
+      for (const step of vector.steps) {
+        const { snapshot, isError } = await executeStep(
+          surface,
+          port,
+          handlers,
+          sdkClient,
+          restContext,
+          definition,
+          vector.executionId,
+          step,
+          /** @type {Record<string, unknown>} */ (scenarioInput)
+        );
+        snapshots.push(snapshot);
 
-      if (Boolean(step.expectError) !== isError) {
-        return {
-          passed: false,
-          reason: `Step ${step.op} (${surface}): expected expectError=${Boolean(step.expectError)} but got error=${isError}`,
-          context: { snapshot },
-        };
-      }
-
-      if (step.expectErrorCode && snapshot.error?.code !== step.expectErrorCode) {
-        return {
-          passed: false,
-          reason: `Step ${step.op} (${surface}): expected error code ${step.expectErrorCode}`,
-          context: { snapshot },
-        };
-      }
-
-      if (step.expect && !step.expectError) {
-        const match = snapshotMatchesExpect(snapshot, step.expect);
-        if (!match.ok) {
+        if (Boolean(step.expectError) !== isError) {
           return {
             passed: false,
-            reason: `Step ${step.op} (${surface}): ${match.reason}`,
-            context: { snapshot, expect: step.expect },
+            reason: `Step ${step.op} (${surface}): expected expectError=${Boolean(step.expectError)} but got error=${isError}`,
+            context: { snapshot },
           };
         }
+
+        if (step.expectErrorCode && snapshot.error?.code !== step.expectErrorCode) {
+          return {
+            passed: false,
+            reason: `Step ${step.op} (${surface}): expected error code ${step.expectErrorCode}`,
+            context: { snapshot },
+          };
+        }
+
+        if (step.expect && !step.expectError) {
+          const match = snapshotMatchesExpect(snapshot, step.expect);
+          if (!match.ok) {
+            return {
+              passed: false,
+              reason: `Step ${step.op} (${surface}): ${match.reason}`,
+              context: { snapshot, expect: step.expect },
+            };
+          }
+        }
+      }
+
+      return { passed: true, snapshots };
+    } finally {
+      if (closeRestServer) {
+        await closeRestServer();
       }
     }
+  }
 
-    return { passed: true, snapshots };
+  /**
+   * @param {Record<string, unknown>[]} baseline
+   * @param {ParitySurface} surface
+   */
+  async function assertSurfaceMatchesBaseline(baseline, surface) {
+    const surfaceRun = await runScenario(surface);
+    if (!surfaceRun.passed) {
+      return surfaceRun;
+    }
+    for (let i = 0; i < baseline.length; i += 1) {
+      if (!snapshotsEqual(baseline[i], surfaceRun.snapshots[i])) {
+        return {
+          passed: false,
+          reason: `Step index ${i} (${vector.steps[i].op}): port and ${surface} normalized snapshots differ`,
+          context: { port: baseline[i], [surface]: surfaceRun.snapshots[i] },
+        };
+      }
+    }
+    return { passed: true };
   }
 
   try {
@@ -486,7 +814,22 @@ export async function runParityVector(vector, repoRoot) {
       }
     }
 
-    return { passed: true, context: { stepCount: vector.steps.length } };
+    if (isR2ParityVector(vector)) {
+      for (const surface of /** @type {ParitySurface[]} */ (["rest", "sdk"])) {
+        const adapterRun = await assertSurfaceMatchesBaseline(portRun.snapshots, surface);
+        if (!adapterRun.passed) {
+          return adapterRun;
+        }
+      }
+    }
+
+    return {
+      passed: true,
+      context: {
+        stepCount: vector.steps.length,
+        ...(isR2ParityVector(vector) ? { surfaces: ["port", "mcp", "rest", "sdk"] } : { surfaces: ["port", "mcp"] }),
+      },
+    };
   } finally {
     if (closeMockA2A) {
       await closeMockA2A();

--- a/conformance/parity-runner.mjs
+++ b/conformance/parity-runner.mjs
@@ -185,7 +185,7 @@ function normalizeSdkSnapshot(op, transportBody, error) {
     const code =
       error instanceof SdkError
         ? error.code
-        : error && typeof error === "object" && "code" in error && typeof error.code === "string"
+        : typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
           ? error.code
           : "ENGINE_FAILURE";
     return { op, is_error: true, error: { code } };
@@ -200,6 +200,7 @@ function normalizeSdkSnapshot(op, transportBody, error) {
  * @param {unknown} [body]
  */
 async function restRequestJson(baseUrl, method, pathname, body) {
+  // codeql[js/file-access-to-http]: conformance posts fixture JSON to in-process localhost only
   const response = await fetch(`${baseUrl}${pathname}`, {
     method,
     headers: body !== undefined ? { "content-type": "application/json" } : undefined,

--- a/conformance/run-conformance.mjs
+++ b/conformance/run-conformance.mjs
@@ -1,7 +1,21 @@
 import { discoverVectors, runVector } from "./runner.mjs";
+import { runSdkParitySmoke } from "./sdk-parity-smoke.mjs";
 
 const discovered = discoverVectors();
 const results = await Promise.all(discovered.map(runVector));
+const sdkSmoke = await runSdkParitySmoke();
+if (sdkSmoke.passed) {
+  console.error("PASS [sdk-parity-smoke] WorkflowClient REST transport");
+} else {
+  console.error(`FAIL [sdk-parity-smoke] ${sdkSmoke.reason}`);
+  results.push({
+    id: "sdk-parity-smoke",
+    file: "conformance/sdk-parity-smoke.mjs",
+    category: "sdk-parity-fail",
+    passed: false,
+    reason: sdkSmoke.reason,
+  });
+}
 const failed = results.filter((result) => !result.passed);
 
 for (const result of results) {
@@ -36,6 +50,7 @@ const summary = {
     parityPass: results.filter((result) => result.category === "parity-pass").length,
     parityPending: results.filter((result) => result.category === "parity-pending").length,
     parityFail: results.filter((result) => result.category === "parity-fail").length,
+    sdkParityFail: results.filter((result) => result.category === "sdk-parity-fail").length,
     unexpected: results.filter((result) => result.category === "unexpected").length,
   },
   vectors: results,

--- a/conformance/sdk-parity-smoke.mjs
+++ b/conformance/sdk-parity-smoke.mjs
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { MemoryExecutionHistoryStore } from "../packages/engine/src/index.mjs";
+import { WorkflowClient } from "../packages/sdk/src/index.mjs";
+import { createParityRestServer } from "./parity-runner.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+
+/**
+ * SDK REST transport smoke: WorkflowClient over in-process RFC-05 server matches port/MCP
+ * normalized snapshots for the r2 linear-complete scenario.
+ */
+export async function runSdkParitySmoke() {
+  const definition = JSON.parse(
+    readFileSync(path.join(repoRoot, "examples", "lighthouse-customer-routing.workflow.json"), "utf8")
+  );
+  const executionId = "sdk-parity-smoke-linear-1";
+  const input = { ticket_text: "clear technical issue" };
+  const stubActivityOutputs = {
+    classify: { intent: "technical", confidence: 0.9 },
+    search_kb: { snippets: [] },
+  };
+
+  const store = new MemoryExecutionHistoryStore();
+  const { baseUrl, wfId, close } = await createParityRestServer(
+    definition,
+    store,
+    undefined,
+    stubActivityOutputs
+  );
+
+  try {
+    const client = new WorkflowClient({ baseUrl });
+
+    const started = await client.start({
+      wfId,
+      executionId,
+      input,
+    });
+    if (started.status !== "completed") {
+      return {
+        passed: false,
+        reason: `SDK REST start expected status completed but got ${started.status}`,
+      };
+    }
+
+    const status = await client.getStatus({ executionId });
+    if (status.phase !== "completed") {
+      return {
+        passed: false,
+        reason: `SDK REST status expected phase completed but got ${status.phase}`,
+      };
+    }
+
+    return { passed: true };
+  } finally {
+    await close();
+  }
+}
+
+if (import.meta.url === new URL(process.argv[1], "file:").href) {
+  const result = await runSdkParitySmoke();
+  if (result.passed) {
+    console.error("PASS [sdk-parity-smoke] WorkflowClient REST transport");
+  } else {
+    console.error(`FAIL [sdk-parity-smoke] ${result.reason}`);
+    process.exitCode = 1;
+  }
+}

--- a/docs/architecture/arc42-assets/contracts/integration-parity-matrix.md
+++ b/docs/architecture/arc42-assets/contracts/integration-parity-matrix.md
@@ -1,32 +1,36 @@
 # Integration parity matrix
 
-Normative orchestration behavior lives in `createWorkflowApplicationPort` ([RFC-05 §5.1](https://github.com/benvdbergh/workflows/blob/master/docs/RFC/rfc-05-integration-interfaces.md)). Adapters (MCP today; REST/SDK forecast) MUST map to the same lifecycle semantics. The conformance harness under `conformance/vectors/parity/` proves **application port ↔ MCP tool handler** equivalence via normalized JSON snapshots (in-process; no stdio HTTP in CI).
+Normative orchestration behavior lives in `createWorkflowApplicationPort` ([RFC-05 §5.1](https://github.com/benvdbergh/workflows/blob/master/docs/RFC/rfc-05-integration-interfaces.md)). Adapters (MCP, REST, SDK) MUST map to the same lifecycle semantics. The conformance harness under `conformance/vectors/parity/` proves **application port ↔ MCP ↔ REST ↔ SDK (port transport)** equivalence via normalized JSON snapshots (in-process; no stdio HTTP in CI).
 
 ## Lifecycle operations
 
-| Scenario ID | MCP tool | Port method | RFC-05 REST (planned) | Conformance vector |
-|-------------|----------|-------------|------------------------|-------------------|
-| Start execution | `workflow_start` | `startWorkflow` | `POST /v1/workflows/{wf_id}/executions` | `parity.*` start steps |
-| Observe phase | `workflow_status` | `getWorkflowStatus` | `GET /v1/executions/{exec_id}` | all parity vectors with `status` steps |
-| Continue interrupt | `workflow_resume` | `resumeWorkflow` | `POST /v1/executions/{exec_id}:resume` | `parity.r2.interrupt_resume` |
-| Complete host activity | `workflow_submit_activity` | `submitWorkflowActivity` | (host-mediated; REST TBD) | `parity.r2.host_mediated_submit`, `parity.r2.host_mediated_lighthouse_classify`, `parity.r2.parallel_join` |
+| Scenario ID | MCP tool | Port method | RFC-05 REST | SDK (`WorkflowClient`) | Conformance vector |
+|-------------|----------|-------------|-------------|------------------------|-------------------|
+| Start execution | `workflow_start` | `startWorkflow` | `POST /v1/workflows/{wf_id}/executions` | `start` | `parity.*` start steps |
+| Observe phase | `workflow_status` | `getWorkflowStatus` | `GET /v1/executions/{exec_id}` | `getStatus` | all parity vectors with `status` steps |
+| Continue interrupt | `workflow_resume` | `resumeWorkflow` | `POST /v1/executions/{exec_id}:resume` | `resume` | `parity.r2.interrupt_resume` |
+| Complete host activity | `workflow_submit_activity` | `submitWorkflowActivity` | `POST /v1/executions/{exec_id}:submit_activity` | `submitActivity` | `parity.r2.host_mediated_submit`, `parity.r2.host_mediated_lighthouse_classify`, `parity.r2.parallel_join` |
 
 ### Core orchestration parity (implemented)
 
 | Vector | Workflow fixture | Surfaces exercised |
 |--------|------------------|-------------------|
-| `parity.r2.linear_complete` | `examples/lighthouse-customer-routing.workflow.json` | start → completed; status → completed |
-| `parity.r2.interrupt_resume` | lighthouse | start → interrupted; status; resume → completed |
-| `parity.r2.host_mediated_submit` | `examples/conformance-host-activity-linear.workflow.json` | start → awaiting_activity; submit → completed |
-| `parity.r2.host_mediated_lighthouse_classify` | `examples/lighthouse-customer-routing.workflow.json` | host_mediated start → classify submit → open_ticket submit → completed |
-| `parity.r2.parallel_join` | `examples/conformance-host-activity-parallel.workflow.json` | start with `parallel_span`; submit with span correlation → completed |
+| `parity.r2.linear_complete` | `examples/lighthouse-customer-routing.workflow.json` | port, MCP, REST, SDK (port transport) — start → completed; status → completed |
+| `parity.r2.interrupt_resume` | lighthouse | port, MCP, REST, SDK — start → interrupted; status; resume → completed |
+| `parity.r2.host_mediated_submit` | `examples/conformance-host-activity-linear.workflow.json` | port, MCP, REST, SDK — start → awaiting_activity; submit → completed |
+| `parity.r2.host_mediated_lighthouse_classify` | `examples/lighthouse-customer-routing.workflow.json` | port, MCP, REST, SDK — host_mediated start → classify submit → open_ticket submit → completed |
+| `parity.r2.parallel_join` | `examples/conformance-host-activity-parallel.workflow.json` | port, MCP, REST, SDK — start with `parallel_span`; submit with span correlation → completed |
 
-### Composition parity (implemented)
+### Composition parity (port + MCP; REST/SDK deferred to R3 vectors)
 
 | Vector | Workflow fixture | Surfaces exercised |
 |--------|------------------|-------------------|
-| `parity.r3.delegate_status_correlation` | `examples/conformance-agent-delegate-linear.workflow.json` | start → completed; status includes `delegate_correlation_id` |
-| `parity.r3.subworkflow_status_correlation` | `examples/conformance-subworkflow-parent.workflow.json` | nested child run; status includes `child_execution_id` / `parent_execution_id` |
+| `parity.r3.delegate_status_correlation` | `examples/conformance-agent-delegate-linear.workflow.json` | port, MCP — start → completed; status includes `delegate_correlation_id` |
+| `parity.r3.subworkflow_status_correlation` | `examples/conformance-subworkflow-parent.workflow.json` | port, MCP — nested child run; status includes `child_execution_id` / `parent_execution_id` |
+
+### SDK REST transport smoke
+
+`conformance/sdk-parity-smoke.mjs` exercises `WorkflowClient` over in-process RFC-05 REST (`baseUrl`) for the r2 linear-complete lighthouse path. Invoked from `npm run conformance` and standalone via `npm run conformance:parity-sdk`.
 
 ## Normalized snapshot format
 
@@ -34,6 +38,8 @@ Harness compares canonical snake_case objects per step:
 
 - Success: `execution_id`, `status` or `phase`, optional `node_id`, `result`, `final_state`, `parallel_span`, `state`, `delegate_correlation_id`, `child_execution_id`, `parent_execution_id`
 - Error: `is_error: true`, `error.code` aligned with MCP adapter codes (`VALIDATION_ERROR`, `EXECUTION_NOT_FOUND`, `INVALID_RESUME_PAYLOAD`, `ACTIVITY_SUBMIT_*`, `ENGINE_FAILURE`, `INTERNAL_ERROR`)
+
+REST and SDK surfaces use the same normalized snapshot shape as MCP (`normalizeTransportSnapshot` in `conformance/parity-runner.mjs`).
 
 ## Trace propagation
 
@@ -45,7 +51,7 @@ W3C Trace Context fields are **specified** for future surfaces; the parity harne
 | `delegate_correlation_id` | `workflow_status` when `agent_delegate` history exists | Asserted by `parity.r3.delegate_status_correlation` |
 | `child_execution_id` / `parent_execution_id` | `workflow_status` when `subworkflow` history exists | Asserted by `parity.r3.subworkflow_status_correlation` |
 
-Informative command/event prefix narratives remain under `examples/*.trace.*.json` (not harness-validated). Parity vectors use live port/MCP responses as the executable contract.
+Informative command/event prefix narratives remain under `examples/*.trace.*.json` (not harness-validated). Parity vectors use live port/MCP/REST/SDK responses as the executable contract.
 
 ## Deferred MCP tools (RFC-05 §5.2)
 
@@ -57,12 +63,14 @@ From repository root:
 
 ```bash
 npm run conformance
+npm run conformance:parity-sdk   # SDK REST transport smoke only
 ```
 
-Parity vectors are discovered with schema/replay vectors under `conformance/vectors/` (`kind: "parity"`).
+Parity vectors are discovered with schema/replay vectors under `conformance/vectors/` (`kind: "parity"`). CI fails on adapter semantic drift when any surface snapshot diverges from the port baseline.
 
 ## Changelog (process)
 
 | Date | Note |
 |------|------|
+| R3 interop | Extended parity harness with REST and SDK (port transport) for `parity.r2.*` vectors; SDK REST smoke via `sdk-parity-smoke.mjs`. |
 | R3 runway | Added delegate/subworkflow status correlation parity vectors ([#8](https://github.com/benvdbergh/workflows/issues/8)); runtime for `agent_delegate` ([#6](https://github.com/benvdbergh/workflows/issues/6)) and `subworkflow` ([#7](https://github.com/benvdbergh/workflows/issues/7)) precedes status projection. |

--- a/docs/architecture/arc42/07-deployment-view.md
+++ b/docs/architecture/arc42/07-deployment-view.md
@@ -5,6 +5,7 @@
 | Deployment unit | How it runs | Typical backing store |
 |-----------------|------------|------------------------|
 | **MCP stdio server** | Host spawns `workflows-engine-mcp` (published npx) or `node packages/engine/src/mcp-stdio-server.mjs` | In-memory store by default in reference bin; SQLite optional per integration wiring |
+| **REST HTTP server** | Host runs `workflows-engine-rest` (published npx) or `npm run engine:rest:serve` | In-memory store and in-memory definition registry by default; same operator manifest env as MCP for activity/delegate routing |
 | **Validation CLI** | `workflows-engine validate …` | N/A |
 | **CI worker** | GitHub Actions Node 24 job | Ephemeral; conformance + tests + validate-workflows |
 | **Library consumers** | `import … from '@agent-workflow/engine'` in Node ESM | Caller-selected store |
@@ -17,6 +18,7 @@ Represented deployment storylines (**draw.io** annotations defer non-shipping ca
 |------|--------------|
 | **Operator MCP host** | IDE/automation launches published **`workflows-engine-mcp`** (**`npx -y -p …`**) over **stdio**. Reference wiring defaults to **in-memory** `ExecutionHistoryStore`; operators may inject **SQLite** when composing `createWorkflowApplicationPort` externally. |
 | **Local developer** | Host invokes `node packages/engine/src/mcp-stdio-server.mjs` (or **`npm run engine:mcp:stdio`**) — same MCP JSON-RPC choreography with repo-local artifacts. Optional SQLite-backed history when wired by integrators. |
+| **REST integrator** | Run `workflows-engine-rest` or **`npm run engine:rest:serve`** (default `http://127.0.0.1:8787`). OpenAPI contract: `packages/engine/openapi/openapi.yaml`. Library embedders call `createRestWorkflowHandler(workflowPort, { definitionRegistry, store })`. |
 | **CI worker** | `npm run validate-workflows`, `npm run conformance`, `npm test` exercise the identical validation/orchestration modules without shipping MCP unless a test launches the adapter deliberately. |
 
 Operator runbook: [`../arc42-assets/runbooks/mcp-stdio-host-smoke.md`](../arc42-assets/runbooks/mcp-stdio-host-smoke.md).
@@ -26,6 +28,7 @@ Operator runbook: [`../arc42-assets/runbooks/mcp-stdio-host-smoke.md`](../arc42-
 | Channel | Data exchanged | Notes |
 |---------|----------------|-------|
 | **stdio MCP** | JSON-RPC MCP messages | Primary integration path for hosts |
+| **HTTP REST** | JSON over RFC-05 §5.3 paths | Reference `workflows-engine-rest` bin; maps to same application port as MCP |
 | **Optional stdio MCP to upstream servers** | Engine-direct invocation | Operator-supplied manifest; see ADR-0003 |
 
 ## 7.3 Artifact distribution
@@ -40,12 +43,14 @@ Operator runbook: [`../arc42-assets/runbooks/mcp-stdio-host-smoke.md`](../arc42-
 | Variable / flag | Purpose |
 |-----------------|---------|
 | `WORKFLOW_ENGINE_MCP_CONFIG` / `--mcp-config` | Engine-direct MCP operator manifest wiring |
+| `WORKFLOW_ENGINE_REST_PORT` / `--port` | REST server listen port (default `8787`) |
 | `npm run engine:mcp:stdio` | Local MCP server bootstrap |
+| `npm run engine:rest:serve` | Local REST server bootstrap |
 
 ---
 
 **Improvement candidates**
 
-1. **Documented Helm/K8s** only when REST/service wrapper exists—avoid implying cluster deployment today.
+1. **Documented Helm/K8s** only when a production-hardened REST/service wrapper exists—reference REST is local/demo posture today.
 2. **SQLite persistence** path for published MCP bin: clarify recommended production wiring in application port/host examples (beyond smoke doc).
 3. Add **diagram diff review** guideline when deployment assumptions change (`drawio` + this section).

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,10 @@
       "resolved": "packages/engine",
       "link": true
     },
+    "node_modules/@agent-workflow/sdk": {
+      "resolved": "packages/sdk",
+      "link": true
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
@@ -1177,7 +1181,19 @@
       },
       "bin": {
         "workflows-engine": "src/cli.mjs",
-        "workflows-engine-mcp": "src/mcp-stdio-server.mjs"
+        "workflows-engine-mcp": "src/mcp-stdio-server.mjs",
+        "workflows-engine-rest": "src/rest-server.mjs"
+      },
+      "engines": {
+        "node": ">=22.5.0"
+      }
+    },
+    "packages/sdk": {
+      "name": "@agent-workflow/sdk",
+      "version": "0.1.5",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@agent-workflow/engine": "0.1.5"
       },
       "engines": {
         "node": ">=22.5.0"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "engine:validate": "node packages/engine/src/cli.mjs validate",
     "engine:mcp-manifest:validate": "node packages/engine/src/cli.mjs mcp-manifest validate",
     "engine:mcp:stdio": "node packages/engine/src/mcp-stdio-server.mjs",
+    "engine:rest:serve": "node packages/engine/src/rest-server.mjs",
     "conformance": "node conformance/run-conformance.mjs",
     "test": "npm test --workspace=@agent-workflow/engine",
     "docs:prepare": "node scripts/build-docs-site.mjs",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "engine:rest:serve": "node packages/engine/src/rest-server.mjs",
     "conformance": "node conformance/run-conformance.mjs",
     "test": "npm test --workspace=@agent-workflow/engine",
+    "sdk:test": "npm test --workspace=@agent-workflow/sdk",
     "docs:prepare": "node scripts/build-docs-site.mjs",
     "docs:build": "node scripts/build-docs-site.mjs && node scripts/run-mkdocs.mjs build -f website/mkdocs.yml -d site",
     "docs:serve": "node scripts/build-docs-site.mjs && node scripts/run-mkdocs.mjs serve -f website/mkdocs.yml -a localhost:8000"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "engine:mcp:stdio": "node packages/engine/src/mcp-stdio-server.mjs",
     "engine:rest:serve": "node packages/engine/src/rest-server.mjs",
     "conformance": "node conformance/run-conformance.mjs",
+    "conformance:parity-sdk": "node conformance/sdk-parity-smoke.mjs",
     "test": "npm test --workspace=@agent-workflow/engine",
     "sdk:test": "npm test --workspace=@agent-workflow/sdk",
     "docs:prepare": "node scripts/build-docs-site.mjs",

--- a/packages/engine/openapi/openapi.yaml
+++ b/packages/engine/openapi/openapi.yaml
@@ -1,0 +1,518 @@
+openapi: 3.0.3
+info:
+  title: Agent Workflow Protocol — Reference Engine REST Control Plane
+  version: 0.1.5
+  description: |
+    HTTP control-plane adapter for the `@agent-workflow/engine` reference implementation.
+    Maps RFC-05 §5.3 resource paths to `createWorkflowApplicationPort` with the same
+    lifecycle semantics and error codes as the MCP stdio adapter.
+servers:
+  - url: http://127.0.0.1:8787
+    description: Local reference REST server (`workflows-engine-rest`)
+paths:
+  /v1/workflows:
+    post:
+      operationId: registerWorkflowDefinition
+      summary: Register a workflow definition
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisterWorkflowRequest"
+      responses:
+        "201":
+          description: Definition registered
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RegisterWorkflowResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "409":
+          $ref: "#/components/responses/DuplicateWorkflowId"
+  /v1/workflows/{wf_id}:
+    get:
+      operationId: getWorkflowDefinition
+      summary: Fetch a registered workflow definition
+      parameters:
+        - $ref: "#/components/parameters/WfId"
+      responses:
+        "200":
+          description: Registered definition
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RegisterWorkflowResponse"
+        "404":
+          $ref: "#/components/responses/WorkflowNotFound"
+  /v1/workflows/{wf_id}/executions:
+    post:
+      operationId: startWorkflowExecution
+      summary: Start an execution for a registered workflow
+      parameters:
+        - $ref: "#/components/parameters/WfId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StartExecutionRequest"
+      responses:
+        "200":
+          description: Execution started or reached a terminal/interrupted/awaiting state
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowStartResult"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "404":
+          $ref: "#/components/responses/WorkflowNotFound"
+        "409":
+          $ref: "#/components/responses/DuplicateExecutionId"
+        "500":
+          $ref: "#/components/responses/EngineFailure"
+  /v1/executions/{exec_id}:
+    get:
+      operationId: getExecutionStatus
+      summary: Read execution phase and cursor metadata
+      parameters:
+        - $ref: "#/components/parameters/ExecId"
+      responses:
+        "200":
+          description: Current execution status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowStatusResult"
+        "404":
+          $ref: "#/components/responses/ExecutionNotFound"
+  /v1/executions/{exec_id}/events:
+    get:
+      operationId: listExecutionEvents
+      summary: Paginated append-only execution history
+      parameters:
+        - $ref: "#/components/parameters/ExecId"
+        - name: from_seq
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+        - name: to_seq
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            default: 100
+        - name: cursor
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+          description: Alias for `from_seq` when paginating forward
+      responses:
+        "200":
+          description: History page
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExecutionEventsPage"
+        "404":
+          $ref: "#/components/responses/ExecutionNotFound"
+  /v1/executions/{exec_id}:resume:
+    post:
+      operationId: resumeExecution
+      summary: Resume an interrupted execution
+      parameters:
+        - $ref: "#/components/parameters/ExecId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ResumeExecutionRequest"
+      responses:
+        "200":
+          description: Resume accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowResumeResult"
+        "400":
+          $ref: "#/components/responses/InvalidResumePayload"
+        "500":
+          $ref: "#/components/responses/EngineFailure"
+  /v1/executions/{exec_id}:submit_activity:
+    post:
+      operationId: submitHostMediatedActivity
+      summary: Submit a host-mediated activity outcome
+      parameters:
+        - $ref: "#/components/parameters/ExecId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SubmitActivityRequest"
+      responses:
+        "200":
+          description: Activity outcome accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowSubmitActivityResult"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "409":
+          $ref: "#/components/responses/ActivitySubmitConflict"
+        "500":
+          $ref: "#/components/responses/EngineFailure"
+  /v1/executions/{exec_id}:cancel:
+    post:
+      operationId: cancelExecution
+      summary: Cancel a running execution (not implemented in reference port)
+      parameters:
+        - $ref: "#/components/parameters/ExecId"
+      responses:
+        "501":
+          description: Cancel not implemented
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorBody"
+  /v1/executions/{exec_id}/checkpoint:
+    get:
+      operationId: getExecutionCheckpoint
+      summary: Optional checkpoint introspection
+      parameters:
+        - $ref: "#/components/parameters/ExecId"
+      responses:
+        "200":
+          description: Latest checkpoint event payload
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CheckpointResponse"
+        "404":
+          $ref: "#/components/responses/ExecutionNotFound"
+components:
+  parameters:
+    WfId:
+      name: wf_id
+      in: path
+      required: true
+      schema:
+        type: string
+    ExecId:
+      name: exec_id
+      in: path
+      required: true
+      schema:
+        type: string
+  responses:
+    ValidationError:
+      description: Request validation failed
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorBody"
+          example:
+            error:
+              code: VALIDATION_ERROR
+              message: Workflow definition failed schema validation.
+    WorkflowNotFound:
+      description: Workflow definition was not registered
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorBody"
+          example:
+            error:
+              code: WORKFLOW_NOT_FOUND
+              message: Workflow definition "missing" was not found.
+    ExecutionNotFound:
+      description: Execution identity was not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorBody"
+          example:
+            error:
+              code: EXECUTION_NOT_FOUND
+              message: Execution "missing" was not found.
+    DuplicateWorkflowId:
+      description: Workflow id already registered
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorBody"
+    DuplicateExecutionId:
+      description: Execution id already exists
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorBody"
+    InvalidResumePayload:
+      description: Resume payload rejected
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorBody"
+    ActivitySubmitConflict:
+      description: Activity submit rejected due to execution state mismatch
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorBody"
+    EngineFailure:
+      description: Engine reported a workflow failure
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorBody"
+  schemas:
+    ErrorBody:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+              enum:
+                - VALIDATION_ERROR
+                - EXECUTION_NOT_FOUND
+                - WORKFLOW_NOT_FOUND
+                - DUPLICATE_EXECUTION_ID
+                - DUPLICATE_WORKFLOW_ID
+                - INVALID_RESUME_PAYLOAD
+                - ACTIVITY_SUBMIT_NOT_AWAITING
+                - ACTIVITY_SUBMIT_NODE_MISMATCH
+                - ACTIVITY_SUBMIT_PARALLEL_MISMATCH
+                - SUBMIT_VALIDATION_ERROR
+                - ENGINE_FAILURE
+                - INTERNAL_ERROR
+                - NOT_IMPLEMENTED
+                - NOT_FOUND
+            message:
+              type: string
+            details:
+              type: object
+              additionalProperties: true
+    RegisterWorkflowRequest:
+      type: object
+      required: [definition]
+      properties:
+        definition:
+          type: object
+          additionalProperties: true
+    RegisterWorkflowResponse:
+      type: object
+      required: [wf_id, definition]
+      properties:
+        wf_id:
+          type: string
+        definition:
+          type: object
+          additionalProperties: true
+    StartExecutionRequest:
+      type: object
+      properties:
+        execution_id:
+          type: string
+        input:
+          type: object
+          additionalProperties: true
+        activity_execution_mode:
+          type: string
+          enum: [in_process, host_mediated]
+        allow_existing_execution_id:
+          type: boolean
+    ResumeExecutionRequest:
+      type: object
+      required: [definition, resume_payload]
+      properties:
+        definition:
+          type: object
+          additionalProperties: true
+        resume_payload:
+          type: object
+          additionalProperties: true
+        activity_execution_mode:
+          type: string
+          enum: [in_process, host_mediated]
+    SubmitActivityRequest:
+      type: object
+      required: [definition, node_id, outcome]
+      properties:
+        definition:
+          type: object
+          additionalProperties: true
+        input:
+          type: object
+          additionalProperties: true
+        node_id:
+          type: string
+        outcome:
+          oneOf:
+            - type: object
+              required: [ok]
+              properties:
+                ok:
+                  type: boolean
+                  enum: [true]
+                result:
+                  type: object
+                  additionalProperties: true
+                delegate_correlation_id:
+                  type: string
+                external_task_id:
+                  type: string
+            - type: object
+              required: [ok, error]
+              properties:
+                ok:
+                  type: boolean
+                  enum: [false]
+                error:
+                  type: string
+                code:
+                  type: string
+        parallel_span:
+          $ref: "#/components/schemas/ParallelSpan"
+        activity_execution_mode:
+          type: string
+          enum: [in_process, host_mediated]
+    ParallelSpan:
+      type: object
+      required: [parallel_node_id, join_target_id, branch_name, branch_entry_node_id]
+      properties:
+        parallel_node_id:
+          type: string
+        join_target_id:
+          type: string
+        branch_name:
+          type: string
+        branch_entry_node_id:
+          type: string
+    WorkflowStartResult:
+      type: object
+      required: [execution_id, status]
+      properties:
+        execution_id:
+          type: string
+        status:
+          type: string
+          enum: [completed, failed, interrupted, awaiting_activity]
+        final_state:
+          type: object
+          additionalProperties: true
+        result:
+          nullable: true
+        error:
+          type: string
+        node_id:
+          type: string
+        state:
+          type: object
+          additionalProperties: true
+        parallel_span:
+          $ref: "#/components/schemas/ParallelSpan"
+        agent_id:
+          type: string
+        protocol:
+          type: string
+        delegate_input:
+          type: object
+          additionalProperties: true
+        delegate_correlation_id:
+          type: string
+    WorkflowStatusResult:
+      type: object
+      required: [execution_id, phase]
+      properties:
+        execution_id:
+          type: string
+        phase:
+          type: string
+          enum: [running, completed, failed, interrupted, awaiting_activity]
+        current_node_id:
+          type: string
+        last_error:
+          type: string
+        delegate_correlation_id:
+          type: string
+        child_execution_id:
+          type: string
+        parent_execution_id:
+          type: string
+        agent_id:
+          type: string
+        protocol:
+          type: string
+        delegate_input:
+          type: object
+          additionalProperties: true
+    WorkflowResumeResult:
+      allOf:
+        - $ref: "#/components/schemas/WorkflowStartResult"
+    WorkflowSubmitActivityResult:
+      allOf:
+        - $ref: "#/components/schemas/WorkflowStartResult"
+        - type: object
+          properties:
+            code:
+              type: string
+    HistoryEvent:
+      type: object
+      required: [seq, kind, name, payload]
+      properties:
+        seq:
+          type: integer
+        kind:
+          type: string
+          enum: [command, event]
+        name:
+          type: string
+        payload:
+          type: object
+          additionalProperties: true
+        created_at:
+          type: string
+          format: date-time
+        record_schema_version:
+          type: integer
+    ExecutionEventsPage:
+      type: object
+      required: [execution_id, events]
+      properties:
+        execution_id:
+          type: string
+        events:
+          type: array
+          items:
+            $ref: "#/components/schemas/HistoryEvent"
+        next_cursor:
+          type: integer
+    CheckpointResponse:
+      type: object
+      required: [execution_id, checkpoint, seq]
+      properties:
+        execution_id:
+          type: string
+        checkpoint:
+          type: object
+          additionalProperties: true
+        seq:
+          type: integer
+        created_at:
+          type: string
+          format: date-time

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -18,16 +18,19 @@
   "files": [
     "src/",
     "schemas/",
+    "openapi/",
     "README.md"
   ],
   "bin": {
     "workflows-engine": "src/cli.mjs",
-    "workflows-engine-mcp": "src/mcp-stdio-server.mjs"
+    "workflows-engine-mcp": "src/mcp-stdio-server.mjs",
+    "workflows-engine-rest": "src/rest-server.mjs"
   },
   "scripts": {
     "prepack": "node ../../scripts/sync-engine-schema.mjs",
     "test": "node --test test/*.mjs",
-    "mcp:stdio": "node ./src/mcp-stdio-server.mjs"
+    "mcp:stdio": "node ./src/mcp-stdio-server.mjs",
+    "rest:serve": "node ./src/rest-server.mjs"
   },
   "engines": {
     "node": ">=22.5.0"

--- a/packages/engine/src/adapters/mcp/workflow-tools.mjs
+++ b/packages/engine/src/adapters/mcp/workflow-tools.mjs
@@ -1,18 +1,20 @@
 import {
   workflowResumeArgsSchema,
-  workflowResumeResultSchema,
   workflowStartArgsSchema,
-  workflowStartResultSchema,
   workflowStatusArgsSchema,
-  workflowStatusResultSchema,
   workflowSubmitActivityArgsSchema,
-  workflowSubmitActivityResultSchema,
 } from "./contracts.mjs";
 import { MCP_ADAPTER_ERROR, McpAdapterError, normalizeMcpAdapterError, toToolErrorResult } from "./errors.mjs";
 import {
   validateWorkflowResumeTransportPayload,
   validateWorkflowStartTransportPayload,
 } from "./transport-validation.mjs";
+import {
+  resumeResponseFromPort,
+  startResponseFromPort,
+  statusResponseFromPort,
+  submitActivityResponseFromPort,
+} from "../transport-response.mjs";
 import { ZodError } from "zod";
 
 /**
@@ -59,123 +61,6 @@ function mcpErrorForResumeFailure(code, message) {
  */
 function withStructuredJsonInText(headline, structured) {
   return `${headline}\n\nStructured result (JSON):\n${JSON.stringify(structured, null, 2)}`;
-}
-
-/**
- * @param {Record<string, unknown>} parsed
- */
-function awaitingDelegateFieldsFromPort(parsed) {
-  return {
-    ...(parsed.agentId !== undefined ? { agent_id: parsed.agentId } : {}),
-    ...(parsed.protocol !== undefined ? { protocol: parsed.protocol } : {}),
-    ...(parsed.delegateInput !== undefined ? { delegate_input: parsed.delegateInput } : {}),
-    ...(parsed.delegateCorrelationId !== undefined
-      ? { delegate_correlation_id: parsed.delegateCorrelationId }
-      : {}),
-  };
-}
-
-function startResponseFromPort(parsed) {
-  const parallelSpan = parsed.parallelSpan;
-  const response = {
-    execution_id: parsed.executionId,
-    status: parsed.status,
-    ...(parsed.finalState !== undefined ? { final_state: parsed.finalState } : {}),
-    ...(parsed.result !== undefined ? { result: parsed.result } : {}),
-    ...(parsed.error !== undefined ? { error: parsed.error } : {}),
-    ...(parsed.nodeId !== undefined ? { node_id: parsed.nodeId } : {}),
-    ...(parsed.state !== undefined ? { state: parsed.state } : {}),
-    ...(parallelSpan
-      ? {
-          parallel_span: {
-            parallel_node_id: parallelSpan.parallelNodeId,
-            join_target_id: parallelSpan.joinTargetId,
-            branch_name: parallelSpan.branchName,
-            branch_entry_node_id: parallelSpan.branchEntryNodeId,
-          },
-        }
-      : {}),
-    ...awaitingDelegateFieldsFromPort(parsed),
-  };
-  return workflowStartResultSchema.parse(response);
-}
-
-/**
- * @param {unknown} parsed
- */
-function statusResponseFromPort(parsed) {
-  const response = {
-    execution_id: parsed.executionId,
-    phase: parsed.phase,
-    ...(parsed.currentNodeId !== undefined ? { current_node_id: parsed.currentNodeId } : {}),
-    ...(parsed.lastError !== undefined ? { last_error: parsed.lastError } : {}),
-    ...(parsed.delegateCorrelationId !== undefined
-      ? { delegate_correlation_id: parsed.delegateCorrelationId }
-      : {}),
-    ...(parsed.childExecutionId !== undefined ? { child_execution_id: parsed.childExecutionId } : {}),
-    ...(parsed.parentExecutionId !== undefined ? { parent_execution_id: parsed.parentExecutionId } : {}),
-    ...(parsed.agentId !== undefined ? { agent_id: parsed.agentId } : {}),
-    ...(parsed.protocol !== undefined ? { protocol: parsed.protocol } : {}),
-    ...(parsed.delegateInput !== undefined ? { delegate_input: parsed.delegateInput } : {}),
-  };
-  return workflowStatusResultSchema.parse(response);
-}
-
-/**
- * @param {unknown} parsed
- */
-function resumeResponseFromPort(parsed) {
-  const parallelSpan = parsed.parallelSpan;
-  const response = {
-    execution_id: parsed.executionId,
-    status: parsed.status,
-    ...(parsed.finalState !== undefined ? { final_state: parsed.finalState } : {}),
-    ...(parsed.result !== undefined ? { result: parsed.result } : {}),
-    ...(parsed.error !== undefined ? { error: parsed.error } : {}),
-    ...(parsed.nodeId !== undefined ? { node_id: parsed.nodeId } : {}),
-    ...(parsed.state !== undefined ? { state: parsed.state } : {}),
-    ...(parallelSpan
-      ? {
-          parallel_span: {
-            parallel_node_id: parallelSpan.parallelNodeId,
-            join_target_id: parallelSpan.joinTargetId,
-            branch_name: parallelSpan.branchName,
-            branch_entry_node_id: parallelSpan.branchEntryNodeId,
-          },
-        }
-      : {}),
-    ...awaitingDelegateFieldsFromPort(parsed),
-  };
-  return workflowResumeResultSchema.parse(response);
-}
-
-/**
- * @param {unknown} parsed
- */
-function submitActivityResponseFromPort(parsed) {
-  const parallelSpan = parsed.parallelSpan;
-  const response = {
-    execution_id: parsed.executionId,
-    status: parsed.status,
-    ...(parsed.finalState !== undefined ? { final_state: parsed.finalState } : {}),
-    ...(parsed.result !== undefined ? { result: parsed.result } : {}),
-    ...(parsed.error !== undefined ? { error: parsed.error } : {}),
-    ...(parsed.nodeId !== undefined ? { node_id: parsed.nodeId } : {}),
-    ...(parsed.state !== undefined ? { state: parsed.state } : {}),
-    ...(parsed.code !== undefined ? { code: parsed.code } : {}),
-    ...(parallelSpan
-      ? {
-          parallel_span: {
-            parallel_node_id: parallelSpan.parallelNodeId,
-            join_target_id: parallelSpan.joinTargetId,
-            branch_name: parallelSpan.branchName,
-            branch_entry_node_id: parallelSpan.branchEntryNodeId,
-          },
-        }
-      : {}),
-    ...awaitingDelegateFieldsFromPort(parsed),
-  };
-  return workflowSubmitActivityResultSchema.parse(response);
 }
 
 const SUBMIT_ACTIVITY_ADAPTER_CODES = new Set([

--- a/packages/engine/src/adapters/rest/definition-registry.mjs
+++ b/packages/engine/src/adapters/rest/definition-registry.mjs
@@ -1,5 +1,5 @@
-import { randomUUID } from "node:crypto";
 import { assertValidWorkflowDefinitionAtTransport } from "../mcp/transport-validation.mjs";
+import { deriveWorkflowId } from "../workflow-id.mjs";
 
 /**
  * In-memory workflow definition registry keyed by `wf_id`.
@@ -33,22 +33,4 @@ export class DefinitionRegistry {
     const definition = this.#definitions.get(wfId);
     return definition ? structuredClone(definition) : undefined;
   }
-}
-
-/**
- * @param {object} definition
- */
-export function deriveWorkflowId(definition) {
-  const name = definition?.document?.name;
-  if (typeof name === "string" && name.trim() !== "") {
-    const normalized = name
-      .trim()
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "");
-    if (normalized !== "") {
-      return normalized;
-    }
-  }
-  return randomUUID();
 }

--- a/packages/engine/src/adapters/rest/definition-registry.mjs
+++ b/packages/engine/src/adapters/rest/definition-registry.mjs
@@ -1,0 +1,54 @@
+import { randomUUID } from "node:crypto";
+import { assertValidWorkflowDefinitionAtTransport } from "../mcp/transport-validation.mjs";
+
+/**
+ * In-memory workflow definition registry keyed by `wf_id`.
+ */
+export class DefinitionRegistry {
+  /** @type {Map<string, object>} */
+  #definitions = new Map();
+
+  /**
+   * @param {object} definition
+   * @returns {{ wf_id: string; definition: object }}
+   */
+  register(definition) {
+    assertValidWorkflowDefinitionAtTransport(definition);
+    const wfId = deriveWorkflowId(definition);
+    if (this.#definitions.has(wfId)) {
+      const err = new Error(`Workflow definition "${wfId}" is already registered.`);
+      err.code = "DUPLICATE_WORKFLOW_ID";
+      throw err;
+    }
+    const stored = structuredClone(definition);
+    this.#definitions.set(wfId, stored);
+    return { wf_id: wfId, definition: stored };
+  }
+
+  /**
+   * @param {string} wfId
+   * @returns {object | undefined}
+   */
+  get(wfId) {
+    const definition = this.#definitions.get(wfId);
+    return definition ? structuredClone(definition) : undefined;
+  }
+}
+
+/**
+ * @param {object} definition
+ */
+export function deriveWorkflowId(definition) {
+  const name = definition?.document?.name;
+  if (typeof name === "string" && name.trim() !== "") {
+    const normalized = name
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    if (normalized !== "") {
+      return normalized;
+    }
+  }
+  return randomUUID();
+}

--- a/packages/engine/src/adapters/rest/errors.mjs
+++ b/packages/engine/src/adapters/rest/errors.mjs
@@ -1,0 +1,41 @@
+import { MCP_ADAPTER_ERROR, McpAdapterError } from "../mcp/errors.mjs";
+
+/**
+ * @param {string} code
+ * @returns {number}
+ */
+export function httpStatusForAdapterError(code) {
+  switch (code) {
+    case MCP_ADAPTER_ERROR.VALIDATION_ERROR:
+    case MCP_ADAPTER_ERROR.INVALID_RESUME_PAYLOAD:
+    case MCP_ADAPTER_ERROR.SUBMIT_VALIDATION_ERROR:
+      return 400;
+    case MCP_ADAPTER_ERROR.EXECUTION_NOT_FOUND:
+      return 404;
+    case "WORKFLOW_NOT_FOUND":
+      return 404;
+    case MCP_ADAPTER_ERROR.DUPLICATE_EXECUTION_ID:
+    case "DUPLICATE_WORKFLOW_ID":
+    case MCP_ADAPTER_ERROR.ACTIVITY_SUBMIT_NOT_AWAITING:
+    case MCP_ADAPTER_ERROR.ACTIVITY_SUBMIT_NODE_MISMATCH:
+    case MCP_ADAPTER_ERROR.ACTIVITY_SUBMIT_PARALLEL_MISMATCH:
+      return 409;
+    case MCP_ADAPTER_ERROR.ENGINE_FAILURE:
+    case MCP_ADAPTER_ERROR.INTERNAL_ERROR:
+    default:
+      return 500;
+  }
+}
+
+/**
+ * @param {McpAdapterError} error
+ */
+export function adapterErrorToHttpBody(error) {
+  return {
+    error: {
+      code: error.code,
+      message: error.message,
+      ...(error.details !== undefined ? { details: error.details } : {}),
+    },
+  };
+}

--- a/packages/engine/src/adapters/rest/errors.mjs
+++ b/packages/engine/src/adapters/rest/errors.mjs
@@ -1,4 +1,4 @@
-import { MCP_ADAPTER_ERROR, McpAdapterError } from "../mcp/errors.mjs";
+import { MCP_ADAPTER_ERROR } from "../mcp/errors.mjs";
 
 /**
  * @param {string} code
@@ -28,7 +28,7 @@ export function httpStatusForAdapterError(code) {
 }
 
 /**
- * @param {McpAdapterError} error
+ * @param {import("../mcp/errors.mjs").McpAdapterError} error
  */
 export function adapterErrorToHttpBody(error) {
   return {

--- a/packages/engine/src/adapters/rest/http-utils.mjs
+++ b/packages/engine/src/adapters/rest/http-utils.mjs
@@ -1,0 +1,70 @@
+import { MCP_ADAPTER_ERROR } from "../mcp/errors.mjs";
+
+/**
+ * @param {import("node:http").IncomingMessage} req
+ * @param {number} [maxBytes]
+ * @returns {Promise<unknown>}
+ */
+export function readJsonBody(req, maxBytes = 2 * 1024 * 1024) {
+  return new Promise((resolve, reject) => {
+    /** @type {Buffer[]} */
+    const chunks = [];
+    let total = 0;
+    req.on("data", (chunk) => {
+      total += chunk.length;
+      if (total > maxBytes) {
+        reject(Object.assign(new Error("Request body exceeds maximum allowed size."), { code: MCP_ADAPTER_ERROR.VALIDATION_ERROR }));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      if (chunks.length === 0) {
+        resolve(undefined);
+        return;
+      }
+      const text = Buffer.concat(chunks).toString("utf8");
+      if (text.trim() === "") {
+        resolve(undefined);
+        return;
+      }
+      try {
+        resolve(JSON.parse(text));
+      } catch {
+        reject(Object.assign(new Error("Request body is not valid JSON."), { code: MCP_ADAPTER_ERROR.VALIDATION_ERROR }));
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+/**
+ * @param {import("node:http").ServerResponse} res
+ * @param {number} status
+ * @param {unknown} body
+ */
+export function sendJson(res, status, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "content-length": Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+/**
+ * @param {import("node:http").IncomingMessage} req
+ */
+export function requestPathname(req) {
+  const url = new URL(req.url ?? "/", "http://localhost");
+  return url.pathname;
+}
+
+/**
+ * @param {import("node:http").IncomingMessage} req
+ */
+export function requestQuery(req) {
+  const url = new URL(req.url ?? "/", "http://localhost");
+  return url.searchParams;
+}

--- a/packages/engine/src/adapters/rest/rest-handler.mjs
+++ b/packages/engine/src/adapters/rest/rest-handler.mjs
@@ -1,0 +1,366 @@
+import { ZodError } from "zod";
+import {
+  workflowResumeArgsSchema,
+  workflowStartArgsSchema,
+  workflowStatusArgsSchema,
+  workflowSubmitActivityArgsSchema,
+} from "../mcp/contracts.mjs";
+import {
+  MCP_ADAPTER_ERROR,
+  McpAdapterError,
+  normalizeMcpAdapterError,
+} from "../mcp/errors.mjs";
+import {
+  validateWorkflowResumeTransportPayload,
+  validateWorkflowStartTransportPayload,
+} from "../mcp/transport-validation.mjs";
+import {
+  historyRowToTransport,
+  resumeResponseFromPort,
+  startResponseFromPort,
+  statusResponseFromPort,
+  submitActivityResponseFromPort,
+} from "../transport-response.mjs";
+import { DefinitionRegistry } from "./definition-registry.mjs";
+import { adapterErrorToHttpBody, httpStatusForAdapterError } from "./errors.mjs";
+import { readJsonBody, requestPathname, requestQuery, sendJson } from "./http-utils.mjs";
+
+const SUBMIT_ACTIVITY_ADAPTER_CODES = new Set([
+  MCP_ADAPTER_ERROR.ACTIVITY_SUBMIT_NOT_AWAITING,
+  MCP_ADAPTER_ERROR.ACTIVITY_SUBMIT_NODE_MISMATCH,
+  MCP_ADAPTER_ERROR.ACTIVITY_SUBMIT_PARALLEL_MISMATCH,
+  MCP_ADAPTER_ERROR.SUBMIT_VALIDATION_ERROR,
+]);
+
+/**
+ * @param {string | undefined} code
+ * @param {string | undefined} message
+ */
+function adapterErrorForStartFailure(code, message) {
+  const text = message && message.trim() !== "" ? message : "Workflow start failed.";
+  if (code === MCP_ADAPTER_ERROR.VALIDATION_ERROR || code === "VALIDATION_ERROR") {
+    return new McpAdapterError(MCP_ADAPTER_ERROR.VALIDATION_ERROR, text, { engineCode: code });
+  }
+  return new McpAdapterError(MCP_ADAPTER_ERROR.ENGINE_FAILURE, "Engine reported a workflow failure.", {
+    cause: text,
+  });
+}
+
+/**
+ * @param {string | undefined} code
+ * @param {string | undefined} message
+ */
+function adapterErrorForResumeFailure(code, message) {
+  const text = message && message.trim() !== "" ? message : "Resume request failed.";
+  if (code === MCP_ADAPTER_ERROR.INVALID_RESUME_PAYLOAD) {
+    return new McpAdapterError(MCP_ADAPTER_ERROR.INVALID_RESUME_PAYLOAD, text);
+  }
+  return new McpAdapterError(MCP_ADAPTER_ERROR.ENGINE_FAILURE, "Engine reported a workflow failure.", {
+    cause: text,
+  });
+}
+
+/**
+ * @param {string | undefined} code
+ * @param {string | undefined} message
+ */
+function adapterErrorForSubmitFailure(code, message) {
+  const text = message && message.trim() !== "" ? message : "Activity submit rejected.";
+  if (code && SUBMIT_ACTIVITY_ADAPTER_CODES.has(code)) {
+    return new McpAdapterError(code, text);
+  }
+  return new McpAdapterError(MCP_ADAPTER_ERROR.ENGINE_FAILURE, "Engine reported a workflow failure.", {
+    cause: text,
+  });
+}
+
+/**
+ * @param {import("node:http").ServerResponse} res
+ * @param {McpAdapterError} error
+ */
+function sendAdapterError(res, error) {
+  sendJson(res, httpStatusForAdapterError(error.code), adapterErrorToHttpBody(error));
+}
+
+/**
+ * @param {unknown} error
+ * @returns {McpAdapterError}
+ */
+function adaptCaughtError(error) {
+  if (error instanceof ZodError) {
+    return new McpAdapterError(MCP_ADAPTER_ERROR.VALIDATION_ERROR, "Invalid request arguments.", {
+      issues: error.issues,
+    });
+  }
+  if (error instanceof McpAdapterError) {
+    return error;
+  }
+  if (typeof error?.code === "string") {
+    if (error.code === "DUPLICATE_WORKFLOW_ID") {
+      return new McpAdapterError("DUPLICATE_WORKFLOW_ID", error.message);
+    }
+    if (error.code === MCP_ADAPTER_ERROR.DUPLICATE_EXECUTION_ID) {
+      return new McpAdapterError(MCP_ADAPTER_ERROR.DUPLICATE_EXECUTION_ID, error.message);
+    }
+  }
+  return normalizeMcpAdapterError(error);
+}
+
+/**
+ * @param {{
+ *   startWorkflow: Function;
+ *   getWorkflowStatus: Function;
+ *   resumeWorkflow: Function;
+ *   submitWorkflowActivity: Function;
+ * }} workflowPort
+ * @param {{
+ *   definitionRegistry?: DefinitionRegistry;
+ *   store?: import("../../persistence/types.mjs").ExecutionHistoryStore;
+ * }} [deps]
+ */
+export function createRestWorkflowHandler(workflowPort, deps = {}) {
+  const definitionRegistry = deps.definitionRegistry ?? new DefinitionRegistry();
+  const store = deps.store;
+
+  /**
+   * @param {import("node:http").IncomingMessage} req
+   * @param {import("node:http").ServerResponse} res
+   */
+  return async function restWorkflowHandler(req, res) {
+    const method = req.method ?? "GET";
+    const pathname = requestPathname(req);
+
+    try {
+      if (method === "POST" && pathname === "/v1/workflows") {
+        const body = await readJsonBody(req);
+        if (!body || typeof body !== "object" || Array.isArray(body) || !body.definition) {
+          throw new McpAdapterError(MCP_ADAPTER_ERROR.VALIDATION_ERROR, "Request body must include a definition object.");
+        }
+        const registered = definitionRegistry.register(body.definition);
+        sendJson(res, 201, registered);
+        return;
+      }
+
+      const getWorkflowMatch = pathname.match(/^\/v1\/workflows\/([^/]+)$/);
+      if (method === "GET" && getWorkflowMatch) {
+        const wfId = decodeURIComponent(getWorkflowMatch[1]);
+        const definition = definitionRegistry.get(wfId);
+        if (!definition) {
+          throw new McpAdapterError("WORKFLOW_NOT_FOUND", `Workflow definition "${wfId}" was not found.`);
+        }
+        sendJson(res, 200, { wf_id: wfId, definition });
+        return;
+      }
+
+      const startExecutionMatch = pathname.match(/^\/v1\/workflows\/([^/]+)\/executions$/);
+      if (method === "POST" && startExecutionMatch) {
+        const wfId = decodeURIComponent(startExecutionMatch[1]);
+        const definition = definitionRegistry.get(wfId);
+        if (!definition) {
+          throw new McpAdapterError("WORKFLOW_NOT_FOUND", `Workflow definition "${wfId}" was not found.`);
+        }
+        const body = (await readJsonBody(req)) ?? {};
+        const parsed = workflowStartArgsSchema.parse({
+          execution_id: body.execution_id,
+          definition,
+          input: body.input ?? {},
+          activity_execution_mode: body.activity_execution_mode,
+          allow_existing_execution_id: body.allow_existing_execution_id,
+        });
+        validateWorkflowStartTransportPayload(parsed.definition, parsed.input);
+        const response = await workflowPort.startWorkflow({
+          executionId: parsed.execution_id,
+          definition: parsed.definition,
+          input: parsed.input,
+          ...(parsed.activity_execution_mode ? { activityExecutionMode: parsed.activity_execution_mode } : {}),
+          ...(parsed.allow_existing_execution_id === true ? { allowExistingExecutionId: true } : {}),
+        });
+        if (response.status === "failed" && response.error) {
+          throw adapterErrorForStartFailure(response.code, response.error);
+        }
+        sendJson(res, 200, startResponseFromPort(response));
+        return;
+      }
+
+      const statusMatch = pathname.match(/^\/v1\/executions\/([^/]+)$/);
+      if (method === "GET" && statusMatch) {
+        const executionId = decodeURIComponent(statusMatch[1]);
+        const parsed = workflowStatusArgsSchema.parse({ execution_id: executionId });
+        const response = await workflowPort.getWorkflowStatus({ executionId: parsed.execution_id });
+        sendJson(res, 200, statusResponseFromPort(response));
+        return;
+      }
+
+      const eventsMatch = pathname.match(/^\/v1\/executions\/([^/]+)\/events$/);
+      if (method === "GET" && eventsMatch) {
+        if (!store) {
+          throw new McpAdapterError(
+            MCP_ADAPTER_ERROR.INTERNAL_ERROR,
+            "Execution history store is not configured for this REST handler."
+          );
+        }
+        const executionId = decodeURIComponent(eventsMatch[1]);
+        const rows = store.listByExecution(executionId);
+        if (rows.length === 0) {
+          throw new McpAdapterError(MCP_ADAPTER_ERROR.EXECUTION_NOT_FOUND, `Execution "${executionId}" was not found.`);
+        }
+        const query = requestQuery(req);
+        const fromSeq = parseOptionalPositiveInt(query.get("from_seq"));
+        const toSeq = parseOptionalPositiveInt(query.get("to_seq"));
+        const limit = parseOptionalPositiveInt(query.get("limit")) ?? 100;
+        const cursor = parseOptionalPositiveInt(query.get("cursor"));
+        const effectiveFromSeq = fromSeq ?? cursor;
+        let filtered = store.readRange(executionId, effectiveFromSeq, toSeq);
+        if (filtered.length > limit) {
+          filtered = filtered.slice(0, limit);
+        }
+        const events = filtered.map(historyRowToTransport);
+        const lastSeq = events.length > 0 ? events[events.length - 1].seq : undefined;
+        const hasMore =
+          lastSeq !== undefined && store.readRange(executionId, lastSeq + 1, toSeq).length > 0;
+        sendJson(res, 200, {
+          execution_id: executionId,
+          events,
+          ...(hasMore && lastSeq !== undefined ? { next_cursor: lastSeq + 1 } : {}),
+        });
+        return;
+      }
+
+      const resumeMatch = pathname.match(/^\/v1\/executions\/([^/]+):resume$/);
+      if (method === "POST" && resumeMatch) {
+        const executionId = decodeURIComponent(resumeMatch[1]);
+        const body = (await readJsonBody(req)) ?? {};
+        const parsed = workflowResumeArgsSchema.parse({
+          execution_id: executionId,
+          definition: body.definition,
+          resume_payload: body.resume_payload ?? {},
+          activity_execution_mode: body.activity_execution_mode,
+        });
+        validateWorkflowResumeTransportPayload(parsed.definition, parsed.resume_payload);
+        const response = await workflowPort.resumeWorkflow({
+          executionId: parsed.execution_id,
+          definition: parsed.definition,
+          resumePayload: parsed.resume_payload,
+          ...(parsed.activity_execution_mode ? { activityExecutionMode: parsed.activity_execution_mode } : {}),
+        });
+        if (response.status === "failed") {
+          throw adapterErrorForResumeFailure(response.code, response.error);
+        }
+        sendJson(res, 200, resumeResponseFromPort(response));
+        return;
+      }
+
+      const submitMatch = pathname.match(/^\/v1\/executions\/([^/]+):submit_activity$/);
+      if (method === "POST" && submitMatch) {
+        const executionId = decodeURIComponent(submitMatch[1]);
+        const body = (await readJsonBody(req)) ?? {};
+        const parsed = workflowSubmitActivityArgsSchema.parse({
+          execution_id: executionId,
+          definition: body.definition,
+          input: body.input ?? {},
+          node_id: body.node_id,
+          outcome: body.outcome,
+          parallel_span: body.parallel_span,
+          activity_execution_mode: body.activity_execution_mode,
+        });
+        const expectedParallelSpan = parsed.parallel_span
+          ? {
+              parallelNodeId: parsed.parallel_span.parallel_node_id,
+              joinTargetId: parsed.parallel_span.join_target_id,
+              branchName: parsed.parallel_span.branch_name,
+              branchEntryNodeId: parsed.parallel_span.branch_entry_node_id,
+            }
+          : undefined;
+        const response = await workflowPort.submitWorkflowActivity({
+          executionId: parsed.execution_id,
+          definition: parsed.definition,
+          input: parsed.input,
+          nodeId: parsed.node_id,
+          outcome:
+            parsed.outcome.ok === true
+              ? {
+                  ok: true,
+                  ...(parsed.outcome.result !== undefined ? { result: parsed.outcome.result } : {}),
+                  ...(parsed.outcome.delegate_correlation_id !== undefined
+                    ? { delegateCorrelationId: parsed.outcome.delegate_correlation_id }
+                    : {}),
+                  ...(parsed.outcome.external_task_id !== undefined
+                    ? { externalTaskId: parsed.outcome.external_task_id }
+                    : {}),
+                }
+              : parsed.outcome,
+          ...(expectedParallelSpan ? { expectedParallelSpan } : {}),
+          ...(parsed.activity_execution_mode ? { activityExecutionMode: parsed.activity_execution_mode } : {}),
+        });
+        if (response.status === "failed") {
+          throw adapterErrorForSubmitFailure(response.code, response.error);
+        }
+        sendJson(res, 200, submitActivityResponseFromPort(response));
+        return;
+      }
+
+      const cancelMatch = pathname.match(/^\/v1\/executions\/([^/]+):cancel$/);
+      if (method === "POST" && cancelMatch) {
+        sendJson(res, 501, {
+          error: {
+            code: "NOT_IMPLEMENTED",
+            message: "Execution cancel is not implemented in the reference engine application port.",
+          },
+        });
+        return;
+      }
+
+      const checkpointMatch = pathname.match(/^\/v1\/executions\/([^/]+)\/checkpoint$/);
+      if (method === "GET" && checkpointMatch) {
+        if (!store) {
+          throw new McpAdapterError(
+            MCP_ADAPTER_ERROR.INTERNAL_ERROR,
+            "Execution history store is not configured for this REST handler."
+          );
+        }
+        const executionId = decodeURIComponent(checkpointMatch[1]);
+        const rows = store.listByExecution(executionId);
+        if (rows.length === 0) {
+          throw new McpAdapterError(MCP_ADAPTER_ERROR.EXECUTION_NOT_FOUND, `Execution "${executionId}" was not found.`);
+        }
+        for (let i = rows.length - 1; i >= 0; i -= 1) {
+          const row = rows[i];
+          if (row.kind === "event" && row.name === "CheckpointWritten") {
+            sendJson(res, 200, {
+              execution_id: executionId,
+              checkpoint: row.payload,
+              seq: row.seq,
+              ...(row.createdAt !== undefined ? { created_at: row.createdAt } : {}),
+            });
+            return;
+          }
+        }
+        throw new McpAdapterError(MCP_ADAPTER_ERROR.EXECUTION_NOT_FOUND, `No checkpoint found for execution "${executionId}".`);
+      }
+
+      sendJson(res, 404, {
+        error: {
+          code: "NOT_FOUND",
+          message: `No route for ${method} ${pathname}`,
+        },
+      });
+    } catch (error) {
+      sendAdapterError(res, adaptCaughtError(error));
+    }
+  };
+}
+
+/**
+ * @param {string | null} value
+ * @returns {number | undefined}
+ */
+function parseOptionalPositiveInt(value) {
+  if (value === null || value.trim() === "") {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    throw new McpAdapterError(MCP_ADAPTER_ERROR.VALIDATION_ERROR, `Invalid positive integer query parameter: ${value}`);
+  }
+  return parsed;
+}

--- a/packages/engine/src/adapters/transport-response.mjs
+++ b/packages/engine/src/adapters/transport-response.mjs
@@ -1,0 +1,125 @@
+import {
+  workflowResumeResultSchema,
+  workflowStartResultSchema,
+  workflowStatusResultSchema,
+  workflowSubmitActivityResultSchema,
+} from "./mcp/contracts.mjs";
+
+/**
+ * @param {Record<string, unknown>} parsed
+ */
+function awaitingDelegateFieldsFromPort(parsed) {
+  return {
+    ...(parsed.agentId !== undefined ? { agent_id: parsed.agentId } : {}),
+    ...(parsed.protocol !== undefined ? { protocol: parsed.protocol } : {}),
+    ...(parsed.delegateInput !== undefined ? { delegate_input: parsed.delegateInput } : {}),
+    ...(parsed.delegateCorrelationId !== undefined
+      ? { delegate_correlation_id: parsed.delegateCorrelationId }
+      : {}),
+  };
+}
+
+/**
+ * @param {{ parallelNodeId: string; joinTargetId: string; branchName: string; branchEntryNodeId: string } | undefined} parallelSpan
+ */
+function parallelSpanToTransport(parallelSpan) {
+  if (!parallelSpan) return {};
+  return {
+    parallel_span: {
+      parallel_node_id: parallelSpan.parallelNodeId,
+      join_target_id: parallelSpan.joinTargetId,
+      branch_name: parallelSpan.branchName,
+      branch_entry_node_id: parallelSpan.branchEntryNodeId,
+    },
+  };
+}
+
+/**
+ * @param {unknown} parsed
+ */
+export function startResponseFromPort(parsed) {
+  const response = {
+    execution_id: parsed.executionId,
+    status: parsed.status,
+    ...(parsed.finalState !== undefined ? { final_state: parsed.finalState } : {}),
+    ...(parsed.result !== undefined ? { result: parsed.result } : {}),
+    ...(parsed.error !== undefined ? { error: parsed.error } : {}),
+    ...(parsed.nodeId !== undefined ? { node_id: parsed.nodeId } : {}),
+    ...(parsed.state !== undefined ? { state: parsed.state } : {}),
+    ...parallelSpanToTransport(parsed.parallelSpan),
+    ...awaitingDelegateFieldsFromPort(parsed),
+  };
+  return workflowStartResultSchema.parse(response);
+}
+
+/**
+ * @param {unknown} parsed
+ */
+export function statusResponseFromPort(parsed) {
+  const response = {
+    execution_id: parsed.executionId,
+    phase: parsed.phase,
+    ...(parsed.currentNodeId !== undefined ? { current_node_id: parsed.currentNodeId } : {}),
+    ...(parsed.lastError !== undefined ? { last_error: parsed.lastError } : {}),
+    ...(parsed.delegateCorrelationId !== undefined
+      ? { delegate_correlation_id: parsed.delegateCorrelationId }
+      : {}),
+    ...(parsed.childExecutionId !== undefined ? { child_execution_id: parsed.childExecutionId } : {}),
+    ...(parsed.parentExecutionId !== undefined ? { parent_execution_id: parsed.parentExecutionId } : {}),
+    ...(parsed.agentId !== undefined ? { agent_id: parsed.agentId } : {}),
+    ...(parsed.protocol !== undefined ? { protocol: parsed.protocol } : {}),
+    ...(parsed.delegateInput !== undefined ? { delegate_input: parsed.delegateInput } : {}),
+  };
+  return workflowStatusResultSchema.parse(response);
+}
+
+/**
+ * @param {unknown} parsed
+ */
+export function resumeResponseFromPort(parsed) {
+  const response = {
+    execution_id: parsed.executionId,
+    status: parsed.status,
+    ...(parsed.finalState !== undefined ? { final_state: parsed.finalState } : {}),
+    ...(parsed.result !== undefined ? { result: parsed.result } : {}),
+    ...(parsed.error !== undefined ? { error: parsed.error } : {}),
+    ...(parsed.nodeId !== undefined ? { node_id: parsed.nodeId } : {}),
+    ...(parsed.state !== undefined ? { state: parsed.state } : {}),
+    ...parallelSpanToTransport(parsed.parallelSpan),
+    ...awaitingDelegateFieldsFromPort(parsed),
+  };
+  return workflowResumeResultSchema.parse(response);
+}
+
+/**
+ * @param {unknown} parsed
+ */
+export function submitActivityResponseFromPort(parsed) {
+  const response = {
+    execution_id: parsed.executionId,
+    status: parsed.status,
+    ...(parsed.finalState !== undefined ? { final_state: parsed.finalState } : {}),
+    ...(parsed.result !== undefined ? { result: parsed.result } : {}),
+    ...(parsed.error !== undefined ? { error: parsed.error } : {}),
+    ...(parsed.nodeId !== undefined ? { node_id: parsed.nodeId } : {}),
+    ...(parsed.state !== undefined ? { state: parsed.state } : {}),
+    ...(parsed.code !== undefined ? { code: parsed.code } : {}),
+    ...parallelSpanToTransport(parsed.parallelSpan),
+    ...awaitingDelegateFieldsFromPort(parsed),
+  };
+  return workflowSubmitActivityResultSchema.parse(response);
+}
+
+/**
+ * @param {import("../persistence/types.mjs").HistoryRow} row
+ */
+export function historyRowToTransport(row) {
+  return {
+    seq: row.seq,
+    kind: row.kind,
+    name: row.name,
+    payload: row.payload,
+    ...(row.createdAt !== undefined ? { created_at: row.createdAt } : {}),
+    ...(row.recordSchemaVersion !== undefined ? { record_schema_version: row.recordSchemaVersion } : {}),
+  };
+}

--- a/packages/engine/src/adapters/workflow-id.mjs
+++ b/packages/engine/src/adapters/workflow-id.mjs
@@ -1,0 +1,34 @@
+import { randomUUID } from "node:crypto";
+
+/**
+ * Linear-time slug from workflow document name (lowercase, alphanumeric segments joined by dashes).
+ * @param {string} name
+ * @returns {string}
+ */
+export function normalizeWorkflowIdSlug(name) {
+  const slug = name.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  let start = 0;
+  let end = slug.length;
+  while (start < end && slug[start] === "-") {
+    start += 1;
+  }
+  while (end > start && slug[end - 1] === "-") {
+    end -= 1;
+  }
+  return slug.slice(start, end);
+}
+
+/**
+ * @param {object} definition
+ * @returns {string}
+ */
+export function deriveWorkflowId(definition) {
+  const name = definition?.document?.name;
+  if (typeof name === "string" && name.trim() !== "") {
+    const normalized = normalizeWorkflowIdSlug(name);
+    if (normalized !== "") {
+      return normalized;
+    }
+  }
+  return randomUUID();
+}

--- a/packages/engine/src/index.mjs
+++ b/packages/engine/src/index.mjs
@@ -97,6 +97,15 @@ export { hydrateReplayContext } from "./orchestrator/replay-loader.mjs";
 export { createWorkflowApplicationPort } from "./application/workflow-application-port.mjs";
 export { createMcpWorkflowStdioServer } from "./adapters/mcp/stdio-server.mjs";
 export { createMcpWorkflowToolHandlers } from "./adapters/mcp/workflow-tools.mjs";
+export { createRestWorkflowHandler } from "./adapters/rest/rest-handler.mjs";
+export { DefinitionRegistry } from "./adapters/rest/definition-registry.mjs";
+export {
+  startResponseFromPort,
+  statusResponseFromPort,
+  resumeResponseFromPort,
+  submitActivityResponseFromPort,
+  historyRowToTransport,
+} from "./adapters/transport-response.mjs";
 export { MCP_ADAPTER_ERROR, McpAdapterError } from "./adapters/mcp/errors.mjs";
 export {
   normalizeMcpOperatorManifest,

--- a/packages/engine/src/index.mjs
+++ b/packages/engine/src/index.mjs
@@ -99,6 +99,7 @@ export { createMcpWorkflowStdioServer } from "./adapters/mcp/stdio-server.mjs";
 export { createMcpWorkflowToolHandlers } from "./adapters/mcp/workflow-tools.mjs";
 export { createRestWorkflowHandler } from "./adapters/rest/rest-handler.mjs";
 export { DefinitionRegistry } from "./adapters/rest/definition-registry.mjs";
+export { deriveWorkflowId, normalizeWorkflowIdSlug } from "./adapters/workflow-id.mjs";
 export {
   startResponseFromPort,
   statusResponseFromPort,

--- a/packages/engine/src/rest-server.mjs
+++ b/packages/engine/src/rest-server.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+import { createServer } from "node:http";
+import { createWorkflowApplicationPort } from "./application/workflow-application-port.mjs";
+import { createRestWorkflowHandler } from "./adapters/rest/rest-handler.mjs";
+import { DefinitionRegistry } from "./adapters/rest/definition-registry.mjs";
+import {
+  formatActivityRoutingSummaryLog,
+  formatMcpManifestValidationErrors,
+  loadProductionActivityExecutor,
+  loadProductionDelegateExecutor,
+  resolveWorkflowEngineMcpConfigPath,
+} from "./adapters/mcp/stdio-server-config.mjs";
+import { MemoryExecutionHistoryStore } from "./persistence/memory-history-store.mjs";
+
+/**
+ * @param {string[]} argv
+ */
+function parsePort(argv) {
+  const portIndex = argv.indexOf("--port");
+  if (portIndex >= 0 && argv[portIndex + 1]) {
+    const parsed = Number.parseInt(argv[portIndex + 1], 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  const fromEnv = process.env.WORKFLOW_ENGINE_REST_PORT;
+  if (fromEnv) {
+    const parsed = Number.parseInt(fromEnv, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return 8787;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(
+      "Usage: workflows-engine-rest [--port <number>] [--mcp-config <path>]\n" +
+        "Starts HTTP REST control-plane adapter (RFC-05 §5.3 paths).\n" +
+        "\n" +
+        "Environment:\n" +
+        "  WORKFLOW_ENGINE_REST_PORT — listen port (default 8787)\n" +
+        "  WORKFLOW_ENGINE_MCP_CONFIG — operator manifest for in-process activity/delegate routing\n" +
+        "\n" +
+        "OpenAPI: packages/engine/openapi/openapi.yaml\n"
+    );
+    return;
+  }
+
+  const manifestPath = resolveWorkflowEngineMcpConfigPath(process.argv);
+  let activityExecutor = undefined;
+  let delegateExecutor = undefined;
+  try {
+    const [activityLoaded, delegateLoaded] = await Promise.all([
+      loadProductionActivityExecutor({ manifestPath }),
+      loadProductionDelegateExecutor({ manifestPath }),
+    ]);
+    if (!activityLoaded.ok) {
+      if ("errors" in activityLoaded && activityLoaded.errors) {
+        process.stderr.write(
+          `[engine-rest] Invalid operator manifest at ${manifestPath}:\n${formatMcpManifestValidationErrors(activityLoaded.errors)}\n`
+        );
+      } else {
+        process.stderr.write(`[engine-rest] Activity executor configuration failed: ${activityLoaded.error}\n`);
+      }
+      process.exitCode = 1;
+      return;
+    }
+    activityExecutor = activityLoaded.executor;
+
+    if (!delegateLoaded.ok) {
+      if ("errors" in delegateLoaded && delegateLoaded.errors) {
+        process.stderr.write(
+          `[engine-rest] Invalid operator manifest at ${manifestPath}:\n${formatMcpManifestValidationErrors(delegateLoaded.errors)}\n`
+        );
+      } else {
+        process.stderr.write(`[engine-rest] Delegate executor configuration failed: ${delegateLoaded.error}\n`);
+      }
+      process.exitCode = 1;
+      return;
+    }
+    delegateExecutor = delegateLoaded.executor;
+    process.stderr.write(formatActivityRoutingSummaryLog(activityLoaded.routingSummary));
+  } catch (err) {
+    process.stderr.write(
+      `[engine-rest] Executor configuration failed: ${err instanceof Error ? err.message : String(err)}\n`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const store = new MemoryExecutionHistoryStore();
+  const definitionRegistry = new DefinitionRegistry();
+  const workflowPort = createWorkflowApplicationPort({
+    store,
+    ...(activityExecutor ? { activityExecutor } : {}),
+    ...(delegateExecutor ? { delegateExecutor } : {}),
+  });
+  const handler = createRestWorkflowHandler(workflowPort, { definitionRegistry, store });
+  const port = parsePort(args);
+  const server = createServer((req, res) => {
+    handler(req, res).catch((error) => {
+      process.stderr.write(`[engine-rest] handler error: ${error instanceof Error ? error.message : String(error)}\n`);
+      if (!res.headersSent) {
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: { code: "INTERNAL_ERROR", message: "Unexpected handler failure." } }));
+      }
+    });
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", resolve);
+  });
+  process.stderr.write(`[engine-rest] listening on http://127.0.0.1:${port}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`[engine-rest] startup failed: ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/packages/engine/test/rest-adapter.test.mjs
+++ b/packages/engine/test/rest-adapter.test.mjs
@@ -1,0 +1,263 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+import { createRestWorkflowHandler } from "../src/adapters/rest/rest-handler.mjs";
+import { DefinitionRegistry } from "../src/adapters/rest/definition-registry.mjs";
+import { createWorkflowApplicationPort } from "../src/application/workflow-application-port.mjs";
+import { MemoryExecutionHistoryStore } from "../src/persistence/memory-history-store.mjs";
+import { findWorkflowRepoRoot } from "../src/validate.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function minimalValidWorkflowDefinition(name = "rest-mock") {
+  return {
+    document: {
+      schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
+      name,
+      version: "1.0.0",
+    },
+    state_schema: { type: "object" },
+    nodes: [
+      { id: "start", type: "start" },
+      { id: "end", type: "end" },
+    ],
+    edges: [
+      { source: "__start__", target: "start" },
+      { source: "start", target: "end" },
+    ],
+  };
+}
+
+function hostMediatedLinearDefinition() {
+  return {
+    document: {
+      schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
+      name: "rest-host-med-linear",
+      version: "1.0.0",
+    },
+    state_schema: {
+      type: "object",
+      properties: {
+        out: { type: "string" },
+      },
+    },
+    nodes: [
+      { id: "start", type: "start" },
+      {
+        id: "work",
+        type: "tool_call",
+        config: { server: "demo-mcp", tool: "stub", arguments: {} },
+      },
+      { id: "end", type: "end", config: { output_mapping: ".out" } },
+    ],
+    edges: [
+      { source: "__start__", target: "start" },
+      { source: "start", target: "work" },
+      { source: "work", target: "end" },
+    ],
+  };
+}
+
+function loadLighthouse() {
+  const root = findWorkflowRepoRoot(__dirname);
+  return JSON.parse(readFileSync(path.join(root, "examples", "lighthouse-customer-routing.workflow.json"), "utf8"));
+}
+
+/**
+ * @param {(port: number) => Promise<void>} run
+ */
+async function withRestServer(run) {
+  const store = new MemoryExecutionHistoryStore();
+  const definitionRegistry = new DefinitionRegistry();
+  const workflowPort = createWorkflowApplicationPort({ store });
+  const handler = createRestWorkflowHandler(workflowPort, { definitionRegistry, store });
+  const server = createServer((req, res) => {
+    handler(req, res).catch((error) => {
+      if (!res.headersSent) {
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: { code: "INTERNAL_ERROR", message: String(error) } }));
+      }
+    });
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  try {
+    await run(address.port);
+  } finally {
+    await new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve(undefined))));
+  }
+}
+
+/**
+ * @param {number} port
+ * @param {string} method
+ * @param {string} pathname
+ * @param {unknown} [body]
+ */
+async function requestJson(port, method, pathname, body) {
+  const response = await fetch(`http://127.0.0.1:${port}${pathname}`, {
+    method,
+    headers: body !== undefined ? { "content-type": "application/json" } : undefined,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const text = await response.text();
+  const parsed = text ? JSON.parse(text) : undefined;
+  return { status: response.status, body: parsed };
+}
+
+describe("REST workflow adapter", () => {
+  it("registers definition and starts execution via RFC-05 paths", async () => {
+    await withRestServer(async (port) => {
+      const definition = minimalValidWorkflowDefinition("rest-register-start");
+      const registered = await requestJson(port, "POST", "/v1/workflows", { definition });
+      assert.equal(registered.status, 201);
+      assert.equal(registered.body.wf_id, "rest-register-start");
+
+      const fetched = await requestJson(port, "GET", `/v1/workflows/${registered.body.wf_id}`);
+      assert.equal(fetched.status, 200);
+      assert.equal(fetched.body.wf_id, "rest-register-start");
+
+      const started = await requestJson(port, "POST", `/v1/workflows/${registered.body.wf_id}/executions`, {
+        execution_id: "rest-exec-1",
+        input: {},
+      });
+      assert.equal(started.status, 200);
+      assert.equal(started.body.execution_id, "rest-exec-1");
+      assert.equal(started.body.status, "completed");
+
+      const status = await requestJson(port, "GET", "/v1/executions/rest-exec-1");
+      assert.equal(status.status, 200);
+      assert.equal(status.body.phase, "completed");
+    });
+  });
+
+  it("returns structured validation errors aligned with MCP adapter codes", async () => {
+    await withRestServer(async (port) => {
+      const response = await requestJson(port, "POST", "/v1/workflows", {
+        definition: { nodes: [], edges: [] },
+      });
+      assert.equal(response.status, 400);
+      assert.equal(response.body.error.code, "VALIDATION_ERROR");
+    });
+  });
+
+  it("maps missing execution to EXECUTION_NOT_FOUND on status", async () => {
+    await withRestServer(async (port) => {
+      const response = await requestJson(port, "GET", "/v1/executions/missing-exec");
+      assert.equal(response.status, 404);
+      assert.equal(response.body.error.code, "EXECUTION_NOT_FOUND");
+    });
+  });
+
+  it("lists paginated execution events from the history store", async () => {
+    await withRestServer(async (port) => {
+      const definition = minimalValidWorkflowDefinition("rest-events");
+      const registered = await requestJson(port, "POST", "/v1/workflows", { definition });
+      await requestJson(port, "POST", `/v1/workflows/${registered.body.wf_id}/executions`, {
+        execution_id: "rest-events-1",
+        input: {},
+      });
+
+      const events = await requestJson(port, "GET", "/v1/executions/rest-events-1/events?limit=5");
+      assert.equal(events.status, 200);
+      assert.equal(events.body.execution_id, "rest-events-1");
+      assert.ok(Array.isArray(events.body.events));
+      assert.ok(events.body.events.length > 0);
+      assert.equal(events.body.events[0].seq, 1);
+    });
+  });
+
+  it("resumes interrupted lighthouse execution", async () => {
+    await withRestServer(async (port) => {
+      const definition = loadLighthouse();
+      const registered = await requestJson(port, "POST", "/v1/workflows", { definition });
+      const started = await requestJson(port, "POST", `/v1/workflows/${registered.body.wf_id}/executions`, {
+        execution_id: "rest-resume-1",
+        input: { ticket_text: "unclear" },
+      });
+      assert.equal(started.body.status, "interrupted");
+
+      const resumed = await requestJson(port, "POST", "/v1/executions/rest-resume-1:resume", {
+        definition,
+        resume_payload: { intent: "billing" },
+      });
+      assert.equal(resumed.status, 200);
+      assert.equal(resumed.body.status, "completed");
+      assert.deepEqual(resumed.body.result, { intent: "billing", confidence: null });
+    });
+  });
+
+  it("maps stale resume attempts to INVALID_RESUME_PAYLOAD", async () => {
+    await withRestServer(async (port) => {
+      const definition = minimalValidWorkflowDefinition("rest-resume-stale");
+      const registered = await requestJson(port, "POST", "/v1/workflows", { definition });
+      await requestJson(port, "POST", `/v1/workflows/${registered.body.wf_id}/executions`, {
+        execution_id: "rest-resume-stale",
+        input: {},
+      });
+
+      const response = await requestJson(port, "POST", "/v1/executions/rest-resume-stale:resume", {
+        definition,
+        resume_payload: { intent: "billing" },
+      });
+      assert.equal(response.status, 400);
+      assert.equal(response.body.error.code, "INVALID_RESUME_PAYLOAD");
+    });
+  });
+
+  it("completes host-mediated execution through submit_activity", async () => {
+    await withRestServer(async (port) => {
+      const definition = hostMediatedLinearDefinition();
+      const registered = await requestJson(port, "POST", "/v1/workflows", { definition });
+      const executionId = "rest-submit-ok";
+      const input = {};
+
+      const started = await requestJson(port, "POST", `/v1/workflows/${registered.body.wf_id}/executions`, {
+        execution_id: executionId,
+        input,
+        activity_execution_mode: "host_mediated",
+      });
+      assert.equal(started.body.status, "awaiting_activity");
+      assert.equal(started.body.node_id, "work");
+
+      const submitted = await requestJson(port, "POST", `/v1/executions/${executionId}:submit_activity`, {
+        definition,
+        input,
+        node_id: "work",
+        outcome: { ok: true, result: { out: "from-host" } },
+      });
+      assert.equal(submitted.status, 200);
+      assert.equal(submitted.body.status, "completed");
+      assert.equal(submitted.body.result, "from-host");
+    });
+  });
+
+  it("maps stale activity submit to ACTIVITY_SUBMIT_NOT_AWAITING", async () => {
+    await withRestServer(async (port) => {
+      const definition = hostMediatedLinearDefinition();
+      const response = await requestJson(port, "POST", "/v1/executions/no-such-exec:submit_activity", {
+        definition,
+        input: {},
+        node_id: "work",
+        outcome: { ok: true, result: { out: "x" } },
+      });
+      assert.equal(response.status, 409);
+      assert.equal(response.body.error.code, "ACTIVITY_SUBMIT_NOT_AWAITING");
+    });
+  });
+
+  it("returns 501 for cancel until application port supports it", async () => {
+    await withRestServer(async (port) => {
+      const response = await requestJson(port, "POST", "/v1/executions/some-exec:cancel");
+      assert.equal(response.status, 501);
+      assert.equal(response.body.error.code, "NOT_IMPLEMENTED");
+    });
+  });
+});

--- a/packages/engine/test/rest-adapter.test.mjs
+++ b/packages/engine/test/rest-adapter.test.mjs
@@ -102,6 +102,7 @@ async function withRestServer(run) {
  * @param {unknown} [body]
  */
 async function requestJson(port, method, pathname, body) {
+  // codeql[js/file-access-to-http]: test posts fixture JSON to in-process localhost only
   const response = await fetch(`http://127.0.0.1:${port}${pathname}`, {
     method,
     headers: body !== undefined ? { "content-type": "application/json" } : undefined,

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,100 @@
+# @agent-workflow/sdk
+
+JavaScript/TypeScript client for the [Agent Workflow Protocol](https://github.com/benvdbergh/workflows) reference engine. Responses use MCP-aligned `snake_case` DTOs; method options accept camelCase or snake_case.
+
+## Install
+
+```bash
+npm install @agent-workflow/sdk @agent-workflow/engine
+```
+
+## Quickstart — REST backend (< 5 minutes)
+
+**1. Start the reference REST server** (from a clone of this repo):
+
+```bash
+npm install
+npm run engine:rest:serve
+```
+
+Default base URL: `http://127.0.0.1:8787`
+
+**2. Run a workflow from Node:**
+
+```javascript
+import { WorkflowClient } from "@agent-workflow/sdk";
+
+const client = new WorkflowClient({ baseUrl: "http://127.0.0.1:8787" });
+
+const definition = {
+  document: {
+    schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
+    name: "hello-sdk",
+    version: "1.0.0",
+  },
+  state_schema: { type: "object" },
+  nodes: [
+    { id: "start", type: "start" },
+    { id: "end", type: "end" },
+  ],
+  edges: [
+    { source: "__start__", target: "start" },
+    { source: "start", target: "end" },
+  ],
+};
+
+const { wf_id } = await client.registerDefinition(definition);
+
+const started = await client.start({
+  wfId: wf_id,
+  executionId: "demo-1",
+  input: {},
+});
+console.log(started.status); // "completed"
+
+const status = await client.getStatus({ executionId: "demo-1" });
+console.log(status.phase); // "completed"
+```
+
+You can skip `registerDefinition` and pass `definition` directly to `start`; the SDK registers it on the server first.
+
+## Quickstart — in-memory (tests, no HTTP)
+
+```javascript
+import { createWorkflowApplicationPort, MemoryExecutionHistoryStore } from "@agent-workflow/engine";
+import { WorkflowClient } from "@agent-workflow/sdk";
+
+const port = createWorkflowApplicationPort({ store: new MemoryExecutionHistoryStore() });
+const client = WorkflowClient.fromPort(port);
+
+const definition = { /* same shape as above */ };
+
+const started = await client.start({
+  definition,
+  executionId: "mem-1",
+  input: {},
+});
+console.log(started.execution_id, started.status);
+```
+
+## API
+
+| Method | Description |
+|--------|-------------|
+| `registerDefinition(definition)` | `POST /v1/workflows` (REST) or local id derivation (port) |
+| `start({ wfId?, definition?, executionId?, input?, activityExecutionMode? })` | Start execution |
+| `getStatus({ executionId })` | Poll execution phase |
+| `resume({ executionId, definition, resumePayload? })` | Continue after `interrupt` |
+| `submitActivity({ executionId, definition, input?, nodeId, outcome })` | Complete host-mediated activity |
+
+Errors throw `SdkError` with a stable `code` (`VALIDATION_ERROR`, `EXECUTION_NOT_FOUND`, `INVALID_RESUME_PAYLOAD`, `ACTIVITY_SUBMIT_*`, `ENGINE_FAILURE`, …) parsed from REST `{ error: { code, message } }` bodies.
+
+## TypeScript
+
+Hand-maintained declarations ship in `src/types.d.ts`. No build step required — the package is ESM `.mjs` with JSDoc.
+
+## Development
+
+```bash
+npm run sdk:test
+```

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@agent-workflow/sdk",
+  "version": "0.1.5",
+  "description": "Agent Workflow Protocol — TypeScript/JavaScript client for REST and in-process engine access",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/benvdbergh/workflows"
+  },
+  "type": "module",
+  "main": "./src/index.mjs",
+  "types": "./src/types.d.ts",
+  "exports": {
+    ".": {
+      "types": "./src/types.d.ts",
+      "import": "./src/index.mjs"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "src/",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "node --test test/*.mjs"
+  },
+  "engines": {
+    "node": ">=22.5.0"
+  },
+  "dependencies": {
+    "@agent-workflow/engine": "0.1.5"
+  }
+}

--- a/packages/sdk/src/client.mjs
+++ b/packages/sdk/src/client.mjs
@@ -1,0 +1,193 @@
+import { createPortTransport } from "./port-transport.mjs";
+import { createRestTransport } from "./rest-transport.mjs";
+
+/**
+ * @typedef {import("./types.mjs").ActivityExecutionMode} ActivityExecutionMode
+ * @typedef {import("./types.mjs").ActivityOutcomeTransport} ActivityOutcomeTransport
+ * @typedef {import("./types.mjs").RegisterDefinitionResultTransport} RegisterDefinitionResultTransport
+ * @typedef {import("./types.mjs").WorkflowParallelSpanTransport} WorkflowParallelSpanTransport
+ * @typedef {import("./types.mjs").WorkflowResumeResultTransport} WorkflowResumeResultTransport
+ * @typedef {import("./types.mjs").WorkflowStartResultTransport} WorkflowStartResultTransport
+ * @typedef {import("./types.mjs").WorkflowStatusResultTransport} WorkflowStatusResultTransport
+ * @typedef {import("./types.mjs").WorkflowSubmitActivityResultTransport} WorkflowSubmitActivityResultTransport
+ */
+
+/**
+ * @param {Record<string, unknown>} options
+ * @param {string} camel
+ * @param {string} snake
+ */
+function pickOption(options, camel, snake) {
+  if (options[camel] !== undefined) {
+    return options[camel];
+  }
+  return options[snake];
+}
+
+export class WorkflowClient {
+  /** @type {ReturnType<typeof createRestTransport> | ReturnType<typeof createPortTransport>} */
+  #transport;
+
+  /** @type {Map<string, object>} */
+  #definitions = new Map();
+
+  /**
+   * @param {{ baseUrl?: string; fetch?: typeof fetch; port?: {
+   *   startWorkflow: Function;
+   *   getWorkflowStatus: Function;
+   *   resumeWorkflow: Function;
+   *   submitWorkflowActivity: Function;
+   * } }} options
+   */
+  constructor(options = {}) {
+    if (options.port) {
+      this.#transport = createPortTransport(options.port);
+    } else if (options.baseUrl) {
+      this.#transport = createRestTransport({ baseUrl: options.baseUrl, fetch: options.fetch });
+    } else {
+      throw new TypeError(
+        "WorkflowClient requires baseUrl for REST mode or port for in-process mode. Use WorkflowClient.fromPort(port) as a shortcut."
+      );
+    }
+    this.#definitions = new Map();
+  }
+
+  /**
+   * @param {{
+   *   startWorkflow: Function;
+   *   getWorkflowStatus: Function;
+   *   resumeWorkflow: Function;
+   *   submitWorkflowActivity: Function;
+   * }} port
+   */
+  static fromPort(port) {
+    return new WorkflowClient({ port });
+  }
+
+  /**
+   * Register a workflow definition. Required for REST `start` unless `definition` is passed to `start`.
+   *
+   * @param {object} definition
+   * @returns {Promise<RegisterDefinitionResultTransport>}
+   */
+  async registerDefinition(definition) {
+    const registered = await this.#transport.registerDefinition(definition);
+    this.#definitions.set(registered.wf_id, registered.definition);
+    return registered;
+  }
+
+  /**
+   * @param {Record<string, unknown>} options
+   * @returns {Promise<WorkflowStartResultTransport>}
+   */
+  async start(options) {
+    let wfId = pickOption(options, "wfId", "wf_id");
+    const definition = /** @type {object | undefined} */ (options.definition);
+    if (!wfId && definition) {
+      const registered = await this.registerDefinition(definition);
+      wfId = registered.wf_id;
+    }
+    if (!wfId) {
+      throw new TypeError("start requires wfId/wf_id or definition (REST registers automatically).");
+    }
+
+    const body = {
+      ...(pickOption(options, "executionId", "execution_id") !== undefined
+        ? { execution_id: pickOption(options, "executionId", "execution_id") }
+        : {}),
+      input: /** @type {Record<string, unknown>} */ (options.input ?? {}),
+      ...(pickOption(options, "activityExecutionMode", "activity_execution_mode") !== undefined
+        ? {
+            activity_execution_mode: pickOption(options, "activityExecutionMode", "activity_execution_mode"),
+          }
+        : {}),
+      ...(pickOption(options, "allowExistingExecutionId", "allow_existing_execution_id") === true
+        ? { allow_existing_execution_id: true }
+        : {}),
+    };
+
+    if (this.#transport.mode === "port") {
+      const resolvedDefinition = definition ?? this.#definitions.get(wfId);
+      if (!resolvedDefinition) {
+        throw new TypeError("start requires definition when using WorkflowClient.fromPort.");
+      }
+      return this.#transport.start(wfId, { ...body, definition: resolvedDefinition });
+    }
+
+    return this.#transport.start(wfId, body);
+  }
+
+  /**
+   * @param {Record<string, unknown>} options
+   * @returns {Promise<WorkflowStatusResultTransport>}
+   */
+  async getStatus(options) {
+    const executionId = pickOption(options, "executionId", "execution_id");
+    if (typeof executionId !== "string" || executionId.trim() === "") {
+      throw new TypeError("getStatus requires executionId/execution_id.");
+    }
+    return this.#transport.getStatus(executionId);
+  }
+
+  /**
+   * @param {Record<string, unknown>} options
+   * @returns {Promise<WorkflowResumeResultTransport>}
+   */
+  async resume(options) {
+    const executionId = pickOption(options, "executionId", "execution_id");
+    if (typeof executionId !== "string" || executionId.trim() === "") {
+      throw new TypeError("resume requires executionId/execution_id.");
+    }
+    const definition = /** @type {object | undefined} */ (options.definition);
+    if (!definition) {
+      throw new TypeError("resume requires definition.");
+    }
+    const body = {
+      definition,
+      resume_payload: /** @type {Record<string, unknown>} */ (
+        pickOption(options, "resumePayload", "resume_payload") ?? {}
+      ),
+      ...(pickOption(options, "activityExecutionMode", "activity_execution_mode") !== undefined
+        ? {
+            activity_execution_mode: pickOption(options, "activityExecutionMode", "activity_execution_mode"),
+          }
+        : {}),
+    };
+    return this.#transport.resume(executionId, body);
+  }
+
+  /**
+   * @param {Record<string, unknown>} options
+   * @returns {Promise<WorkflowSubmitActivityResultTransport>}
+   */
+  async submitActivity(options) {
+    const executionId = pickOption(options, "executionId", "execution_id");
+    const nodeId = pickOption(options, "nodeId", "node_id");
+    if (typeof executionId !== "string" || executionId.trim() === "") {
+      throw new TypeError("submitActivity requires executionId/execution_id.");
+    }
+    if (typeof nodeId !== "string" || nodeId.trim() === "") {
+      throw new TypeError("submitActivity requires nodeId/node_id.");
+    }
+    const definition = /** @type {object | undefined} */ (options.definition);
+    if (!definition) {
+      throw new TypeError("submitActivity requires definition.");
+    }
+    const parallelSpan = /** @type {WorkflowParallelSpanTransport | undefined} */ (
+      pickOption(options, "parallelSpan", "parallel_span")
+    );
+    const body = {
+      definition,
+      input: /** @type {Record<string, unknown>} */ (options.input ?? {}),
+      node_id: nodeId,
+      outcome: /** @type {ActivityOutcomeTransport} */ (options.outcome),
+      ...(parallelSpan ? { parallel_span: parallelSpan } : {}),
+      ...(pickOption(options, "activityExecutionMode", "activity_execution_mode") !== undefined
+        ? {
+            activity_execution_mode: pickOption(options, "activityExecutionMode", "activity_execution_mode"),
+          }
+        : {}),
+    };
+    return this.#transport.submitActivity(executionId, body);
+  }
+}

--- a/packages/sdk/src/errors.mjs
+++ b/packages/sdk/src/errors.mjs
@@ -1,0 +1,30 @@
+/**
+ * Stable SDK error aligned with MCP adapter and REST `{ error: { code, message } }` bodies.
+ */
+export class SdkError extends Error {
+  /**
+   * @param {string} code
+   * @param {string} message
+   * @param {unknown} [details]
+   */
+  constructor(code, message, details) {
+    super(message);
+    this.name = "SdkError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+/**
+ * @param {unknown} body
+ * @returns {SdkError}
+ */
+export function sdkErrorFromRestBody(body) {
+  if (body && typeof body === "object" && !Array.isArray(body)) {
+    const error = /** @type {{ error?: { code?: string; message?: string; details?: unknown } }} */ (body).error;
+    if (error && typeof error.code === "string" && typeof error.message === "string") {
+      return new SdkError(error.code, error.message, error.details);
+    }
+  }
+  return new SdkError("INTERNAL_ERROR", "Unexpected error response from workflow backend.");
+}

--- a/packages/sdk/src/index.mjs
+++ b/packages/sdk/src/index.mjs
@@ -1,0 +1,4 @@
+export { SdkError } from "./errors.mjs";
+export { WorkflowClient } from "./client.mjs";
+export { createRestTransport } from "./rest-transport.mjs";
+export { createPortTransport } from "./port-transport.mjs";

--- a/packages/sdk/src/port-transport.mjs
+++ b/packages/sdk/src/port-transport.mjs
@@ -1,5 +1,6 @@
 import {
   MCP_ADAPTER_ERROR,
+  normalizeWorkflowIdSlug,
   resumeResponseFromPort,
   startResponseFromPort,
   statusResponseFromPort,
@@ -206,11 +207,7 @@ export function createPortTransport(port) {
 function deriveWorkflowId(definition) {
   const name = definition?.document?.name;
   if (typeof name === "string" && name.trim() !== "") {
-    const normalized = name
-      .trim()
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "");
+    const normalized = normalizeWorkflowIdSlug(name);
     if (normalized !== "") {
       return normalized;
     }

--- a/packages/sdk/src/port-transport.mjs
+++ b/packages/sdk/src/port-transport.mjs
@@ -1,0 +1,219 @@
+import {
+  MCP_ADAPTER_ERROR,
+  resumeResponseFromPort,
+  startResponseFromPort,
+  statusResponseFromPort,
+  submitActivityResponseFromPort,
+} from "@agent-workflow/engine";
+import { SdkError } from "./errors.mjs";
+
+const SUBMIT_ACTIVITY_ADAPTER_CODES = new Set([
+  MCP_ADAPTER_ERROR.ACTIVITY_SUBMIT_NOT_AWAITING,
+  MCP_ADAPTER_ERROR.ACTIVITY_SUBMIT_NODE_MISMATCH,
+  MCP_ADAPTER_ERROR.ACTIVITY_SUBMIT_PARALLEL_MISMATCH,
+  MCP_ADAPTER_ERROR.SUBMIT_VALIDATION_ERROR,
+]);
+
+/**
+ * @param {string | undefined} code
+ * @param {string | undefined} message
+ */
+function sdkErrorForStartFailure(code, message) {
+  const text = message && message.trim() !== "" ? message : "Workflow start failed.";
+  if (code === MCP_ADAPTER_ERROR.VALIDATION_ERROR || code === "VALIDATION_ERROR") {
+    return new SdkError(MCP_ADAPTER_ERROR.VALIDATION_ERROR, text);
+  }
+  return new SdkError(MCP_ADAPTER_ERROR.ENGINE_FAILURE, "Engine reported a workflow failure.", text);
+}
+
+/**
+ * @param {string | undefined} code
+ * @param {string | undefined} message
+ */
+function sdkErrorForResumeFailure(code, message) {
+  const text = message && message.trim() !== "" ? message : "Resume request failed.";
+  if (code === MCP_ADAPTER_ERROR.INVALID_RESUME_PAYLOAD) {
+    return new SdkError(MCP_ADAPTER_ERROR.INVALID_RESUME_PAYLOAD, text);
+  }
+  return new SdkError(MCP_ADAPTER_ERROR.ENGINE_FAILURE, "Engine reported a workflow failure.", text);
+}
+
+/**
+ * @param {string | undefined} code
+ * @param {string | undefined} message
+ */
+function sdkErrorForSubmitFailure(code, message) {
+  const text = message && message.trim() !== "" ? message : "Activity submit rejected.";
+  if (code && SUBMIT_ACTIVITY_ADAPTER_CODES.has(code)) {
+    return new SdkError(code, text);
+  }
+  return new SdkError(MCP_ADAPTER_ERROR.ENGINE_FAILURE, "Engine reported a workflow failure.", text);
+}
+
+/**
+ * @param {unknown} error
+ * @returns {SdkError}
+ */
+function normalizePortError(error) {
+  if (error instanceof SdkError) {
+    return error;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  if (typeof error?.code === "string") {
+    if (error.code === MCP_ADAPTER_ERROR.INVALID_RESUME_PAYLOAD) {
+      return new SdkError(MCP_ADAPTER_ERROR.INVALID_RESUME_PAYLOAD, message);
+    }
+    if (error.code === MCP_ADAPTER_ERROR.EXECUTION_NOT_FOUND || error.code === "EXECUTION_NOT_FOUND") {
+      return new SdkError(MCP_ADAPTER_ERROR.EXECUTION_NOT_FOUND, message);
+    }
+    if (error.code === MCP_ADAPTER_ERROR.DUPLICATE_EXECUTION_ID) {
+      return new SdkError(MCP_ADAPTER_ERROR.DUPLICATE_EXECUTION_ID, message);
+    }
+    if (error.code === MCP_ADAPTER_ERROR.VALIDATION_ERROR) {
+      return new SdkError(MCP_ADAPTER_ERROR.VALIDATION_ERROR, message);
+    }
+  }
+  return new SdkError(MCP_ADAPTER_ERROR.INTERNAL_ERROR, "Unexpected internal error in SDK port transport.", message);
+}
+
+/**
+ * @param {{
+ *   startWorkflow: Function;
+ *   getWorkflowStatus: Function;
+ *   resumeWorkflow: Function;
+ *   submitWorkflowActivity: Function;
+ * }} port
+ */
+export function createPortTransport(port) {
+  return {
+    mode: "port",
+  /**
+   * @param {object} definition
+   */
+    async registerDefinition(definition) {
+      return { wf_id: deriveWorkflowId(definition), definition };
+    },
+    /**
+     * @param {string} _wfId
+     * @param {Record<string, unknown>} body
+     */
+    async start(_wfId, body) {
+      try {
+        const response = await port.startWorkflow({
+          executionId: typeof body.execution_id === "string" ? body.execution_id : undefined,
+          definition: /** @type {object} */ (body.definition),
+          input: /** @type {Record<string, unknown>} */ (body.input ?? {}),
+          ...(body.activity_execution_mode
+            ? { activityExecutionMode: /** @type {"in_process" | "host_mediated"} */ (body.activity_execution_mode) }
+            : {}),
+          ...(body.allow_existing_execution_id === true ? { allowExistingExecutionId: true } : {}),
+        });
+        if (response.status === "failed" && response.error) {
+          throw sdkErrorForStartFailure(response.code, response.error);
+        }
+        return startResponseFromPort(response);
+      } catch (error) {
+        throw normalizePortError(error);
+      }
+    },
+    /**
+     * @param {string} executionId
+     */
+    async getStatus(executionId) {
+      try {
+        const response = await port.getWorkflowStatus({ executionId });
+        return statusResponseFromPort(response);
+      } catch (error) {
+        throw normalizePortError(error);
+      }
+    },
+    /**
+     * @param {string} executionId
+     * @param {Record<string, unknown>} body
+     */
+    async resume(executionId, body) {
+      try {
+        const response = await port.resumeWorkflow({
+          executionId,
+          definition: /** @type {object} */ (body.definition),
+          resumePayload: /** @type {Record<string, unknown>} */ (body.resume_payload ?? {}),
+          ...(body.activity_execution_mode
+            ? { activityExecutionMode: /** @type {"in_process" | "host_mediated"} */ (body.activity_execution_mode) }
+            : {}),
+        });
+        if (response.status === "failed") {
+          throw sdkErrorForResumeFailure(response.code, response.error);
+        }
+        return resumeResponseFromPort(response);
+      } catch (error) {
+        throw normalizePortError(error);
+      }
+    },
+    /**
+     * @param {string} executionId
+     * @param {Record<string, unknown>} body
+     */
+    async submitActivity(executionId, body) {
+      try {
+        const parallelSpan = body.parallel_span;
+        const expectedParallelSpan =
+          parallelSpan && typeof parallelSpan === "object" && !Array.isArray(parallelSpan)
+            ? {
+                parallelNodeId: /** @type {string} */ (parallelSpan.parallel_node_id),
+                joinTargetId: /** @type {string} */ (parallelSpan.join_target_id),
+                branchName: /** @type {string} */ (parallelSpan.branch_name),
+                branchEntryNodeId: /** @type {string} */ (parallelSpan.branch_entry_node_id),
+              }
+            : undefined;
+        const outcome = /** @type {{ ok: boolean; result?: Record<string, unknown>; delegate_correlation_id?: string; external_task_id?: string; error?: string; code?: string }} */ (
+          body.outcome
+        );
+        const response = await port.submitWorkflowActivity({
+          executionId,
+          definition: /** @type {object} */ (body.definition),
+          input: /** @type {Record<string, unknown>} */ (body.input ?? {}),
+          nodeId: /** @type {string} */ (body.node_id),
+          outcome:
+            outcome.ok === true
+              ? {
+                  ok: true,
+                  ...(outcome.result !== undefined ? { result: outcome.result } : {}),
+                  ...(outcome.delegate_correlation_id !== undefined
+                    ? { delegateCorrelationId: outcome.delegate_correlation_id }
+                    : {}),
+                  ...(outcome.external_task_id !== undefined ? { externalTaskId: outcome.external_task_id } : {}),
+                }
+              : { ok: false, error: outcome.error ?? "Activity failed.", ...(outcome.code ? { code: outcome.code } : {}) },
+          ...(expectedParallelSpan ? { expectedParallelSpan } : {}),
+          ...(body.activity_execution_mode
+            ? { activityExecutionMode: /** @type {"in_process" | "host_mediated"} */ (body.activity_execution_mode) }
+            : {}),
+        });
+        if (response.status === "failed") {
+          throw sdkErrorForSubmitFailure(response.code, response.error);
+        }
+        return submitActivityResponseFromPort(response);
+      } catch (error) {
+        throw normalizePortError(error);
+      }
+    },
+  };
+}
+
+/**
+ * @param {object} definition
+ */
+function deriveWorkflowId(definition) {
+  const name = definition?.document?.name;
+  if (typeof name === "string" && name.trim() !== "") {
+    const normalized = name
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    if (normalized !== "") {
+      return normalized;
+    }
+  }
+  return "workflow";
+}

--- a/packages/sdk/src/rest-transport.mjs
+++ b/packages/sdk/src/rest-transport.mjs
@@ -21,6 +21,7 @@ export function createRestTransport(options) {
    * @param {unknown} [body]
    */
   async function request(method, pathname, body) {
+    // codeql[js/file-access-to-http]: SDK intentionally posts workflow definitions to the configured REST API
     const response = await fetchFn(`${base}${pathname}`, {
       method,
       headers: body !== undefined ? { "content-type": "application/json" } : undefined,

--- a/packages/sdk/src/rest-transport.mjs
+++ b/packages/sdk/src/rest-transport.mjs
@@ -1,0 +1,88 @@
+import { sdkErrorFromRestBody } from "./errors.mjs";
+
+/**
+ * @typedef {import("./types.mjs").RegisterDefinitionResultTransport} RegisterDefinitionResultTransport
+ * @typedef {import("./types.mjs").WorkflowStartResultTransport} WorkflowStartResultTransport
+ * @typedef {import("./types.mjs").WorkflowStatusResultTransport} WorkflowStatusResultTransport
+ * @typedef {import("./types.mjs").WorkflowResumeResultTransport} WorkflowResumeResultTransport
+ * @typedef {import("./types.mjs").WorkflowSubmitActivityResultTransport} WorkflowSubmitActivityResultTransport
+ */
+
+/**
+ * @param {{ baseUrl: string; fetch?: typeof fetch }} options
+ */
+export function createRestTransport(options) {
+  const fetchFn = options.fetch ?? globalThis.fetch;
+  const base = options.baseUrl.replace(/\/$/, "");
+
+  /**
+   * @param {string} method
+   * @param {string} pathname
+   * @param {unknown} [body]
+   */
+  async function request(method, pathname, body) {
+    const response = await fetchFn(`${base}${pathname}`, {
+      method,
+      headers: body !== undefined ? { "content-type": "application/json" } : undefined,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    const text = await response.text();
+    const parsed = text ? JSON.parse(text) : undefined;
+    if (!response.ok) {
+      throw sdkErrorFromRestBody(parsed);
+    }
+    return parsed;
+  }
+
+  return {
+    mode: "rest",
+    /**
+     * @param {object} definition
+     * @returns {Promise<RegisterDefinitionResultTransport>}
+     */
+    async registerDefinition(definition) {
+      return /** @type {Promise<RegisterDefinitionResultTransport>} */ (
+        request("POST", "/v1/workflows", { definition })
+      );
+    },
+    /**
+     * @param {string} wfId
+     * @param {Record<string, unknown>} body
+     * @returns {Promise<WorkflowStartResultTransport>}
+     */
+    async start(wfId, body) {
+      return /** @type {Promise<WorkflowStartResultTransport>} */ (
+        request("POST", `/v1/workflows/${encodeURIComponent(wfId)}/executions`, body)
+      );
+    },
+    /**
+     * @param {string} executionId
+     * @returns {Promise<WorkflowStatusResultTransport>}
+     */
+    async getStatus(executionId) {
+      return /** @type {Promise<WorkflowStatusResultTransport>} */ (
+        request("GET", `/v1/executions/${encodeURIComponent(executionId)}`)
+      );
+    },
+    /**
+     * @param {string} executionId
+     * @param {Record<string, unknown>} body
+     * @returns {Promise<WorkflowResumeResultTransport>}
+     */
+    async resume(executionId, body) {
+      return /** @type {Promise<WorkflowResumeResultTransport>} */ (
+        request("POST", `/v1/executions/${encodeURIComponent(executionId)}:resume`, body)
+      );
+    },
+    /**
+     * @param {string} executionId
+     * @param {Record<string, unknown>} body
+     * @returns {Promise<WorkflowSubmitActivityResultTransport>}
+     */
+    async submitActivity(executionId, body) {
+      return /** @type {Promise<WorkflowSubmitActivityResultTransport>} */ (
+        request("POST", `/v1/executions/${encodeURIComponent(executionId)}:submit_activity`, body)
+      );
+    },
+  };
+}

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -1,0 +1,250 @@
+export type ActivityExecutionMode = "in_process" | "host_mediated";
+
+export interface WorkflowParallelSpanTransport {
+  parallel_node_id: string;
+  join_target_id: string;
+  branch_name: string;
+  branch_entry_node_id: string;
+}
+
+export type ActivityOutcomeTransport =
+  | {
+      ok: true;
+      result?: Record<string, unknown>;
+      delegate_correlation_id?: string;
+      external_task_id?: string;
+    }
+  | {
+      ok: false;
+      error: string;
+      code?: string;
+    };
+
+export interface WorkflowStartResultTransport {
+  execution_id: string;
+  status: "completed" | "failed" | "interrupted" | "awaiting_activity";
+  final_state?: Record<string, unknown>;
+  result?: unknown;
+  error?: string;
+  node_id?: string;
+  state?: Record<string, unknown>;
+  parallel_span?: WorkflowParallelSpanTransport;
+  agent_id?: string;
+  protocol?: string;
+  delegate_input?: Record<string, unknown>;
+  delegate_correlation_id?: string;
+}
+
+export interface WorkflowStatusResultTransport {
+  execution_id: string;
+  phase: "running" | "completed" | "failed" | "interrupted" | "awaiting_activity";
+  current_node_id?: string;
+  last_error?: string;
+  delegate_correlation_id?: string;
+  child_execution_id?: string;
+  parent_execution_id?: string;
+  agent_id?: string;
+  protocol?: string;
+  delegate_input?: Record<string, unknown>;
+}
+
+export interface WorkflowResumeResultTransport {
+  execution_id: string;
+  status: "completed" | "failed" | "interrupted" | "awaiting_activity";
+  final_state?: Record<string, unknown>;
+  result?: unknown;
+  error?: string;
+  node_id?: string;
+  state?: Record<string, unknown>;
+  parallel_span?: WorkflowParallelSpanTransport;
+  agent_id?: string;
+  protocol?: string;
+  delegate_input?: Record<string, unknown>;
+  delegate_correlation_id?: string;
+}
+
+export interface WorkflowSubmitActivityResultTransport {
+  execution_id: string;
+  status: "completed" | "failed" | "interrupted" | "awaiting_activity";
+  final_state?: Record<string, unknown>;
+  result?: unknown;
+  error?: string;
+  node_id?: string;
+  state?: Record<string, unknown>;
+  parallel_span?: WorkflowParallelSpanTransport;
+  code?: string;
+  agent_id?: string;
+  protocol?: string;
+  delegate_input?: Record<string, unknown>;
+  delegate_correlation_id?: string;
+}
+
+export interface RegisterDefinitionResultTransport {
+  wf_id: string;
+  definition: object;
+}
+
+export interface WorkflowStartOptions {
+  wfId?: string;
+  wf_id?: string;
+  definition?: object;
+  executionId?: string;
+  execution_id?: string;
+  input?: Record<string, unknown>;
+  activityExecutionMode?: ActivityExecutionMode;
+  activity_execution_mode?: ActivityExecutionMode;
+  allowExistingExecutionId?: boolean;
+  allow_existing_execution_id?: boolean;
+}
+
+export interface WorkflowStatusOptions {
+  executionId?: string;
+  execution_id?: string;
+}
+
+export interface WorkflowResumeOptions {
+  executionId?: string;
+  execution_id?: string;
+  definition: object;
+  resumePayload?: Record<string, unknown>;
+  resume_payload?: Record<string, unknown>;
+  activityExecutionMode?: ActivityExecutionMode;
+  activity_execution_mode?: ActivityExecutionMode;
+}
+
+export interface WorkflowSubmitActivityOptions {
+  executionId?: string;
+  execution_id?: string;
+  definition: object;
+  input?: Record<string, unknown>;
+  nodeId?: string;
+  node_id?: string;
+  outcome: ActivityOutcomeTransport;
+  parallelSpan?: WorkflowParallelSpanTransport;
+  parallel_span?: WorkflowParallelSpanTransport;
+  activityExecutionMode?: ActivityExecutionMode;
+  activity_execution_mode?: ActivityExecutionMode;
+}
+
+export interface WorkflowClientRestOptions {
+  baseUrl?: string;
+  fetch?: typeof fetch;
+  port?: WorkflowApplicationPort;
+}
+
+export interface WorkflowApplicationPort {
+  startWorkflow(request: {
+    executionId?: string;
+    definition: object;
+    input: Record<string, unknown>;
+    activityExecutionMode?: ActivityExecutionMode;
+    allowExistingExecutionId?: boolean;
+  }): Promise<{
+    executionId: string;
+    status: string;
+    finalState?: Record<string, unknown>;
+    result?: unknown;
+    error?: string;
+    code?: string;
+    nodeId?: string;
+    state?: Record<string, unknown>;
+    parallelSpan?: {
+      parallelNodeId: string;
+      joinTargetId: string;
+      branchName: string;
+      branchEntryNodeId: string;
+    };
+    agentId?: string;
+    protocol?: string;
+    delegateInput?: Record<string, unknown>;
+    delegateCorrelationId?: string;
+  }>;
+  getWorkflowStatus(request: { executionId: string }): Promise<{
+    executionId: string;
+    phase: string;
+    currentNodeId?: string;
+    lastError?: string;
+    delegateCorrelationId?: string;
+    childExecutionId?: string;
+    parentExecutionId?: string;
+    agentId?: string;
+    protocol?: string;
+    delegateInput?: Record<string, unknown>;
+  }>;
+  resumeWorkflow(request: {
+    executionId: string;
+    definition: object;
+    resumePayload: Record<string, unknown>;
+    activityExecutionMode?: ActivityExecutionMode;
+  }): Promise<{
+    executionId: string;
+    status: string;
+    finalState?: Record<string, unknown>;
+    result?: unknown;
+    error?: string;
+    code?: string;
+    nodeId?: string;
+    state?: Record<string, unknown>;
+    parallelSpan?: {
+      parallelNodeId: string;
+      joinTargetId: string;
+      branchName: string;
+      branchEntryNodeId: string;
+    };
+    agentId?: string;
+    protocol?: string;
+    delegateInput?: Record<string, unknown>;
+    delegateCorrelationId?: string;
+  }>;
+  submitWorkflowActivity(request: {
+    executionId: string;
+    definition: object;
+    input: Record<string, unknown>;
+    nodeId: string;
+    outcome:
+      | { ok: true; result?: Record<string, unknown>; delegateCorrelationId?: string; externalTaskId?: string }
+      | { ok: false; error: string; code?: string };
+    expectedParallelSpan?: {
+      parallelNodeId: string;
+      joinTargetId: string;
+      branchName: string;
+      branchEntryNodeId: string;
+    };
+    activityExecutionMode?: ActivityExecutionMode;
+  }): Promise<{
+    executionId: string;
+    status: string;
+    finalState?: Record<string, unknown>;
+    result?: unknown;
+    error?: string;
+    code?: string;
+    nodeId?: string;
+    state?: Record<string, unknown>;
+    parallelSpan?: {
+      parallelNodeId: string;
+      joinTargetId: string;
+      branchName: string;
+      branchEntryNodeId: string;
+    };
+    agentId?: string;
+    protocol?: string;
+    delegateInput?: Record<string, unknown>;
+    delegateCorrelationId?: string;
+  }>;
+}
+
+export declare class SdkError extends Error {
+  code: string;
+  details?: unknown;
+  constructor(code: string, message: string, details?: unknown);
+}
+
+export declare class WorkflowClient {
+  constructor(options?: WorkflowClientRestOptions);
+  static fromPort(port: WorkflowApplicationPort): WorkflowClient;
+  registerDefinition(definition: object): Promise<RegisterDefinitionResultTransport>;
+  start(options: WorkflowStartOptions): Promise<WorkflowStartResultTransport>;
+  getStatus(options: WorkflowStatusOptions): Promise<WorkflowStatusResultTransport>;
+  resume(options: WorkflowResumeOptions): Promise<WorkflowResumeResultTransport>;
+  submitActivity(options: WorkflowSubmitActivityOptions): Promise<WorkflowSubmitActivityResultTransport>;
+}

--- a/packages/sdk/src/types.mjs
+++ b/packages/sdk/src/types.mjs
@@ -1,0 +1,109 @@
+/**
+ * @typedef {"in_process" | "host_mediated"} ActivityExecutionMode
+ */
+
+/**
+ * @typedef {{
+ *   parallel_node_id: string;
+ *   join_target_id: string;
+ *   branch_name: string;
+ *   branch_entry_node_id: string;
+ * }} WorkflowParallelSpanTransport
+ */
+
+/**
+ * @typedef {{
+ *   ok: true;
+ *   result?: Record<string, unknown>;
+ *   delegate_correlation_id?: string;
+ *   external_task_id?: string;
+ * }} ActivityOutcomeSuccessTransport
+ */
+
+/**
+ * @typedef {{
+ *   ok: false;
+ *   error: string;
+ *   code?: string;
+ * }} ActivityOutcomeFailureTransport
+ */
+
+/**
+ * @typedef {ActivityOutcomeSuccessTransport | ActivityOutcomeFailureTransport} ActivityOutcomeTransport
+ */
+
+/**
+ * @typedef {{
+ *   execution_id: string;
+ *   status: "completed" | "failed" | "interrupted" | "awaiting_activity";
+ *   final_state?: Record<string, unknown>;
+ *   result?: unknown;
+ *   error?: string;
+ *   node_id?: string;
+ *   state?: Record<string, unknown>;
+ *   parallel_span?: WorkflowParallelSpanTransport;
+ *   agent_id?: string;
+ *   protocol?: string;
+ *   delegate_input?: Record<string, unknown>;
+ *   delegate_correlation_id?: string;
+ * }} WorkflowStartResultTransport
+ */
+
+/**
+ * @typedef {{
+ *   execution_id: string;
+ *   phase: "running" | "completed" | "failed" | "interrupted" | "awaiting_activity";
+ *   current_node_id?: string;
+ *   last_error?: string;
+ *   delegate_correlation_id?: string;
+ *   child_execution_id?: string;
+ *   parent_execution_id?: string;
+ *   agent_id?: string;
+ *   protocol?: string;
+ *   delegate_input?: Record<string, unknown>;
+ * }} WorkflowStatusResultTransport
+ */
+
+/**
+ * @typedef {{
+ *   execution_id: string;
+ *   status: "completed" | "failed" | "interrupted" | "awaiting_activity";
+ *   final_state?: Record<string, unknown>;
+ *   result?: unknown;
+ *   error?: string;
+ *   node_id?: string;
+ *   state?: Record<string, unknown>;
+ *   parallel_span?: WorkflowParallelSpanTransport;
+ *   agent_id?: string;
+ *   protocol?: string;
+ *   delegate_input?: Record<string, unknown>;
+ *   delegate_correlation_id?: string;
+ * }} WorkflowResumeResultTransport
+ */
+
+/**
+ * @typedef {{
+ *   execution_id: string;
+ *   status: "completed" | "failed" | "interrupted" | "awaiting_activity";
+ *   final_state?: Record<string, unknown>;
+ *   result?: unknown;
+ *   error?: string;
+ *   node_id?: string;
+ *   state?: Record<string, unknown>;
+ *   parallel_span?: WorkflowParallelSpanTransport;
+ *   code?: string;
+ *   agent_id?: string;
+ *   protocol?: string;
+ *   delegate_input?: Record<string, unknown>;
+ *   delegate_correlation_id?: string;
+ * }} WorkflowSubmitActivityResultTransport
+ */
+
+/**
+ * @typedef {{
+ *   wf_id: string;
+ *   definition: object;
+ * }} RegisterDefinitionResultTransport
+ */
+
+export {};

--- a/packages/sdk/test/client.test.mjs
+++ b/packages/sdk/test/client.test.mjs
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { describe, it } from "node:test";
+import {
+  createRestWorkflowHandler,
+  createWorkflowApplicationPort,
+  DefinitionRegistry,
+  MemoryExecutionHistoryStore,
+} from "@agent-workflow/engine";
+import { SdkError, WorkflowClient } from "../src/index.mjs";
+
+function minimalValidWorkflowDefinition(name = "sdk-linear") {
+  return {
+    document: {
+      schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
+      name,
+      version: "1.0.0",
+    },
+    state_schema: { type: "object" },
+    nodes: [
+      { id: "start", type: "start" },
+      { id: "end", type: "end" },
+    ],
+    edges: [
+      { source: "__start__", target: "start" },
+      { source: "start", target: "end" },
+    ],
+  };
+}
+
+function hostMediatedLinearDefinition() {
+  return {
+    document: {
+      schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
+      name: "sdk-host-med",
+      version: "1.0.0",
+    },
+    state_schema: {
+      type: "object",
+      properties: {
+        out: { type: "string" },
+      },
+    },
+    nodes: [
+      { id: "start", type: "start" },
+      {
+        id: "work",
+        type: "tool_call",
+        config: { server: "demo-mcp", tool: "stub", arguments: {} },
+      },
+      { id: "end", type: "end", config: { output_mapping: ".out" } },
+    ],
+    edges: [
+      { source: "__start__", target: "start" },
+      { source: "start", target: "work" },
+      { source: "work", target: "end" },
+    ],
+  };
+}
+
+/**
+ * @param {(baseUrl: string) => Promise<void>} run
+ */
+async function withRestSdkServer(run) {
+  const store = new MemoryExecutionHistoryStore();
+  const definitionRegistry = new DefinitionRegistry();
+  const workflowPort = createWorkflowApplicationPort({ store });
+  const handler = createRestWorkflowHandler(workflowPort, { definitionRegistry, store });
+  const server = createServer((req, res) => {
+    handler(req, res).catch((error) => {
+      if (!res.headersSent) {
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: { code: "INTERNAL_ERROR", message: String(error) } }));
+      }
+    });
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  try {
+    await run(baseUrl);
+  } finally {
+    await new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve(undefined))));
+  }
+}
+
+describe("WorkflowClient REST transport", () => {
+  it("registers, starts, and reads status via snake_case DTOs", async () => {
+    await withRestSdkServer(async (baseUrl) => {
+      const client = new WorkflowClient({ baseUrl });
+      const definition = minimalValidWorkflowDefinition("sdk-rest-linear");
+      const registered = await client.registerDefinition(definition);
+      assert.equal(registered.wf_id, "sdk-rest-linear");
+
+      const started = await client.start({
+        wfId: registered.wf_id,
+        executionId: "sdk-rest-1",
+        input: {},
+      });
+      assert.equal(started.execution_id, "sdk-rest-1");
+      assert.equal(started.status, "completed");
+
+      const status = await client.getStatus({ executionId: "sdk-rest-1" });
+      assert.equal(status.phase, "completed");
+    });
+  });
+
+  it("auto-registers definition when start receives definition only", async () => {
+    await withRestSdkServer(async (baseUrl) => {
+      const client = new WorkflowClient({ baseUrl });
+      const definition = minimalValidWorkflowDefinition("sdk-auto-reg");
+      const started = await client.start({
+        definition,
+        executionId: "sdk-auto-1",
+        input: {},
+      });
+      assert.equal(started.status, "completed");
+    });
+  });
+
+  it("throws SdkError with MCP-aligned code on missing execution", async () => {
+    await withRestSdkServer(async (baseUrl) => {
+      const client = new WorkflowClient({ baseUrl });
+      await assert.rejects(
+        () => client.getStatus({ executionId: "missing" }),
+        (error) => {
+          assert.ok(error instanceof SdkError);
+          assert.equal(error.code, "EXECUTION_NOT_FOUND");
+          return true;
+        }
+      );
+    });
+  });
+
+  it("completes host-mediated flow through submitActivity", async () => {
+    await withRestSdkServer(async (baseUrl) => {
+      const client = new WorkflowClient({ baseUrl });
+      const definition = hostMediatedLinearDefinition();
+      const executionId = "sdk-submit-1";
+      const input = {};
+
+      const started = await client.start({
+        definition,
+        executionId,
+        input,
+        activityExecutionMode: "host_mediated",
+      });
+      assert.equal(started.status, "awaiting_activity");
+      assert.equal(started.node_id, "work");
+
+      const submitted = await client.submitActivity({
+        executionId,
+        definition,
+        input,
+        nodeId: "work",
+        outcome: { ok: true, result: { out: "from-sdk" } },
+      });
+      assert.equal(submitted.status, "completed");
+      assert.equal(submitted.result, "from-sdk");
+    });
+  });
+});
+
+describe("WorkflowClient port transport", () => {
+  it("runs linear workflow without HTTP", async () => {
+    const store = new MemoryExecutionHistoryStore();
+    const port = createWorkflowApplicationPort({ store });
+    const client = WorkflowClient.fromPort(port);
+    const definition = minimalValidWorkflowDefinition("sdk-port-linear");
+
+    const started = await client.start({
+      definition,
+      executionId: "sdk-port-1",
+      input: {},
+    });
+    assert.equal(started.execution_id, "sdk-port-1");
+    assert.equal(started.status, "completed");
+
+    const status = await client.getStatus({ execution_id: "sdk-port-1" });
+    assert.equal(status.phase, "completed");
+  });
+
+  it("maps stale resume to INVALID_RESUME_PAYLOAD", async () => {
+    const store = new MemoryExecutionHistoryStore();
+    const port = createWorkflowApplicationPort({ store });
+    const client = WorkflowClient.fromPort(port);
+    const definition = minimalValidWorkflowDefinition("sdk-port-stale");
+
+    await client.start({
+      definition,
+      executionId: "sdk-port-stale",
+      input: {},
+    });
+
+    await assert.rejects(
+      () =>
+        client.resume({
+          executionId: "sdk-port-stale",
+          definition,
+          resumePayload: { intent: "billing" },
+        }),
+      (error) => {
+        assert.ok(error instanceof SdkError);
+        assert.equal(error.code, "INVALID_RESUME_PAYLOAD");
+        return true;
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **BEN-84 epic** — second integration surface for GA 1.0: REST/OpenAPI control plane (`workflows-engine-rest`), `@agent-workflow/sdk` client, and parity harness extended to REST + SDK for all `parity.r2.*` vectors.
- Three feature commits: BEN-97 REST adapter, BEN-98 TypeScript SDK, BEN-99 conformance parity extension.
- Linear: [BEN-84](https://linear.app/ben-van-den-bergh/issue/BEN-84), [BEN-97](https://linear.app/ben-van-den-bergh/issue/BEN-97), [BEN-98](https://linear.app/ben-van-den-bergh/issue/BEN-98), [BEN-99](https://linear.app/ben-van-den-bergh/issue/BEN-99)

## What changed

- `packages/engine/openapi/openapi.yaml` + `createRestWorkflowHandler` mapping RFC-05 paths to `createWorkflowApplicationPort`
- `packages/sdk` — `WorkflowClient` with REST and in-process port transports, MCP-aligned DTOs and `SdkError`
- `conformance/parity-runner.mjs` — auto-exercises REST + SDK for r2 parity vectors; `conformance/sdk-parity-smoke.mjs`
- `docs/architecture/arc42-assets/contracts/integration-parity-matrix.md` and deployment notes in arc42 §7

## Spec and architecture traceability

- Spec artifact: [RFC-05 Integration Interfaces](https://github.com/benvdbergh/workflows/blob/master/docs/RFC/rfc-05-integration-interfaces.md) §5.3 REST, §5.5 TypeScript SDK
- Architecture: [integration-parity-matrix.md](https://github.com/benvdbergh/workflows/blob/master/docs/architecture/arc42-assets/contracts/integration-parity-matrix.md)
- Scope reviewed against `docs/engine-profile.md` — adapter layer only; no new node types
- ADR posture: ADR deferred — REST/SDK follow existing MCP adapter layering (ADR-0002 host-mediated unchanged)

## Roadmap alignment

- Target release: R4 GA 1.0 (child of BEN-81 umbrella)
- Type: feature + runway (BEN-99)
- Satisfies ROADMAP exit criterion: two independent integration surfaces

## Test plan

- [x] `npm test` — 214 pass
- [x] `npm run sdk:test` — 6 pass
- [x] `npm run validate-workflows`
- [x] `npm run conformance` — 52/52 pass (includes SDK REST smoke)
- [x] `npm run conformance:parity-sdk`

## Risk and rollback

- Risk level: medium (new public REST/SDK surface)
- Rollback: revert PR; MCP stdio remains primary operator path