### PR TITLE
feat(engine): BEN-86 Security v1 — secret_ref, signing verify, MCP auth

### DIFF
--- a/conformance/runner.mjs
+++ b/conformance/runner.mjs
@@ -11,7 +11,10 @@ import {
   StepHandlerRegistry,
   submitActivityOutcome,
   validateWorkflowDefinition,
+  verifyDefinitionSignature,
 } from "../packages/engine/src/index.mjs";
+import { loadPublicKeysFromConfig } from "../packages/engine/src/definition-signing.mjs";
+import { signDefinitionForTest, TEST_SIGNING_PRIVATE_KEY_PKCS8_B64URL } from "../packages/engine/test/helpers/definition-signing-test-helpers.mjs";
 import { runParityVector } from "./parity-runner.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -22,7 +25,7 @@ const vectorsRoot = path.join(__dirname, "vectors");
  * @typedef {{
  *   id: string;
  *   description?: string;
- *   kind: "schema" | "replay" | "parity";
+ *   kind: "schema" | "replay" | "parity" | "signing";
  *   definition: string;
  *   input?: Record<string, unknown>;
  *   historyPrefix?: Array<{
@@ -51,6 +54,10 @@ const vectorsRoot = path.join(__dirname, "vectors");
  *     definitionTamper?: Record<string, unknown>;
  *   }>;
  *   resumeDefinitionTamper?: Record<string, unknown>;
+ *   signFixture?: boolean;
+ *   signingPolicy?: { mode: "optional" | "require" };
+ *   publicKeys?: Record<string, string>;
+ *   tamperSignatureValue?: boolean;
  *   expect:
  *     | {
  *         ok: boolean;
@@ -142,6 +149,32 @@ function runSchemaVector(vector) {
     actualOk: result.ok,
     expectedOk: vector.expect.ok,
     errors: result.ok ? [] : (result.errors ?? []),
+  };
+}
+
+/**
+ * @param {ConformanceVector} vector
+ */
+function runSigningVector(vector) {
+  const definitionPath = path.resolve(repoRoot, vector.definition);
+  let definition = JSON.parse(readFileSync(definitionPath, "utf8"));
+  if (vector.signFixture === true) {
+    definition = signDefinitionForTest(definition, TEST_SIGNING_PRIVATE_KEY_PKCS8_B64URL);
+  }
+  if (vector.tamperSignatureValue === true && definition.document?.signature) {
+    definition.document.signature.value = definition.document.signature.value.replace(/.$/, "X");
+  }
+  const policy = vector.signingPolicy ?? { mode: "optional" };
+  const publicKeysById = loadPublicKeysFromConfig(vector.publicKeys ?? {});
+  const result = verifyDefinitionSignature(definition, { policy, publicKeysById });
+  const expect = /** @type {{ ok: boolean; verified?: boolean }} */ (vector.expect);
+  const passed =
+    result.ok === expect.ok &&
+    (expect.verified === undefined || (result.ok && result.verified === expect.verified));
+  return {
+    passed,
+    result,
+    expect,
   };
 }
 
@@ -481,7 +514,7 @@ function evaluateDiagnosticSignals(errors, signals) {
  */
 export async function runVector(discovered) {
   const { file, vector } = discovered;
-  if (vector.kind !== "schema" && vector.kind !== "replay" && vector.kind !== "parity") {
+  if (vector.kind !== "schema" && vector.kind !== "replay" && vector.kind !== "parity" && vector.kind !== "signing") {
     return {
       id: vector.id,
       file: path.relative(repoRoot, file),
@@ -504,6 +537,29 @@ export async function runVector(discovered) {
         passed: execution.passed,
         ...(execution.reason ? { reason: execution.reason } : {}),
         ...(execution.context ? { context: execution.context } : {}),
+      };
+    }
+
+    if (vector.kind === "signing") {
+      const execution = runSigningVector(vector);
+      const category = execution.passed ? "signing-pass" : "signing-fail-by-design";
+      if (execution.passed) {
+        return {
+          id: vector.id,
+          file: path.relative(repoRoot, file),
+          category,
+          passed: true,
+        };
+      }
+      return {
+        id: vector.id,
+        file: path.relative(repoRoot, file),
+        category,
+        passed: false,
+        reason: `Expected ok=${execution.expect.ok} verified=${execution.expect.verified ?? "any"} but got ${JSON.stringify(execution.result)}`,
+        context: {
+          definition: vector.definition,
+        },
       };
     }
 

--- a/conformance/vectors/signing/invalid/tampered-signature.vector.json
+++ b/conformance/vectors/signing/invalid/tampered-signature.vector.json
@@ -1,0 +1,13 @@
+{
+  "id": "signing.invalid-signature",
+  "description": "Tampered JWS value fails verification",
+  "kind": "signing",
+  "definition": "examples/fixtures.valid/minimal-linear.workflow.json",
+  "signFixture": true,
+  "tamperSignatureValue": true,
+  "signingPolicy": { "mode": "optional" },
+  "publicKeys": {
+    "test-key-1": "MCowBQYDK2VwAyEA-_wc6pHan2aD2MyBvmSWwoarQ0EWXjtZ-tr3LF_ujOI"
+  },
+  "expect": { "ok": false }
+}

--- a/conformance/vectors/signing/invalid/unsigned-require.vector.json
+++ b/conformance/vectors/signing/invalid/unsigned-require.vector.json
@@ -1,0 +1,11 @@
+{
+  "id": "signing.unsigned-require",
+  "description": "Unsigned definition rejected when require policy is active",
+  "kind": "signing",
+  "definition": "examples/fixtures.valid/minimal-linear.workflow.json",
+  "signingPolicy": { "mode": "require" },
+  "publicKeys": {
+    "test-key-1": "MCowBQYDK2VwAyEA-_wc6pHan2aD2MyBvmSWwoarQ0EWXjtZ-tr3LF_ujOI"
+  },
+  "expect": { "ok": false }
+}

--- a/conformance/vectors/signing/valid/signed-optional.vector.json
+++ b/conformance/vectors/signing/valid/signed-optional.vector.json
@@ -1,0 +1,12 @@
+{
+  "id": "signing.valid-signed-optional",
+  "description": "Signed minimal-linear fixture verifies in optional mode",
+  "kind": "signing",
+  "definition": "examples/fixtures.valid/minimal-linear.workflow.json",
+  "signFixture": true,
+  "signingPolicy": { "mode": "optional" },
+  "publicKeys": {
+    "test-key-1": "MCowBQYDK2VwAyEA-_wc6pHan2aD2MyBvmSWwoarQ0EWXjtZ-tr3LF_ujOI"
+  },
+  "expect": { "ok": true, "verified": true }
+}

--- a/conformance/vectors/signing/valid/unsigned-optional.vector.json
+++ b/conformance/vectors/signing/valid/unsigned-optional.vector.json
@@ -1,0 +1,11 @@
+{
+  "id": "signing.unsigned-optional",
+  "description": "Unsigned definition passes optional policy without verification",
+  "kind": "signing",
+  "definition": "examples/fixtures.valid/minimal-linear.workflow.json",
+  "signingPolicy": { "mode": "optional" },
+  "publicKeys": {
+    "test-key-1": "MCowBQYDK2VwAyEA-_wc6pHan2aD2MyBvmSWwoarQ0EWXjtZ-tr3LF_ujOI"
+  },
+  "expect": { "ok": true, "verified": false }
+}

--- a/docs/architecture/adr/ADR-0005-mcp-control-plane-auth.md
+++ b/docs/architecture/adr/ADR-0005-mcp-control-plane-auth.md
@@ -1,0 +1,89 @@
+# ADR-0005: MCP control-plane scoped bearer auth
+
+**Status:** Accepted  
+**Date:** 2026-06-22  
+**Tags:** security, MCP, REST, authZ, R4
+
+## Context
+
+The reference engine exposes workflow lifecycle operations through MCP tools and an HTTP REST adapter (`workflows-engine-rest`). Alpha deployments assumed **OS process isolation** for MCP stdio (single trusted host process on stdin/stdout). Unattended automation and multi-tenant REST surfaces need **action-level authorization** without widening engine trust zones.
+
+BEN-105 implements scoped bearer tokens for the control plane while preserving backward compatibility when no tokens are configured.
+
+## Decision
+
+### 1. Token format and scopes
+
+Operators configure tokens via `WORKFLOW_ENGINE_AUTH_TOKENS` (inline JSON array or `file:path`):
+
+```json
+[
+  { "token": "opaque-secret", "scopes": ["start", "read_history"] }
+]
+```
+
+**Core scopes (minimum set):**
+
+| Scope | Meaning |
+|-------|---------|
+| `start` | Start executions and register definitions; cooperative cancel |
+| `resume` | Resume interrupted executions |
+| `read_history` | Read status, list executions, fetch events/checkpoints |
+| `submit_activity` | Host-mediated activity submit and signal delivery |
+
+When `WORKFLOW_ENGINE_AUTH_TOKENS` is unset or empty, auth is **disabled** (local dev / stdio default).
+
+### 2. Tool and route mapping
+
+| MCP tool | Required scope | Rationale |
+|----------|----------------|-----------|
+| `workflow_start` | `start` | Creates execution |
+| `workflow_resume` | `resume` | Continues interrupt |
+| `workflow_status` | `read_history` | Read-only observation |
+| `workflow_list` | `read_history` | Read-only listing |
+| `workflow_submit_activity` | `submit_activity` | Mutates awaiting activity |
+| `workflow_signal` | `submit_activity` | Unblocks wait — same privilege as external input |
+| `workflow_cancel` | `start` | Lifecycle control — same class as start |
+
+REST RFC-05 routes map to the same scopes (`POST /v1/workflows` → `start`, `GET /v1/executions/{id}/events` → `read_history`, etc.) in `control-plane-auth.mjs`.
+
+### 3. Enforcement surfaces
+
+| Surface | Enforcement |
+|---------|-------------|
+| **REST** (`rest-handler.mjs`) | `Authorization: Bearer <token>` on all workflow routes when tokens configured |
+| **MCP stdio** | **No token channel** — relies on OS process isolation; auth not enforced on stdio even when tokens are configured |
+| **MCP HTTP** (future) | `createMcpWorkflowToolHandlers` accepts `authContext: { enforce: true, bearerToken }` for transport-level hook |
+
+Unauthorized calls return stable adapter code **`AUTH_ERROR`** (`401` on REST).
+
+### 4. Error contract
+
+`AUTH_ERROR` is added to `MCP_ADAPTER_ERROR` alongside existing validation and execution errors. MCP tools surface it via `structuredContent.error.code`; REST returns JSON `{ error: { code, message } }`.
+
+## Considered options
+
+1. **Per-tool API keys in manifest** — rejected; duplicates operator manifest and does not compose with REST.
+2. **Stdio `_auth_token` in tool args** — rejected for production; documented REST-primary model avoids leaking tokens into workflow tool payloads.
+3. **OAuth2 / JWT** — deferred to post-GA; opaque scoped tokens suffice for alpha→R4 runway.
+
+## Consequences
+
+- **Positive:** REST automation can enforce least privilege; error code is stable for integrators.
+- **Positive:** Stdio local dev unchanged when env unset.
+- **Negative:** Stdio with tokens configured does not auto-enforce — operators must not expose stdio across trust boundaries.
+- **Negative:** Token store is static env config (no rotation API in-engine).
+
+## Follow-up
+
+- MCP HTTP transport adapter with Bearer metadata passthrough.
+- Token rotation / external IdP integration (R4+ GA hardening).
+- SDK client automatic `Authorization` header from operator config.
+
+## References
+
+- `packages/engine/src/security/control-plane-auth.mjs`
+- `docs/security/mcp-control-plane-auth.md`
+- `docs/security/alpha-security-baseline.md`
+- RFC-05 integration interfaces
+- BEN-105 / BEN-86 security epic

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -55,3 +55,4 @@ Each ADR should include:
 - `ADR-0002-host-mediated-activity-execution.md`
 - `ADR-0003-engine-direct-mcp-activity-execution.md`
 - `ADR-0004-r3-delegation-and-subworkflow.md`
+- `ADR-0005-mcp-control-plane-auth.md`

--- a/docs/architecture/arc42-assets/contracts/integration-parity-matrix.md
+++ b/docs/architecture/arc42-assets/contracts/integration-parity-matrix.md
@@ -58,7 +58,7 @@ Normative orchestration behavior lives in `createWorkflowApplicationPort` ([RFC-
 Harness compares canonical snake_case objects per step:
 
 - Success: `execution_id`, `status` or `phase`, optional `node_id`, `result`, `final_state`, `parallel_span`, `state`, `delegate_correlation_id`, `child_execution_id`, `parent_execution_id`
-- Error: `is_error: true`, `error.code` aligned with MCP adapter codes (`VALIDATION_ERROR`, `EXECUTION_NOT_FOUND`, `INVALID_RESUME_PAYLOAD`, `ACTIVITY_SUBMIT_*`, `SIGNAL_*`, `CANCEL_*`, `ENGINE_FAILURE`, `INTERNAL_ERROR`)
+- Error: `is_error: true`, `error.code` aligned with MCP adapter codes (`AUTH_ERROR`, `VALIDATION_ERROR`, `EXECUTION_NOT_FOUND`, `INVALID_RESUME_PAYLOAD`, `ACTIVITY_SUBMIT_*`, `SIGNAL_*`, `CANCEL_*`, `ENGINE_FAILURE`, `INTERNAL_ERROR`)
 
 REST and SDK surfaces use the same normalized snapshot shape as MCP (`normalizeTransportSnapshot` in `conformance/parity-runner.mjs`).
 

--- a/docs/architecture/arc42/11-risks-and-technical-debt.md
+++ b/docs/architecture/arc42/11-risks-and-technical-debt.md
@@ -8,7 +8,7 @@
 | **`interrupt` inside `parallel` branch** | Resume would not restore `parallelSpan`/fork context | **Refused** at validation and runtime with `INTERRUPT_IN_PARALLEL_BRANCH`; conformance vector `schema.invalid.interrupt-in-parallel-branch`; parallel-aware resume deferred |
 | **Documentation drift** *(meta)* | Narrative contradicts walker code | Maintain arc42 + draw.io cross-links each release |
 | **Engine-direct ergonomics mismatch** | Integrators omit manifest wiring | MCP stdio binary defaults **`in_process` stub executor** unless operators supply **`WORKFLOW_ENGINE_MCP_CONFIG` / `--mcp-config`** or inject a bespoke **`ActivityExecutor`**—easily mistaken for broken tool execution (**ADR-0003**) |
-| **Security posture (alpha reference engine)** | Local stdio MCP trust assumptions bleed into unattended automation | Elevate manifests + scopes before scaling engine-direct footprints (**ADR-0002**, **ADR-0003**) |
+| **Security posture (alpha reference engine)** | Local stdio MCP trust assumptions bleed into unattended automation | Scoped REST bearer tokens (ADR-0005); stdio OS isolation boundary; elevate manifests before scaling engine-direct footprints (**ADR-0002**, **ADR-0003**) |
 | **Delegate/subworkflow status not on `workflow_status`** | Operators read full history for correlation ids | [#8](https://github.com/benvdbergh/workflows/issues/8) |
 | **Mock A2A only** | Production A2A interop not proven in CI | Real adapter + phase events per **ADR-0004** / roadmap |
 | **`subworkflow` URN registry coupling** | Packaged installs must call `registerWorkflowRef` | Document host wiring; optional built-in registry for demos |

--- a/docs/security/alpha-security-baseline.md
+++ b/docs/security/alpha-security-baseline.md
@@ -31,14 +31,14 @@ Reference: [`SECURITY.md`](../../SECURITY.md)
 - **Adapter error mapping:** definition validation failures on `workflow_start` return `VALIDATION_ERROR` (not `ENGINE_FAILURE`).
 - **Persisted-event secret redaction:** keys `apiKey`, `token`, `password`, `secret` (case-insensitive) redacted via `RedactingExecutionHistoryStore` on all port-backed runs.
 - **Engine-direct command allowlist:** default `node` / `npx` basenames; extend with `WORKFLOW_ENGINE_MCP_ALLOW_COMMANDS` — see [engine-direct-manifest-policy.md](engine-direct-manifest-policy.md).
-- **Definition signing stub:** `verifyDefinitionSignature` (unsigned passes; signed presence recorded, crypto verify deferred to v1 profile).
+- **Definition signing (v1):** JWS compact Ed25519 (`EdDSA`) via `verifyDefinitionSignature`; policy `WORKFLOW_ENGINE_DEFINITION_SIGNING_MODE` (`optional` default, `require` rejects unsigned). See [definition-signing-v1-profile.md](definition-signing-v1-profile.md).
 
 ### Pending (v1 / org)
 
 - **Scoped MCP auth tokens** and action-level authZ on MCP tools (required for R4 GA per `ROADMAP.md`; not implemented in alpha — document as ADR follow-up, no token validation on stdio adapter today).
 - Secret scanning and push protection (org/repo settings).
 - Private GitHub Security Advisories workflow.
-- Full manifest path sandbox and cryptographic definition/manifest verification.
+- Full manifest path sandbox and cryptographic **manifest** verification (definition signing v1 is implemented — see [definition-signing-v1-profile.md](definition-signing-v1-profile.md)).
 
 ## 3) Secret scanning and push protection expectations
 

--- a/docs/security/alpha-security-baseline.md
+++ b/docs/security/alpha-security-baseline.md
@@ -32,10 +32,10 @@ Reference: [`SECURITY.md`](../../SECURITY.md)
 - **Persisted-event secret redaction:** keys `apiKey`, `token`, `password`, `secret` (case-insensitive) redacted via `RedactingExecutionHistoryStore` on all port-backed runs.
 - **Engine-direct command allowlist:** default `node` / `npx` basenames; extend with `WORKFLOW_ENGINE_MCP_ALLOW_COMMANDS` — see [engine-direct-manifest-policy.md](engine-direct-manifest-policy.md).
 - **Definition signing (v1):** JWS compact Ed25519 (`EdDSA`) via `verifyDefinitionSignature`; policy `WORKFLOW_ENGINE_DEFINITION_SIGNING_MODE` (`optional` default, `require` rejects unsigned). See [definition-signing-v1-profile.md](definition-signing-v1-profile.md).
+- **Scoped control-plane auth:** Bearer tokens with scopes `start`, `resume`, `read_history`, `submit_activity` via `WORKFLOW_ENGINE_AUTH_TOKENS`; enforced on REST when configured; MCP stdio relies on OS process isolation. See [mcp-control-plane-auth.md](mcp-control-plane-auth.md) and [ADR-0005](../architecture/adr/ADR-0005-mcp-control-plane-auth.md).
 
 ### Pending (v1 / org)
 
-- **Scoped MCP auth tokens** and action-level authZ on MCP tools (required for R4 GA per `ROADMAP.md`; not implemented in alpha — document as ADR follow-up, no token validation on stdio adapter today).
 - Secret scanning and push protection (org/repo settings).
 - Private GitHub Security Advisories workflow.
 - Full manifest path sandbox and cryptographic **manifest** verification (definition signing v1 is implemented — see [definition-signing-v1-profile.md](definition-signing-v1-profile.md)).

--- a/docs/security/definition-signing-v1-profile.md
+++ b/docs/security/definition-signing-v1-profile.md
@@ -30,9 +30,11 @@ A signed definition carries a signature block on `document.signature` (preferred
 |-------|----------|-------------|
 | `alg` | Yes | Must be `"EdDSA"` (Ed25519). |
 | `value` | Yes | JWS compact serialization (three base64url segments). |
-| `keyId` | No | Selects a configured verification public key; when omitted, all configured keys are tried. |
+| `keyId` | No | Optional metadata; when present must match JWS protected header `kid`. Not part of the signed payload — verification selects keys from JWS `kid` only. |
 
 The signature field is **removed** before JSON Schema validation so alpha schema `additionalProperties: false` on `document` is unchanged.
+
+**Key selection:** The engine reads `kid` from the JWS protected header (inside the signed envelope) and looks it up in `WORKFLOW_ENGINE_SIGNING_PUBLIC_KEYS`. When JWS `kid` is omitted, all configured keys are tried. The `document.signature.keyId` field is not used to select verification keys.
 
 ## Signed payload
 
@@ -46,7 +48,7 @@ Verification recomputes this payload and compares it to the decoded JWS payload 
 BASE64URL({"alg":"EdDSA","typ":"JWS","kid":"..."}) . BASE64URL(payload) . BASE64URL(signature)
 ```
 
-- **Protected header:** `alg` = `EdDSA`, `typ` = `JWS`, optional `kid` matching `keyId`.
+- **Protected header:** `alg` = `EdDSA`, `typ` = `JWS`, optional `kid` for verification key lookup (must match `document.signature.keyId` when that field is present).
 - **Signing input:** ASCII bytes of `protected.payload` (two segments joined by `.`).
 - **Signature:** Ed25519 over the signing input (`crypto.sign` / `crypto.verify`).
 

--- a/docs/security/definition-signing-v1-profile.md
+++ b/docs/security/definition-signing-v1-profile.md
@@ -34,7 +34,7 @@ A signed definition carries a signature block on `document.signature` (preferred
 
 The signature field is **removed** before JSON Schema validation so alpha schema `additionalProperties: false` on `document` is unchanged.
 
-**Key selection:** The engine reads `kid` from the JWS protected header (inside the signed envelope) and looks it up in `WORKFLOW_ENGINE_SIGNING_PUBLIC_KEYS`. When JWS `kid` is omitted, all configured keys are tried. The `document.signature.keyId` field is not used to select verification keys.
+**Key selection:** The engine requires `kid` in the JWS protected header (inside the signed envelope) and looks it up in `WORKFLOW_ENGINE_SIGNING_PUBLIC_KEYS`. Signatures without JWS `kid` are rejected. The `document.signature.keyId` field is not used to select verification keys.
 
 ## Signed payload
 
@@ -48,7 +48,7 @@ Verification recomputes this payload and compares it to the decoded JWS payload 
 BASE64URL({"alg":"EdDSA","typ":"JWS","kid":"..."}) . BASE64URL(payload) . BASE64URL(signature)
 ```
 
-- **Protected header:** `alg` = `EdDSA`, `typ` = `JWS`, optional `kid` for verification key lookup (must match `document.signature.keyId` when that field is present).
+- **Protected header:** `alg` = `EdDSA`, `typ` = `JWS`, required `kid` for verification key lookup (must match `document.signature.keyId` when that field is present).
 - **Signing input:** ASCII bytes of `protected.payload` (two segments joined by `.`).
 - **Signature:** Ed25519 over the signing input (`crypto.sign` / `crypto.verify`).
 

--- a/docs/security/definition-signing-v1-profile.md
+++ b/docs/security/definition-signing-v1-profile.md
@@ -65,13 +65,15 @@ Inline JSON:
 export WORKFLOW_ENGINE_SIGNING_PUBLIC_KEYS='{"publisher-key-1":"MCowBQYDK2VwAyEA..."}'
 ```
 
-File ref (relative to process cwd, same pattern as `secret_ref` file refs):
+File ref (relative paths resolve against process cwd):
 
 ```bash
 export WORKFLOW_ENGINE_SIGNING_PUBLIC_KEYS='file:.config/signing-public-keys.json'
 ```
 
-A bare filesystem path (without `file:`) is also accepted for backward compatibility with other `WORKFLOW_ENGINE_*` JSON env vars.
+A bare filesystem path (without `file:`) is also accepted for backward compatibility with other `WORKFLOW_ENGINE_*` JSON env vars; absolute paths are read as-is.
+
+**Operator trust zone:** Signing key `file:` refs and bare paths resolve relative to cwd and are **not** sandboxed to a base directory. The engine reads whatever path the operator configures (including absolute paths). Activity `secret_ref` `file:` refs are different: they resolve under a configured `baseDir` and cannot escape it. Treat signing key paths as operator-controlled configuration in the host trust zone, not as workflow-supplied secret refs.
 
 ## Deployment policy
 

--- a/docs/security/definition-signing-v1-profile.md
+++ b/docs/security/definition-signing-v1-profile.md
@@ -1,0 +1,104 @@
+# Definition signing v1 profile
+
+**Status:** Reference engine v1 (BEN-104)  
+**Algorithm:** JWS compact serialization with Ed25519 (`EdDSA`) using Node.js built-in `crypto` (no additional npm dependencies).
+
+## Purpose
+
+Signed workflow definitions let operators enforce that only trusted publishers can start or resume executions when deployment policy requires signing. The reference engine verifies signatures at the MCP and REST transport boundaries before `createWorkflowApplicationPort` accepts a definition.
+
+## Signature block
+
+A signed definition carries a signature block on `document.signature` (preferred) or top-level `signature` (transitional):
+
+```json
+{
+  "document": {
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
+    "name": "example",
+    "version": "1.0.0",
+    "signature": {
+      "alg": "EdDSA",
+      "value": "<compact-jws>",
+      "keyId": "publisher-key-1"
+    }
+  }
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `alg` | Yes | Must be `"EdDSA"` (Ed25519). |
+| `value` | Yes | JWS compact serialization (three base64url segments). |
+| `keyId` | No | Selects a configured verification public key; when omitted, all configured keys are tried. |
+
+The signature field is **removed** before JSON Schema validation so alpha schema `additionalProperties: false` on `document` is unchanged.
+
+## Signed payload
+
+The JWS payload is the **canonical JSON** (RFC-03 `canonicalJsonStringify`: lexicographic key sort at every object level, array order preserved) of the full definition object **with the signature block removed** from `document` and from the top level.
+
+Verification recomputes this payload and compares it to the decoded JWS payload segment before Ed25519 signature check.
+
+## JWS compact format
+
+```
+BASE64URL({"alg":"EdDSA","typ":"JWS","kid":"..."}) . BASE64URL(payload) . BASE64URL(signature)
+```
+
+- **Protected header:** `alg` = `EdDSA`, `typ` = `JWS`, optional `kid` matching `keyId`.
+- **Signing input:** ASCII bytes of `protected.payload` (two segments joined by `.`).
+- **Signature:** Ed25519 over the signing input (`crypto.sign` / `crypto.verify`).
+
+## Operator verification keys
+
+Set `WORKFLOW_ENGINE_SIGNING_PUBLIC_KEYS` to a JSON object mapping `keyId` → public key material:
+
+| Material | Format |
+|----------|--------|
+| SPKI DER | Base64url-encoded SubjectPublicKeyInfo (recommended) |
+| Raw Ed25519 | Base64url-encoded 32-byte public key |
+
+Inline JSON:
+
+```bash
+export WORKFLOW_ENGINE_SIGNING_PUBLIC_KEYS='{"publisher-key-1":"MCowBQYDK2VwAyEA..."}'
+```
+
+File ref (relative to process cwd, same pattern as `secret_ref` file refs):
+
+```bash
+export WORKFLOW_ENGINE_SIGNING_PUBLIC_KEYS='file:.config/signing-public-keys.json'
+```
+
+A bare filesystem path (without `file:`) is also accepted for backward compatibility with other `WORKFLOW_ENGINE_*` JSON env vars.
+
+## Deployment policy
+
+`WORKFLOW_ENGINE_DEFINITION_SIGNING_MODE`:
+
+| Mode | Behavior |
+|------|----------|
+| `optional` (default) | Unsigned definitions pass (`verified: false`). Signed definitions must verify when present. |
+| `require` | Unsigned definitions are rejected at transport with `VALIDATION_ERROR`. Signed definitions must verify. |
+
+When a signature is present but no public keys are configured, verification fails with a clear error (crypto verify is not skipped).
+
+## API
+
+`verifyDefinitionSignature(definition, options?)` in `@agent-workflow/engine`:
+
+- `options.policy` — `{ mode: "optional" | "require" }`
+- `options.publicKeysById` — map of `keyId` → `KeyObject` (or resolve from env via `WORKFLOW_ENGINE_SIGNING_PUBLIC_KEYS`)
+
+MCP stdio and REST entrypoints load policy and keys from env at startup and pass them through `assertValidWorkflowDefinitionAtTransport`.
+
+## Test fixtures
+
+Use `signDefinitionForTest(definition, privateKey)` from `packages/engine/test/helpers/definition-signing-test-helpers.mjs` (test-only; not published API) to generate signed fixtures in unit and conformance tests.
+
+## Related
+
+- [Alpha security baseline](alpha-security-baseline.md)
+- [Engine-direct manifest policy](engine-direct-manifest-policy.md)
+- `packages/engine/src/definition-signing.mjs`

--- a/docs/security/engine-direct-manifest-policy.md
+++ b/docs/security/engine-direct-manifest-policy.md
@@ -33,7 +33,14 @@ Filesystem path constraints for manifest `cwd` and server binaries are **not** i
 
 ## Workflow definition signing
 
-Optional definition signatures are handled by `verifyDefinitionSignature` in `@agent-workflow/engine` (stub: unsigned passes; signed records presence without crypto verify until v1 profile).
+Optional or required definition signatures are verified by `verifyDefinitionSignature` in `@agent-workflow/engine` using the **v1 JWS Ed25519 profile** ([definition-signing-v1-profile.md](definition-signing-v1-profile.md)).
+
+| Env var | Purpose |
+|---------|---------|
+| `WORKFLOW_ENGINE_DEFINITION_SIGNING_MODE` | `optional` (default) or `require` |
+| `WORKFLOW_ENGINE_SIGNING_PUBLIC_KEYS` | Inline JSON or `file:path` map of `keyId` → base64url public key |
+
+Signed definitions are schema-validated with the signature block stripped; invalid or missing signatures fail transport validation with `VALIDATION_ERROR`.
 
 ## When to use engine-direct
 

--- a/docs/security/mcp-control-plane-auth.md
+++ b/docs/security/mcp-control-plane-auth.md
@@ -1,0 +1,94 @@
+# MCP control-plane authentication
+
+Operator guide for scoped bearer tokens on the workflow engine control plane.
+
+## Overview
+
+The reference engine supports **optional** scoped bearer tokens for lifecycle operations. When `WORKFLOW_ENGINE_AUTH_TOKENS` is configured:
+
+- **REST** (`workflows-engine-rest`) requires `Authorization: Bearer <token>` on all workflow endpoints.
+- **MCP stdio** does **not** enforce tokens — it relies on **OS process isolation** between the MCP host and the engine child process.
+
+When the env var is unset or empty, auth is disabled (backward compatible for local development).
+
+See [ADR-0005](../architecture/adr/ADR-0005-mcp-control-plane-auth.md) for design rationale.
+
+## Configuration
+
+```bash
+export WORKFLOW_ENGINE_AUTH_TOKENS='[
+  {"token":"agent-read","scopes":["read_history"]},
+  {"token":"agent-run","scopes":["start","resume","submit_activity"]},
+  {"token":"ops-admin","scopes":["start","resume","read_history","submit_activity"]}
+]'
+```
+
+Or load from file:
+
+```bash
+export WORKFLOW_ENGINE_AUTH_TOKENS=file:./control-plane-tokens.json
+```
+
+Each record requires:
+
+- `token` — opaque secret string (treat as credential; never commit to git)
+- `scopes` — non-empty array of scope names (see below)
+
+## Scopes
+
+| Scope | Allows |
+|-------|--------|
+| `start` | Register definitions (`POST /v1/workflows`), start executions, cooperative cancel |
+| `resume` | Resume interrupted executions |
+| `read_history` | Status, list, events, checkpoint reads |
+| `submit_activity` | Host-mediated activity submit and signal delivery |
+
+### MCP tool mapping
+
+| Tool | Scope |
+|------|-------|
+| `workflow_start` | `start` |
+| `workflow_cancel` | `start` |
+| `workflow_resume` | `resume` |
+| `workflow_status` | `read_history` |
+| `workflow_list` | `read_history` |
+| `workflow_submit_activity` | `submit_activity` |
+| `workflow_signal` | `submit_activity` |
+
+## REST usage
+
+```bash
+curl -sS -H "Authorization: Bearer agent-read" \
+  http://127.0.0.1:8787/v1/executions/my-exec-id
+```
+
+Missing or invalid tokens return HTTP **401** with:
+
+```json
+{ "error": { "code": "AUTH_ERROR", "message": "Missing or invalid bearer token." } }
+```
+
+Insufficient scope returns HTTP **401** with `AUTH_ERROR` and `details.required_scope`.
+
+## MCP stdio boundary
+
+`workflows-engine-mcp` communicates over stdin/stdout. There is no standard Authorization header on stdio. Security model:
+
+1. **Trust boundary** — only the MCP host process should spawn the engine; use OS user permissions and host configuration to prevent untrusted clients from attaching.
+2. **No token on stdio** — when auth is disabled (default), any client on the stdio session can invoke tools.
+3. **Tokens configured** — REST enforces tokens; stdio remains unauthenticated by design. Do not expose stdio across network hops or shared multi-tenant hosts when tokens are required elsewhere.
+
+For automated testing of MCP auth hooks, library callers may pass `authContext: { enforce: true, bearerToken }` to `createMcpWorkflowToolHandlers` — not exposed on the stdio binary.
+
+## Error code
+
+| Code | Meaning |
+|------|---------|
+| `AUTH_ERROR` | Missing, invalid, or under-scoped bearer token |
+
+Aligned across MCP structured tool errors and REST JSON responses.
+
+## Related
+
+- [Alpha security baseline](alpha-security-baseline.md)
+- [Definition signing v1 profile](definition-signing-v1-profile.md)

--- a/docs/security/mcp-control-plane-auth.md
+++ b/docs/security/mcp-control-plane-auth.md
@@ -68,7 +68,7 @@ Missing or invalid tokens return HTTP **401** with:
 { "error": { "code": "AUTH_ERROR", "message": "Missing or invalid bearer token." } }
 ```
 
-Insufficient scope returns HTTP **401** with `AUTH_ERROR` and `details.required_scope`.
+Insufficient scope returns HTTP **403** with `AUTH_FORBIDDEN` and `details.reason: "insufficient_scope"` (plus `required_scope` / `granted_scopes`).
 
 ## MCP stdio boundary
 

--- a/docs/security/secret-ref-operator-config.md
+++ b/docs/security/secret-ref-operator-config.md
@@ -1,0 +1,44 @@
+# Secret refs in operator config
+
+**Scope:** LLM and A2A operator config only — not workflow JSON ([RFC-07 §7.3](../RFC/rfc-07-security-model.md)).
+
+Operator credentials for `llm_call` and `agent_delegate` (A2A) activities are supplied via host config (`WORKFLOW_ENGINE_LLM_CONFIG`, `WORKFLOW_ENGINE_A2A_CONFIG`, or programmatic bootstrap). Use **`apiKeyEnv`** for a direct environment variable name, or **`apiKeySecretRef`** for a structured secret reference resolved at activity invocation time.
+
+## Ref format
+
+| Prefix | Example | Resolution |
+|--------|---------|------------|
+| `env:` | `env:OPENAI_API_KEY` | Read `process.env.OPENAI_API_KEY` (trimmed; must be non-empty) |
+| `file:` | `file:.secrets/openai-key` | Read file relative to process cwd (trimmed; must be non-empty) |
+
+The reference engine tries providers in order: **env**, then **file**. External vault SDKs are out of scope for v1; host operators can inject secrets via env or mounted files.
+
+## Operator config fields
+
+**LLM** (`LlmOperatorConfig`):
+
+```json
+{
+  "apiKeySecretRef": "env:OPENAI_API_KEY",
+  "baseUrl": "https://api.openai.com/v1"
+}
+```
+
+**A2A** (`A2AOperatorConfig`):
+
+```json
+{
+  "baseUrl": "https://a2a.example",
+  "apiKeySecretRef": "file:.secrets/a2a-token"
+}
+```
+
+Exactly one of `apiKeyEnv` or `apiKeySecretRef` is required when credentials are needed.
+
+## Persistence
+
+Resolved secret values are used only for the outbound provider call at the activity boundary. They are **never** written to execution history. Persisted event/command payloads pass through `RedactingExecutionHistoryStore`, which redacts keys such as `apiKey`, `token`, `password`, and `secret`.
+
+## MCP stdio bootstrap
+
+`workflows-engine-mcp` wires a default composite resolver from `process.env` and the current working directory when constructing `LlmActivityExecutor` and `A2ADelegateExecutor`. Library integrators may inject a custom `SecretResolver` via executor options or `createDefaultSecretResolver({ env, cwd })`.

--- a/docs/security/secret-ref-operator-config.md
+++ b/docs/security/secret-ref-operator-config.md
@@ -33,7 +33,7 @@ The reference engine tries providers in order: **env**, then **file**. External 
 }
 ```
 
-Exactly one of `apiKeyEnv` or `apiKeySecretRef` is required when credentials are needed.
+Exactly one of `apiKeyEnv` or `apiKeySecretRef` is required when credentials are needed; setting both is rejected at resolution with `LLM_CONFIG_INVALID` / `A2A_CONFIG_INVALID`.
 
 ## Persistence
 

--- a/docs/security/security-gap-register.md
+++ b/docs/security/security-gap-register.md
@@ -10,7 +10,7 @@ This register tracks accepted temporary security gaps for alpha, with explicit o
 | SG-002 | Dependabot config and update automation absent | Was deferred during alpha; **closed in-repo** via `.github/dependabot.yml` (alerts still require repo settings) | Maintainers | — | BEN-10 | **Closed** (2026-06-04) |
 | SG-003 | Code scanning workflow not configured | Was deferred; **closed in-repo** via `.github/workflows/codeql.yml` | Maintainers | — | BEN-10 | **Closed** (2026-06-04) |
 | SG-004 | Secret scanning/push protection may be org-gated and not verifiable in-repo | Expectations documented; activation requires admin entitlement/settings outside repository files | Org/repo admin + maintainers | 2026-05-15 | Org security controls review window | Open |
-| SG-005 | Scoped MCP auth tokens / action-level authZ | Required for v1 GA profile per ROADMAP R4; stdio adapter has no auth today | Maintainers | R4 GA cut | ADR / implementation story after BEN-10 | Open |
+| SG-005 | Scoped MCP auth tokens / action-level authZ | REST bearer enforcement when `WORKFLOW_ENGINE_AUTH_TOKENS` set; stdio OS isolation boundary per ADR-0005 | Maintainers | R4 GA cut | BEN-105 | **Closed** (partial — REST enforced; stdio documented boundary) |
 | SG-006 | GHSA / Dependabot alert triage routine | Dependabot file present; org must enable alerts and maintain triage SLA | Maintainers | 2026-07-01 | First weekly Dependabot PR cycle | Open (partial — config landed BEN-10) |
 
 ## Closure rules

--- a/docs/user/a2a-delegate-mapping.md
+++ b/docs/user/a2a-delegate-mapping.md
@@ -38,7 +38,7 @@ const port = createWorkflowApplicationPort({
 |-------|----------|-------------|
 | `baseUrl` | Yes | A2A HTTP API root (no trailing slash), e.g. `https://a2a.example.com` |
 | `apiKeyEnv` | Yes* | Env var holding the Bearer token sent as `Authorization: Bearer …` |
-| `apiKeySecretRef` | Yes* | Vault ref (deferred; use `apiKeyEnv` until vault resolver ships) |
+| `apiKeySecretRef` | Yes* | Secret ref (`env:VAR` or `file:path`); see [secret-ref-operator-config.md](../security/secret-ref-operator-config.md) |
 | `pollIntervalMs` | No | Poll interval while status is non-terminal (default `500`) |
 | `pollTimeoutMs` | No | Max wait for `completed` / `failed` (default `120000`) |
 

--- a/docs/user/security-operators.md
+++ b/docs/user/security-operators.md
@@ -17,16 +17,18 @@ Condensed operator checklist for running the reference engine in alpha. Full bas
 | Transport validation | AJV on `workflow_start` and `workflow_resume` |
 | Persisted event redaction | Keys matching `apiKey`, `token`, `password`, `secret` (case-insensitive) |
 | Engine-direct commands | Default allowlist: `node`, `npx` basenames |
+| REST control-plane auth | Optional scoped bearer tokens via `WORKFLOW_ENGINE_AUTH_TOKENS` (REST only) |
 
 Extend engine-direct allowlist only with `WORKFLOW_ENGINE_MCP_ALLOW_COMMANDS` and documented manifest policy.
 
-## Not in alpha
+## MCP stdio trust boundary
 
-- Scoped MCP auth tokens on stdio adapter
-- Cryptographic definition signing verification
+Stdio has no Authorization header. Rely on OS process isolation — only trusted hosts should spawn `workflows-engine-mcp`. When tokens are configured, enforcement applies to REST, not stdio. See [mcp-control-plane-auth.md](https://github.com/benvdbergh/workflows/blob/main/docs/security/mcp-control-plane-auth.md).
+
+## Not in alpha (remaining)
+
 - Full manifest path sandbox
-
-Plan for these at GA (R4) if deploying beyond evaluation sandboxes.
+- OAuth/JWT token federation
 
 ## Incident response
 

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -99,7 +99,7 @@ import { LlmActivityExecutor, runGraphWorkflow } from "@agent-workflow/engine";
 
 const activityExecutor = new LlmActivityExecutor({
   operatorConfig: {
-    apiKeyEnv: "OPENAI_API_KEY", // apiKeySecretRef accepted; vault resolver deferred to BEN-103
+    apiKeyEnv: "OPENAI_API_KEY", // or apiKeySecretRef: "env:OPENAI_API_KEY" / "file:.secrets/key"
     baseUrl: "https://api.openai.com/v1", // optional OpenAI-compatible base
   },
 });

--- a/packages/engine/src/adapters/mcp/errors.mjs
+++ b/packages/engine/src/adapters/mcp/errors.mjs
@@ -1,5 +1,7 @@
 export const MCP_ADAPTER_ERROR = {
   AUTH_ERROR: "AUTH_ERROR",
+  /** Valid bearer token lacks required control-plane scope. */
+  AUTH_FORBIDDEN: "AUTH_FORBIDDEN",
   VALIDATION_ERROR: "VALIDATION_ERROR",
   EXECUTION_NOT_FOUND: "EXECUTION_NOT_FOUND",
   DUPLICATE_EXECUTION_ID: "DUPLICATE_EXECUTION_ID",
@@ -43,6 +45,9 @@ export function normalizeMcpAdapterError(error) {
   const message = error instanceof Error ? error.message : String(error);
   if (typeof error?.code === "string" && error.code === MCP_ADAPTER_ERROR.AUTH_ERROR) {
     return new McpAdapterError(MCP_ADAPTER_ERROR.AUTH_ERROR, message, error.details);
+  }
+  if (typeof error?.code === "string" && error.code === MCP_ADAPTER_ERROR.AUTH_FORBIDDEN) {
+    return new McpAdapterError(MCP_ADAPTER_ERROR.AUTH_FORBIDDEN, message, error.details);
   }
   if (typeof error?.code === "string" && error.code === MCP_ADAPTER_ERROR.INVALID_RESUME_PAYLOAD) {
     return new McpAdapterError(MCP_ADAPTER_ERROR.INVALID_RESUME_PAYLOAD, message);

--- a/packages/engine/src/adapters/mcp/errors.mjs
+++ b/packages/engine/src/adapters/mcp/errors.mjs
@@ -1,4 +1,5 @@
 export const MCP_ADAPTER_ERROR = {
+  AUTH_ERROR: "AUTH_ERROR",
   VALIDATION_ERROR: "VALIDATION_ERROR",
   EXECUTION_NOT_FOUND: "EXECUTION_NOT_FOUND",
   DUPLICATE_EXECUTION_ID: "DUPLICATE_EXECUTION_ID",
@@ -40,6 +41,9 @@ export function normalizeMcpAdapterError(error) {
     return error;
   }
   const message = error instanceof Error ? error.message : String(error);
+  if (typeof error?.code === "string" && error.code === MCP_ADAPTER_ERROR.AUTH_ERROR) {
+    return new McpAdapterError(MCP_ADAPTER_ERROR.AUTH_ERROR, message, error.details);
+  }
   if (typeof error?.code === "string" && error.code === MCP_ADAPTER_ERROR.INVALID_RESUME_PAYLOAD) {
     return new McpAdapterError(MCP_ADAPTER_ERROR.INVALID_RESUME_PAYLOAD, message);
   }

--- a/packages/engine/src/adapters/mcp/stdio-server-config.mjs
+++ b/packages/engine/src/adapters/mcp/stdio-server-config.mjs
@@ -30,6 +30,7 @@ import {
   StepActivityExecutor,
   StepHandlerRegistry,
 } from "../../orchestrator/step-activity-executor.mjs";
+import { createDefaultSecretResolver } from "../../security/secret-resolver.mjs";
 
 const enginePackageJsonPath = fileURLToPath(new URL("../../../package.json", import.meta.url));
 const enginePackageVersion = JSON.parse(readFileSync(enginePackageJsonPath, "utf8")).version;
@@ -244,6 +245,7 @@ export async function loadEngineDirectActivityExecutor(manifestPath, options = {
  *   manifestPath?: string | null;
  *   llmConfig?: import("../../orchestrator/llm-activity-executor.mjs").LlmOperatorConfig | null;
  *   stepHandlerRegistry?: import("../../orchestrator/step-activity-executor.mjs").StepHandlerRegistry | null;
+ *   secretResolver?: import("../../security/secret-resolver.mjs").SecretResolver;
  *   env?: NodeJS.ProcessEnv;
  *   cwd?: string;
  *   profile?: string | null;
@@ -257,6 +259,7 @@ export async function loadEngineDirectActivityExecutor(manifestPath, options = {
 export async function loadProductionActivityExecutor(options = {}) {
   const cwd = options.cwd ?? process.cwd();
   const env = options.env ?? process.env;
+  const secretResolver = options.secretResolver ?? createDefaultSecretResolver({ env, cwd });
   const profile = options.profile ?? env.WORKFLOW_ENGINE_PROFILE ?? null;
   const demoProfile = profile === "demo";
 
@@ -280,7 +283,7 @@ export async function loadProductionActivityExecutor(options = {}) {
     options.llmConfig !== undefined ? options.llmConfig : resolveLlmOperatorConfigFromEnv(env, cwd);
   let hasLlm = false;
   if (llmConfig) {
-    subExecutors.llm_call = new LlmActivityExecutor({ operatorConfig: llmConfig, env });
+    subExecutors.llm_call = new LlmActivityExecutor({ operatorConfig: llmConfig, env, secretResolver });
     hasLlm = true;
   }
 
@@ -353,6 +356,7 @@ export async function loadEngineDirectMcpDelegateExecutor(manifestPath, options 
  * @param {{
  *   manifestPath?: string | null;
  *   a2aConfig?: import("../../orchestrator/a2a-delegate-executor.mjs").A2AOperatorConfig | null;
+ *   secretResolver?: import("../../security/secret-resolver.mjs").SecretResolver;
  *   env?: NodeJS.ProcessEnv;
  *   cwd?: string;
  *   profile?: string | null;
@@ -366,6 +370,7 @@ export async function loadEngineDirectMcpDelegateExecutor(manifestPath, options 
 export async function loadProductionDelegateExecutor(options = {}) {
   const cwd = options.cwd ?? process.cwd();
   const env = options.env ?? process.env;
+  const secretResolver = options.secretResolver ?? createDefaultSecretResolver({ env, cwd });
   const profile = options.profile ?? env.WORKFLOW_ENGINE_PROFILE ?? null;
   const demoProfile = profile === "demo";
 
@@ -392,7 +397,7 @@ export async function loadProductionDelegateExecutor(options = {}) {
     if (!parsed.ok) {
       return { ok: false, error: parsed.error };
     }
-    subExecutors.a2a = new A2ADelegateExecutor({ operatorConfig: a2aConfig, env });
+    subExecutors.a2a = new A2ADelegateExecutor({ operatorConfig: a2aConfig, env, secretResolver });
   }
 
   if (!subExecutors.a2a && !subExecutors.mcp) {

--- a/packages/engine/src/adapters/mcp/stdio-server-config.mjs
+++ b/packages/engine/src/adapters/mcp/stdio-server-config.mjs
@@ -30,6 +30,11 @@ import {
   StepActivityExecutor,
   StepHandlerRegistry,
 } from "../../orchestrator/step-activity-executor.mjs";
+import {
+  resolveDefinitionSigningOptions,
+  resolveDefinitionSigningPolicyFromEnv,
+  resolveSigningPublicKeysFromEnv,
+} from "../../definition-signing.mjs";
 import { createDefaultSecretResolver } from "../../security/secret-resolver.mjs";
 
 const enginePackageJsonPath = fileURLToPath(new URL("../../../package.json", import.meta.url));
@@ -409,6 +414,22 @@ export async function loadProductionDelegateExecutor(options = {}) {
   }
 
   return { ok: true, executor: buildCompositeDelegateExecutor(subExecutors) };
+}
+
+/**
+ * @param {NodeJS.ProcessEnv} [env]
+ * @param {string} [cwd]
+ * @returns {import("../../adapters/mcp/transport-validation.mjs").TransportValidationOptions}
+ */
+export function resolveTransportValidationOptionsFromEnv(env = process.env, cwd = process.cwd()) {
+  return {
+    signing: resolveDefinitionSigningOptions({
+      policy: resolveDefinitionSigningPolicyFromEnv(env),
+      publicKeysById: resolveSigningPublicKeysFromEnv(env, cwd),
+      env,
+      cwd,
+    }),
+  };
 }
 
 export { enginePackageVersion };

--- a/packages/engine/src/adapters/mcp/stdio-server.mjs
+++ b/packages/engine/src/adapters/mcp/stdio-server.mjs
@@ -18,13 +18,16 @@ const enginePackageVersion = JSON.parse(readFileSync(enginePackageJsonPath, "utf
 
 /**
  * @param {{ startWorkflow: Function; getWorkflowStatus: Function; resumeWorkflow: Function; submitWorkflowActivity: Function; signalWorkflow: Function; cancelWorkflow: Function; listWorkflowExecutions: Function }} workflowPort
+ * @param {{ transportValidation?: import("./transport-validation.mjs").TransportValidationOptions }} [options]
  */
-export function createMcpWorkflowStdioServer(workflowPort) {
+export function createMcpWorkflowStdioServer(workflowPort, options = {}) {
   const server = new McpServer({
     name: "@agent-workflow/engine-mcp-stdio",
     version: enginePackageVersion,
   });
-  const handlers = createMcpWorkflowToolHandlers(workflowPort);
+  const handlers = createMcpWorkflowToolHandlers(workflowPort, {
+    transportValidation: options.transportValidation,
+  });
 
   server.registerTool(
     "workflow_start",

--- a/packages/engine/src/adapters/mcp/transport-validation.mjs
+++ b/packages/engine/src/adapters/mcp/transport-validation.mjs
@@ -1,9 +1,22 @@
 import { validateWorkflowDefinition } from "../../validate.mjs";
-import { verifyDefinitionSignature } from "../../definition-signing.mjs";
+import {
+  resolveDefinitionSigningOptions,
+  stripDefinitionSignature,
+  verifyDefinitionSignature,
+} from "../../definition-signing.mjs";
 import { MCP_ADAPTER_ERROR, McpAdapterError } from "./errors.mjs";
 
 /** Maximum UTF-8 byte length for JSON-serialized MCP workflow payloads (definition, input, resume). */
 export const MAX_MCP_WORKFLOW_JSON_BYTES = 2 * 1024 * 1024;
+
+/**
+ * @typedef {import("../../definition-signing.mjs").VerifyDefinitionSignatureOptions} TransportSigningOptions
+ */
+
+/**
+ * @typedef {object} TransportValidationOptions
+ * @property {TransportSigningOptions} [signing]
+ */
 
 /**
  * @param {unknown} value
@@ -30,18 +43,21 @@ export function assertMcpJsonWithinSizeLimit(label, value, maxBytes = MAX_MCP_WO
 }
 
 /**
- * AJV + graph invariants + optional definition signing hook at the MCP transport boundary.
+ * AJV + graph invariants + definition signing at the MCP transport boundary.
  *
  * @param {unknown} definition
+ * @param {TransportValidationOptions} [options]
  */
-export function assertValidWorkflowDefinitionAtTransport(definition) {
-  const v = validateWorkflowDefinition(definition);
+export function assertValidWorkflowDefinitionAtTransport(definition, options = {}) {
+  const forSchema = stripDefinitionSignature(definition);
+  const v = validateWorkflowDefinition(forSchema);
   if (!v.ok) {
     throw new McpAdapterError(MCP_ADAPTER_ERROR.VALIDATION_ERROR, "Workflow definition failed schema validation.", {
       errors: v.errors,
     });
   }
-  const signing = verifyDefinitionSignature(definition);
+  const signingOptions = options.signing ?? resolveDefinitionSigningOptions();
+  const signing = verifyDefinitionSignature(definition, signingOptions);
   if (!signing.ok) {
     throw new McpAdapterError(
       MCP_ADAPTER_ERROR.VALIDATION_ERROR,
@@ -54,21 +70,23 @@ export function assertValidWorkflowDefinitionAtTransport(definition) {
 /**
  * @param {unknown} definition
  * @param {unknown} [extraPayload] input or resume_payload sized together with definition
+ * @param {TransportValidationOptions} [options]
  */
-export function validateWorkflowStartTransportPayload(definition, extraPayload) {
+export function validateWorkflowStartTransportPayload(definition, extraPayload, options = {}) {
   assertMcpJsonWithinSizeLimit("definition", definition);
   if (extraPayload !== undefined) {
     assertMcpJsonWithinSizeLimit("input", extraPayload);
   }
-  assertValidWorkflowDefinitionAtTransport(definition);
+  assertValidWorkflowDefinitionAtTransport(definition, options);
 }
 
 /**
  * @param {unknown} definition
  * @param {unknown} resumePayload
+ * @param {TransportValidationOptions} [options]
  */
-export function validateWorkflowResumeTransportPayload(definition, resumePayload) {
+export function validateWorkflowResumeTransportPayload(definition, resumePayload, options = {}) {
   assertMcpJsonWithinSizeLimit("definition", definition);
   assertMcpJsonWithinSizeLimit("resume_payload", resumePayload);
-  assertValidWorkflowDefinitionAtTransport(definition);
+  assertValidWorkflowDefinitionAtTransport(definition, options);
 }

--- a/packages/engine/src/adapters/mcp/workflow-tools.mjs
+++ b/packages/engine/src/adapters/mcp/workflow-tools.mjs
@@ -8,6 +8,7 @@ import {
   workflowSubmitActivityArgsSchema,
 } from "./contracts.mjs";
 import { MCP_ADAPTER_ERROR, McpAdapterError, normalizeMcpAdapterError, toToolErrorResult } from "./errors.mjs";
+import { authorizeToolCall } from "../../security/control-plane-auth.mjs";
 import {
   validateWorkflowResumeTransportPayload,
   validateWorkflowStartTransportPayload,
@@ -126,14 +127,38 @@ function mcpErrorForCancelFailure(code, message) {
 }
 
 /**
+ * @typedef {import("../../security/control-plane-auth.mjs").ControlPlaneAuthConfig} ControlPlaneAuthConfig
+ */
+
+/**
+ * @param {string} toolName
+ * @param {{ bearerToken?: string | null; enforce?: boolean } | undefined} authContext
+ * @param {ControlPlaneAuthConfig | undefined} authConfig
+ */
+function assertMcpToolAuthorized(toolName, authContext, authConfig) {
+  if (!authConfig?.enabled || authContext?.enforce !== true) {
+    return;
+  }
+  const result = authorizeToolCall(toolName, authContext.bearerToken ?? null, authConfig);
+  if (!result.ok) {
+    throw new McpAdapterError(result.code, result.message, result.details);
+  }
+}
+
+/**
  * @param {{ startWorkflow: Function; getWorkflowStatus: Function; resumeWorkflow: Function; submitWorkflowActivity: Function; signalWorkflow: Function; cancelWorkflow: Function; listWorkflowExecutions: Function }} workflowPort
- * @param {{ transportValidation?: import("./transport-validation.mjs").TransportValidationOptions }} [options]
+ * @param {{
+ *   transportValidation?: import("./transport-validation.mjs").TransportValidationOptions;
+ *   authConfig?: ControlPlaneAuthConfig;
+ * }} [options]
  */
 export function createMcpWorkflowToolHandlers(workflowPort, options = {}) {
   const transportValidation = options.transportValidation ?? {};
+  const authConfig = options.authConfig;
   return {
-    async workflow_start(args) {
+    async workflow_start(args, authContext) {
       try {
+        assertMcpToolAuthorized("workflow_start", authContext, authConfig);
         const parsed = workflowStartArgsSchema.parse(args);
         validateWorkflowStartTransportPayload(parsed.definition, parsed.input, transportValidation);
         const response = await workflowPort.startWorkflow({
@@ -171,8 +196,9 @@ export function createMcpWorkflowToolHandlers(workflowPort, options = {}) {
       }
     },
 
-    async workflow_status(args) {
+    async workflow_status(args, authContext) {
       try {
+        assertMcpToolAuthorized("workflow_status", authContext, authConfig);
         const parsed = workflowStatusArgsSchema.parse(args);
         const response = await workflowPort.getWorkflowStatus({
           executionId: parsed.execution_id,
@@ -199,8 +225,9 @@ export function createMcpWorkflowToolHandlers(workflowPort, options = {}) {
       }
     },
 
-    async workflow_resume(args) {
+    async workflow_resume(args, authContext) {
       try {
+        assertMcpToolAuthorized("workflow_resume", authContext, authConfig);
         const parsed = workflowResumeArgsSchema.parse(args);
         validateWorkflowResumeTransportPayload(parsed.definition, parsed.resume_payload, transportValidation);
         const response = await workflowPort.resumeWorkflow({
@@ -238,8 +265,9 @@ export function createMcpWorkflowToolHandlers(workflowPort, options = {}) {
       }
     },
 
-    async workflow_submit_activity(args) {
+    async workflow_submit_activity(args, authContext) {
       try {
+        assertMcpToolAuthorized("workflow_submit_activity", authContext, authConfig);
         const parsed = workflowSubmitActivityArgsSchema.parse(args);
         const expectedParallelSpan = parsed.parallel_span
           ? {
@@ -300,8 +328,9 @@ export function createMcpWorkflowToolHandlers(workflowPort, options = {}) {
       }
     },
 
-    async workflow_signal(args) {
+    async workflow_signal(args, authContext) {
       try {
+        assertMcpToolAuthorized("workflow_signal", authContext, authConfig);
         const parsed = workflowSignalArgsSchema.parse(args);
         const response = await workflowPort.signalWorkflow({
           executionId: parsed.execution_id,
@@ -340,8 +369,9 @@ export function createMcpWorkflowToolHandlers(workflowPort, options = {}) {
       }
     },
 
-    async workflow_cancel(args) {
+    async workflow_cancel(args, authContext) {
       try {
+        assertMcpToolAuthorized("workflow_cancel", authContext, authConfig);
         const parsed = workflowCancelArgsSchema.parse(args);
         const response = await workflowPort.cancelWorkflow({
           executionId: parsed.execution_id,
@@ -376,8 +406,9 @@ export function createMcpWorkflowToolHandlers(workflowPort, options = {}) {
       }
     },
 
-    async workflow_list(args) {
+    async workflow_list(args, authContext) {
       try {
+        assertMcpToolAuthorized("workflow_list", authContext, authConfig);
         const parsed = workflowListArgsSchema.parse(args);
         const response = await workflowPort.listWorkflowExecutions({
           ...(parsed.phase !== undefined ? { phase: parsed.phase } : {}),

--- a/packages/engine/src/adapters/mcp/workflow-tools.mjs
+++ b/packages/engine/src/adapters/mcp/workflow-tools.mjs
@@ -127,13 +127,15 @@ function mcpErrorForCancelFailure(code, message) {
 
 /**
  * @param {{ startWorkflow: Function; getWorkflowStatus: Function; resumeWorkflow: Function; submitWorkflowActivity: Function; signalWorkflow: Function; cancelWorkflow: Function; listWorkflowExecutions: Function }} workflowPort
+ * @param {{ transportValidation?: import("./transport-validation.mjs").TransportValidationOptions }} [options]
  */
-export function createMcpWorkflowToolHandlers(workflowPort) {
+export function createMcpWorkflowToolHandlers(workflowPort, options = {}) {
+  const transportValidation = options.transportValidation ?? {};
   return {
     async workflow_start(args) {
       try {
         const parsed = workflowStartArgsSchema.parse(args);
-        validateWorkflowStartTransportPayload(parsed.definition, parsed.input);
+        validateWorkflowStartTransportPayload(parsed.definition, parsed.input, transportValidation);
         const response = await workflowPort.startWorkflow({
           executionId: parsed.execution_id,
           definition: parsed.definition,
@@ -200,7 +202,7 @@ export function createMcpWorkflowToolHandlers(workflowPort) {
     async workflow_resume(args) {
       try {
         const parsed = workflowResumeArgsSchema.parse(args);
-        validateWorkflowResumeTransportPayload(parsed.definition, parsed.resume_payload);
+        validateWorkflowResumeTransportPayload(parsed.definition, parsed.resume_payload, transportValidation);
         const response = await workflowPort.resumeWorkflow({
           executionId: parsed.execution_id,
           definition: parsed.definition,

--- a/packages/engine/src/adapters/rest/definition-registry.mjs
+++ b/packages/engine/src/adapters/rest/definition-registry.mjs
@@ -7,13 +7,22 @@ import { deriveWorkflowId } from "../workflow-id.mjs";
 export class DefinitionRegistry {
   /** @type {Map<string, object>} */
   #definitions = new Map();
+  /** @type {import("../mcp/transport-validation.mjs").TransportValidationOptions | undefined} */
+  #transportValidation;
+
+  /**
+   * @param {{ transportValidation?: import("../mcp/transport-validation.mjs").TransportValidationOptions }} [options]
+   */
+  constructor(options = {}) {
+    this.#transportValidation = options.transportValidation;
+  }
 
   /**
    * @param {object} definition
    * @returns {{ wf_id: string; definition: object }}
    */
   register(definition) {
-    assertValidWorkflowDefinitionAtTransport(definition);
+    assertValidWorkflowDefinitionAtTransport(definition, this.#transportValidation);
     const wfId = deriveWorkflowId(definition);
     if (this.#definitions.has(wfId)) {
       const err = new Error(`Workflow definition "${wfId}" is already registered.`);

--- a/packages/engine/src/adapters/rest/errors.mjs
+++ b/packages/engine/src/adapters/rest/errors.mjs
@@ -8,6 +8,8 @@ export function httpStatusForAdapterError(code) {
   switch (code) {
     case MCP_ADAPTER_ERROR.AUTH_ERROR:
       return 401;
+    case MCP_ADAPTER_ERROR.AUTH_FORBIDDEN:
+      return 403;
     case MCP_ADAPTER_ERROR.VALIDATION_ERROR:
     case MCP_ADAPTER_ERROR.INVALID_RESUME_PAYLOAD:
     case MCP_ADAPTER_ERROR.SUBMIT_VALIDATION_ERROR:

--- a/packages/engine/src/adapters/rest/errors.mjs
+++ b/packages/engine/src/adapters/rest/errors.mjs
@@ -6,6 +6,8 @@ import { MCP_ADAPTER_ERROR } from "../mcp/errors.mjs";
  */
 export function httpStatusForAdapterError(code) {
   switch (code) {
+    case MCP_ADAPTER_ERROR.AUTH_ERROR:
+      return 401;
     case MCP_ADAPTER_ERROR.VALIDATION_ERROR:
     case MCP_ADAPTER_ERROR.INVALID_RESUME_PAYLOAD:
     case MCP_ADAPTER_ERROR.SUBMIT_VALIDATION_ERROR:

--- a/packages/engine/src/adapters/rest/rest-handler.mjs
+++ b/packages/engine/src/adapters/rest/rest-handler.mjs
@@ -139,10 +139,12 @@ function adaptCaughtError(error) {
  * @param {{
  *   definitionRegistry?: DefinitionRegistry;
  *   store?: import("../../persistence/types.mjs").ExecutionHistoryStore;
+ *   transportValidation?: import("../mcp/transport-validation.mjs").TransportValidationOptions;
  * }} [deps]
  */
 export function createRestWorkflowHandler(workflowPort, deps = {}) {
-  const definitionRegistry = deps.definitionRegistry ?? new DefinitionRegistry();
+  const transportValidation = deps.transportValidation ?? {};
+  const definitionRegistry = deps.definitionRegistry ?? new DefinitionRegistry({ transportValidation });
   const store = deps.store;
 
   /**
@@ -190,7 +192,7 @@ export function createRestWorkflowHandler(workflowPort, deps = {}) {
           activity_execution_mode: body.activity_execution_mode,
           allow_existing_execution_id: body.allow_existing_execution_id,
         });
-        validateWorkflowStartTransportPayload(parsed.definition, parsed.input);
+        validateWorkflowStartTransportPayload(parsed.definition, parsed.input, transportValidation);
         const response = await workflowPort.startWorkflow({
           executionId: parsed.execution_id,
           definition: parsed.definition,
@@ -259,7 +261,7 @@ export function createRestWorkflowHandler(workflowPort, deps = {}) {
           resume_payload: body.resume_payload ?? {},
           activity_execution_mode: body.activity_execution_mode,
         });
-        validateWorkflowResumeTransportPayload(parsed.definition, parsed.resume_payload);
+        validateWorkflowResumeTransportPayload(parsed.definition, parsed.resume_payload, transportValidation);
         const response = await workflowPort.resumeWorkflow({
           executionId: parsed.execution_id,
           definition: parsed.definition,

--- a/packages/engine/src/adapters/rest/rest-handler.mjs
+++ b/packages/engine/src/adapters/rest/rest-handler.mjs
@@ -26,6 +26,11 @@ import {
 import { DefinitionRegistry } from "./definition-registry.mjs";
 import { adapterErrorToHttpBody, httpStatusForAdapterError } from "./errors.mjs";
 import { readJsonBody, requestPathname, requestQuery, sendJson } from "./http-utils.mjs";
+import {
+  authorizeRestRequest,
+  extractBearerToken,
+  loadControlPlaneAuthConfigFromEnv,
+} from "../../security/control-plane-auth.mjs";
 
 const SUBMIT_ACTIVITY_ADAPTER_CODES = new Set([
   MCP_ADAPTER_ERROR.ACTIVITY_SUBMIT_NOT_AWAITING,
@@ -140,12 +145,14 @@ function adaptCaughtError(error) {
  *   definitionRegistry?: DefinitionRegistry;
  *   store?: import("../../persistence/types.mjs").ExecutionHistoryStore;
  *   transportValidation?: import("../mcp/transport-validation.mjs").TransportValidationOptions;
+ *   authConfig?: import("../../security/control-plane-auth.mjs").ControlPlaneAuthConfig;
  * }} [deps]
  */
 export function createRestWorkflowHandler(workflowPort, deps = {}) {
   const transportValidation = deps.transportValidation ?? {};
   const definitionRegistry = deps.definitionRegistry ?? new DefinitionRegistry({ transportValidation });
   const store = deps.store;
+  const authConfig = deps.authConfig ?? loadControlPlaneAuthConfigFromEnv();
 
   /**
    * @param {import("node:http").IncomingMessage} req
@@ -156,6 +163,18 @@ export function createRestWorkflowHandler(workflowPort, deps = {}) {
     const pathname = requestPathname(req);
 
     try {
+      if (authConfig.enabled) {
+        const authResult = authorizeRestRequest(
+          method,
+          pathname,
+          extractBearerToken(req.headers.authorization),
+          authConfig
+        );
+        if (!authResult.ok) {
+          throw new McpAdapterError(authResult.code, authResult.message, authResult.details);
+        }
+      }
+
       if (method === "POST" && pathname === "/v1/workflows") {
         const body = await readJsonBody(req);
         if (!body || typeof body !== "object" || Array.isArray(body) || !body.definition) {

--- a/packages/engine/src/definition-signing.mjs
+++ b/packages/engine/src/definition-signing.mjs
@@ -1,11 +1,21 @@
 /**
- * Optional workflow definition signing profile (v1 stub).
+ * Workflow definition signing profile v1 — JWS compact with Ed25519 (EdDSA).
  *
- * Signed definitions may carry `document.signature` (or top-level `signature` for transitional
- * fixtures). When no signature is present, verification is a no-op. When a signature is
- * present, this module records intent for a future verifier (JWS, Sigstore, or operator PKI)
- * without blocking alpha/POC runs.
+ * @see docs/security/definition-signing-v1-profile.md
  */
+
+import { createPrivateKey, createPublicKey, sign, verify } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { canonicalJsonStringify } from "./canonical-json.mjs";
+
+export const DEFINITION_SIGNING_ALG = "EdDSA";
+export const DEFINITION_SIGNING_JWS_TYP = "JWS";
+export const DEFINITION_SIGNING_MODE_ENV = "WORKFLOW_ENGINE_DEFINITION_SIGNING_MODE";
+export const DEFINITION_SIGNING_PUBLIC_KEYS_ENV = "WORKFLOW_ENGINE_SIGNING_PUBLIC_KEYS";
+
+/** Ed25519 SPKI DER prefix for raw 32-byte public keys. */
+const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
 
 /**
  * @typedef {object} DefinitionSignatureBlock
@@ -13,6 +23,40 @@
  * @property {string} [value]
  * @property {string} [keyId]
  */
+
+/**
+ * @typedef {{ mode: "optional" | "require" }} DefinitionSigningPolicy
+ */
+
+/**
+ * @typedef {object} VerifyDefinitionSignatureOptions
+ * @property {DefinitionSigningPolicy} [policy]
+ * @property {Record<string, import("node:crypto").KeyObject>} [publicKeysById]
+ * @property {NodeJS.ProcessEnv} [env]
+ * @property {string} [cwd]
+ */
+
+/**
+ * @param {Buffer} buffer
+ * @returns {string}
+ */
+function base64UrlEncode(buffer) {
+  return buffer
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+/**
+ * @param {string} value
+ * @returns {Buffer}
+ */
+function base64UrlDecode(value) {
+  const normalized = String(value).replace(/-/g, "+").replace(/_/g, "/");
+  const padding = normalized.length % 4 === 0 ? "" : "=".repeat(4 - (normalized.length % 4));
+  return Buffer.from(normalized + padding, "base64");
+}
 
 /**
  * @param {unknown} definition
@@ -35,16 +79,282 @@ export function extractDefinitionSignature(definition) {
 }
 
 /**
- * Verify hook for optional signed definitions. Unsigned definitions always pass.
+ * @param {unknown} definition
+ * @returns {Record<string, unknown>}
+ */
+export function stripDefinitionSignature(definition) {
+  const clone = structuredClone(definition);
+  if (!clone || typeof clone !== "object" || Array.isArray(clone)) {
+    return /** @type {Record<string, unknown>} */ (clone);
+  }
+  const record = /** @type {Record<string, unknown> & { document?: Record<string, unknown> }} */ (clone);
+  if (record.document && typeof record.document === "object" && !Array.isArray(record.document)) {
+    delete record.document.signature;
+  }
+  delete record.signature;
+  return record;
+}
+
+/**
+ * Canonical signing payload: definition JSON with signature field removed.
+ *
+ * @param {unknown} definition
+ * @returns {string}
+ */
+export function buildDefinitionSigningPayload(definition) {
+  return canonicalJsonStringify(stripDefinitionSignature(definition));
+}
+
+/**
+ * @param {string | Buffer} keyMaterial Base64url SPKI DER or raw 32-byte Ed25519 public key.
+ * @returns {import("node:crypto").KeyObject}
+ */
+export function importEd25519PublicKey(keyMaterial) {
+  const bytes = typeof keyMaterial === "string" ? base64UrlDecode(keyMaterial) : keyMaterial;
+  if (bytes.length === 32) {
+    return createPublicKey({
+      key: Buffer.concat([ED25519_SPKI_PREFIX, bytes]),
+      format: "der",
+      type: "spki",
+    });
+  }
+  return createPublicKey({ key: bytes, format: "der", type: "spki" });
+}
+
+/**
+ * @param {string | Buffer} keyMaterial Base64url PKCS8 DER Ed25519 private key.
+ * @returns {import("node:crypto").KeyObject}
+ */
+export function importEd25519PrivateKey(keyMaterial) {
+  const bytes = typeof keyMaterial === "string" ? base64UrlDecode(keyMaterial) : keyMaterial;
+  return createPrivateKey({ key: bytes, format: "der", type: "pkcs8" });
+}
+
+/**
+ * @param {string} raw Env value (inline JSON object or `file:relative/path`).
+ * @param {string} cwd
+ * @param {string} label
+ * @returns {Record<string, string>}
+ */
+export function parseSigningPublicKeysConfig(raw, cwd, label = DEFINITION_SIGNING_PUBLIC_KEYS_ENV) {
+  const trimmed = String(raw).trim();
+  if (trimmed === "") {
+    return {};
+  }
+  let text;
+  if (trimmed.startsWith("file:")) {
+    const rel = trimmed.slice(5).trim();
+    if (!rel) {
+      throw new Error(`${label} file ref is missing path`);
+    }
+    const target = path.isAbsolute(rel) ? rel : path.resolve(cwd, rel);
+    text = readFileSync(target, "utf8");
+  } else if (trimmed.startsWith("{")) {
+    text = trimmed;
+  } else {
+    const target = path.isAbsolute(trimmed) ? trimmed : path.resolve(cwd, trimmed);
+    text = readFileSync(target, "utf8");
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`${label} is not valid JSON: ${message}`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${label} must be a JSON object mapping keyId to base64url public key material`);
+  }
+  /** @type {Record<string, string>} */
+  const out = {};
+  for (const [keyId, material] of Object.entries(parsed)) {
+    if (typeof material !== "string" || material.trim() === "") {
+      throw new Error(`${label} entry "${keyId}" must be a non-empty base64url string`);
+    }
+    out[keyId] = material.trim();
+  }
+  return out;
+}
+
+/**
+ * @param {Record<string, string>} keyMap
+ * @returns {Record<string, import("node:crypto").KeyObject>}
+ */
+export function loadPublicKeysFromConfig(keyMap) {
+  /** @type {Record<string, import("node:crypto").KeyObject>} */
+  const out = {};
+  for (const [keyId, material] of Object.entries(keyMap)) {
+    out[keyId] = importEd25519PublicKey(material);
+  }
+  return out;
+}
+
+/**
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {DefinitionSigningPolicy}
+ */
+export function resolveDefinitionSigningPolicyFromEnv(env = process.env) {
+  const raw = env[DEFINITION_SIGNING_MODE_ENV];
+  if (raw === undefined || String(raw).trim() === "") {
+    return { mode: "optional" };
+  }
+  const mode = String(raw).trim().toLowerCase();
+  if (mode === "optional" || mode === "require") {
+    return { mode };
+  }
+  throw new Error(
+    `${DEFINITION_SIGNING_MODE_ENV} must be "optional" or "require" (received "${raw}")`
+  );
+}
+
+/**
+ * @param {NodeJS.ProcessEnv} [env]
+ * @param {string} [cwd]
+ * @returns {Record<string, import("node:crypto").KeyObject>}
+ */
+export function resolveSigningPublicKeysFromEnv(env = process.env, cwd = process.cwd()) {
+  const raw = env[DEFINITION_SIGNING_PUBLIC_KEYS_ENV];
+  if (raw === undefined || String(raw).trim() === "") {
+    return {};
+  }
+  const keyMap = parseSigningPublicKeysConfig(raw, cwd);
+  return loadPublicKeysFromConfig(keyMap);
+}
+
+/**
+ * @param {VerifyDefinitionSignatureOptions} [options]
+ * @returns {{ policy: DefinitionSigningPolicy; publicKeysById: Record<string, import("node:crypto").KeyObject> }}
+ */
+export function resolveDefinitionSigningOptions(options = {}) {
+  const env = options.env ?? process.env;
+  const cwd = options.cwd ?? process.cwd();
+  const policy = options.policy ?? resolveDefinitionSigningPolicyFromEnv(env);
+  const publicKeysById =
+    options.publicKeysById ??
+    (env[DEFINITION_SIGNING_PUBLIC_KEYS_ENV]
+      ? resolveSigningPublicKeysFromEnv(env, cwd)
+      : {});
+  return { policy, publicKeysById };
+}
+
+/**
+ * @param {string} compactJws
+ * @param {string} expectedPayload Canonical JSON payload bytes (UTF-8).
+ * @param {import("node:crypto").KeyObject} publicKey
+ * @returns {{ ok: true } | { ok: false; error: string }}
+ */
+export function verifyEdDsaJwsCompact(compactJws, expectedPayload, publicKey) {
+  const parts = String(compactJws).split(".");
+  if (parts.length !== 3) {
+    return { ok: false, error: "JWS compact serialization must contain three segments" };
+  }
+  const [protectedB64, payloadB64, signatureB64] = parts;
+  let protectedHeader;
+  try {
+    protectedHeader = JSON.parse(Buffer.from(base64UrlDecode(protectedB64)).toString("utf8"));
+  } catch {
+    return { ok: false, error: "JWS protected header is not valid JSON" };
+  }
+  if (protectedHeader?.alg !== DEFINITION_SIGNING_ALG) {
+    return {
+      ok: false,
+      error: `Unsupported JWS alg "${protectedHeader?.alg ?? "missing"}" (expected "${DEFINITION_SIGNING_ALG}")`,
+    };
+  }
+  const payloadBytes = base64UrlDecode(payloadB64);
+  const payloadText = payloadBytes.toString("utf8");
+  if (payloadText !== expectedPayload) {
+    return { ok: false, error: "JWS payload does not match canonical definition signing payload" };
+  }
+  const signingInput = `${protectedB64}.${payloadB64}`;
+  const signature = base64UrlDecode(signatureB64);
+  const valid = verify(null, Buffer.from(signingInput, "ascii"), publicKey, signature);
+  if (!valid) {
+    return { ok: false, error: "Ed25519 signature verification failed" };
+  }
+  return { ok: true };
+}
+
+/**
+ * @param {import("node:crypto").KeyObject} privateKey
+ * @param {string} payload Canonical JSON payload.
+ * @param {string} [keyId]
+ * @returns {string} Compact JWS.
+ */
+export function createEdDsaJwsCompact(privateKey, payload, keyId) {
+  /** @type {Record<string, string>} */
+  const header = { alg: DEFINITION_SIGNING_ALG, typ: DEFINITION_SIGNING_JWS_TYP };
+  if (keyId) {
+    header.kid = keyId;
+  }
+  const protectedB64 = base64UrlEncode(Buffer.from(JSON.stringify(header), "utf8"));
+  const payloadB64 = base64UrlEncode(Buffer.from(payload, "utf8"));
+  const signingInput = `${protectedB64}.${payloadB64}`;
+  const signature = sign(null, Buffer.from(signingInput, "ascii"), privateKey);
+  return `${signingInput}.${base64UrlEncode(signature)}`;
+}
+
+/**
+ * @param {DefinitionSignatureBlock} signature
+ * @param {string} payload
+ * @param {Record<string, import("node:crypto").KeyObject>} publicKeysById
+ * @returns {{ ok: true } | { ok: false; error: string }}
+ */
+function verifySignatureBlock(signature, payload, publicKeysById) {
+  if (signature.alg !== undefined && signature.alg !== DEFINITION_SIGNING_ALG) {
+    return {
+      ok: false,
+      error: `Unsupported signature alg "${signature.alg}" (expected "${DEFINITION_SIGNING_ALG}")`,
+    };
+  }
+  if (typeof signature.value !== "string" || signature.value.trim() === "") {
+    return { ok: false, error: "Signature block is missing compact JWS value" };
+  }
+  const keyIds = Object.keys(publicKeysById);
+  if (keyIds.length === 0) {
+    return { ok: false, error: "Definition signature present but no verification public keys are configured" };
+  }
+  if (signature.keyId) {
+    const key = publicKeysById[signature.keyId];
+    if (!key) {
+      return { ok: false, error: `Unknown signature keyId "${signature.keyId}"` };
+    }
+    return verifyEdDsaJwsCompact(signature.value, payload, key);
+  }
+  for (const keyId of keyIds) {
+    const result = verifyEdDsaJwsCompact(signature.value, payload, publicKeysById[keyId]);
+    if (result.ok) {
+      return result;
+    }
+  }
+  return { ok: false, error: "Ed25519 signature verification failed for all configured public keys" };
+}
+
+/**
+ * Verify optional or required signed definitions (JWS Ed25519 v1 profile).
  *
  * @param {unknown} definition Parsed workflow definition object.
+ * @param {VerifyDefinitionSignatureOptions} [options]
  * @returns {{ ok: true; verified: boolean; signaturePresent: boolean } | { ok: false; error: string }}
  */
-export function verifyDefinitionSignature(definition) {
+export function verifyDefinitionSignature(definition, options = {}) {
+  const { policy, publicKeysById } = resolveDefinitionSigningOptions(options);
   const signature = extractDefinitionSignature(definition);
+
   if (!signature) {
+    if (policy.mode === "require") {
+      return {
+        ok: false,
+        error: "Workflow definition signature is required but no signature block was present",
+      };
+    }
     return { ok: true, verified: false, signaturePresent: false };
   }
-  // Stub: accept presence without cryptographic verification until v1 profile ships.
-  return { ok: true, verified: false, signaturePresent: true };
+
+  const payload = buildDefinitionSigningPayload(definition);
+  const cryptoResult = verifySignatureBlock(signature, payload, publicKeysById);
+  if (!cryptoResult.ok) {
+    return cryptoResult;
+  }
+  return { ok: true, verified: true, signaturePresent: true };
 }

--- a/packages/engine/src/definition-signing.mjs
+++ b/packages/engine/src/definition-signing.mjs
@@ -311,6 +311,26 @@ export function createEdDsaJwsCompact(privateKey, payload, keyId) {
 }
 
 /**
+ * @param {string} compactJws
+ * @returns {{ ok: true; header: Record<string, unknown> } | { ok: false; error: string }}
+ */
+function parseJwsProtectedHeader(compactJws) {
+  const parts = String(compactJws).split(".");
+  if (parts.length !== 3) {
+    return { ok: false, error: "JWS compact serialization must contain three segments" };
+  }
+  try {
+    const header = JSON.parse(Buffer.from(base64UrlDecode(parts[0])).toString("utf8"));
+    if (!header || typeof header !== "object" || Array.isArray(header)) {
+      return { ok: false, error: "JWS protected header is not valid JSON" };
+    }
+    return { ok: true, header };
+  } catch {
+    return { ok: false, error: "JWS protected header is not valid JSON" };
+  }
+}
+
+/**
  * @param {DefinitionSignatureBlock} signature
  * @param {string} payload
  * @param {Record<string, import("node:crypto").KeyObject>} publicKeysById
@@ -326,24 +346,60 @@ function verifySignatureBlock(signature, payload, publicKeysById) {
   if (typeof signature.value !== "string" || signature.value.trim() === "") {
     return { ok: false, error: "Signature block is missing compact JWS value" };
   }
-  const keyIds = Object.keys(publicKeysById);
-  if (keyIds.length === 0) {
+  const configuredKeyIds = Object.keys(publicKeysById);
+  if (configuredKeyIds.length === 0) {
     return { ok: false, error: "Definition signature present but no verification public keys are configured" };
   }
-  if (signature.keyId) {
-    const key = publicKeysById[signature.keyId];
-    if (!key) {
-      return { ok: false, error: `Unknown signature keyId "${signature.keyId}"` };
-    }
-    return verifyEdDsaJwsCompact(signature.value, payload, key, signature.keyId);
+
+  const parsedHeader = parseJwsProtectedHeader(signature.value);
+  if (!parsedHeader.ok) {
+    return parsedHeader;
   }
-  for (const keyId of keyIds) {
-    const result = verifyEdDsaJwsCompact(signature.value, payload, publicKeysById[keyId]);
+  const jwsKid =
+    typeof parsedHeader.header.kid === "string" && parsedHeader.header.kid.trim() !== ""
+      ? parsedHeader.header.kid.trim()
+      : undefined;
+
+  const definitionKeyId =
+    typeof signature.keyId === "string" && signature.keyId.trim() !== ""
+      ? signature.keyId.trim()
+      : undefined;
+  if (definitionKeyId !== undefined && jwsKid !== undefined && definitionKeyId !== jwsKid) {
+    return {
+      ok: false,
+      error: `signature keyId "${definitionKeyId}" does not match JWS protected header kid "${jwsKid}"`,
+    };
+  }
+
+  const keysToTry =
+    jwsKid !== undefined
+      ? Object.hasOwn(publicKeysById, jwsKid)
+        ? [jwsKid]
+        : []
+      : configuredKeyIds;
+
+  if (jwsKid !== undefined && keysToTry.length === 0) {
+    return { ok: false, error: `Unknown JWS kid "${jwsKid}"` };
+  }
+
+  /** @type {string | undefined} */
+  let lastVerifyError;
+  for (const keyId of keysToTry) {
+    const result = verifyEdDsaJwsCompact(
+      signature.value,
+      payload,
+      publicKeysById[keyId],
+      jwsKid
+    );
     if (result.ok) {
       return result;
     }
+    lastVerifyError = result.error;
   }
-  return { ok: false, error: "Ed25519 signature verification failed for all configured public keys" };
+  return {
+    ok: false,
+    error: lastVerifyError ?? "Ed25519 signature verification failed for all configured public keys",
+  };
 }
 
 /**

--- a/packages/engine/src/definition-signing.mjs
+++ b/packages/engine/src/definition-signing.mjs
@@ -346,8 +346,7 @@ function verifySignatureBlock(signature, payload, publicKeysById) {
   if (typeof signature.value !== "string" || signature.value.trim() === "") {
     return { ok: false, error: "Signature block is missing compact JWS value" };
   }
-  const configuredKeyIds = Object.keys(publicKeysById);
-  if (configuredKeyIds.length === 0) {
+  if (Object.keys(publicKeysById).length === 0) {
     return { ok: false, error: "Definition signature present but no verification public keys are configured" };
   }
 
@@ -359,47 +358,37 @@ function verifySignatureBlock(signature, payload, publicKeysById) {
     typeof parsedHeader.header.kid === "string" && parsedHeader.header.kid.trim() !== ""
       ? parsedHeader.header.kid.trim()
       : undefined;
+  if (jwsKid === undefined) {
+    return { ok: false, error: "JWS protected header is missing required kid" };
+  }
 
   const definitionKeyId =
     typeof signature.keyId === "string" && signature.keyId.trim() !== ""
       ? signature.keyId.trim()
       : undefined;
-  if (definitionKeyId !== undefined && jwsKid !== undefined && definitionKeyId !== jwsKid) {
+  if (definitionKeyId !== undefined && definitionKeyId !== jwsKid) {
     return {
       ok: false,
       error: `signature keyId "${definitionKeyId}" does not match JWS protected header kid "${jwsKid}"`,
     };
   }
 
-  const keysToTry =
-    jwsKid !== undefined
-      ? Object.hasOwn(publicKeysById, jwsKid)
-        ? [jwsKid]
-        : []
-      : configuredKeyIds;
-
-  if (jwsKid !== undefined && keysToTry.length === 0) {
+  if (!Object.hasOwn(publicKeysById, jwsKid)) {
     return { ok: false, error: `Unknown JWS kid "${jwsKid}"` };
   }
 
-  /** @type {string | undefined} */
-  let lastVerifyError;
-  for (const keyId of keysToTry) {
-    const result = verifyEdDsaJwsCompact(
-      signature.value,
-      payload,
-      publicKeysById[keyId],
-      jwsKid
-    );
-    if (result.ok) {
-      return result;
-    }
-    lastVerifyError = result.error;
-  }
-  return {
-    ok: false,
-    error: lastVerifyError ?? "Ed25519 signature verification failed for all configured public keys",
-  };
+  return verifyEdDsaJwsCompact(signature.value, payload, publicKeysById[jwsKid], jwsKid);
+}
+
+/**
+ * @param {unknown} definition
+ * @param {DefinitionSignatureBlock} signature
+ * @param {Record<string, import("node:crypto").KeyObject>} publicKeysById
+ * @returns {{ ok: true } | { ok: false; error: string }}
+ */
+function verifySignedDefinition(definition, signature, publicKeysById) {
+  const payload = buildDefinitionSigningPayload(definition);
+  return verifySignatureBlock(signature, payload, publicKeysById);
 }
 
 /**
@@ -413,18 +402,32 @@ export function verifyDefinitionSignature(definition, options = {}) {
   const { policy, publicKeysById } = resolveDefinitionSigningOptions(options);
   const signature = extractDefinitionSignature(definition);
 
-  if (!signature) {
-    if (policy.mode === "require") {
+  switch (policy.mode) {
+    case "require": {
+      if (!signature) {
+        return {
+          ok: false,
+          error: "Workflow definition signature is required but no signature block was present",
+        };
+      }
+      break;
+    }
+    case "optional": {
+      if (!signature) {
+        // codeql[js/user-controlled-bypass]: unsigned definitions allowed only when operator sets WORKFLOW_ENGINE_DEFINITION_SIGNING_MODE=optional
+        return { ok: true, verified: false, signaturePresent: false };
+      }
+      break;
+    }
+    default: {
       return {
         ok: false,
-        error: "Workflow definition signature is required but no signature block was present",
+        error: `Unknown definition signing mode "${policy.mode}"`,
       };
     }
-    return { ok: true, verified: false, signaturePresent: false };
   }
 
-  const payload = buildDefinitionSigningPayload(definition);
-  const cryptoResult = verifySignatureBlock(signature, payload, publicKeysById);
+  const cryptoResult = verifySignedDefinition(definition, signature, publicKeysById);
   if (!cryptoResult.ok) {
     return cryptoResult;
   }

--- a/packages/engine/src/definition-signing.mjs
+++ b/packages/engine/src/definition-signing.mjs
@@ -241,9 +241,10 @@ export function resolveDefinitionSigningOptions(options = {}) {
  * @param {string} compactJws
  * @param {string} expectedPayload Canonical JSON payload bytes (UTF-8).
  * @param {import("node:crypto").KeyObject} publicKey
+ * @param {string} [expectedKeyId] When set, JWS protected header `kid` must match.
  * @returns {{ ok: true } | { ok: false; error: string }}
  */
-export function verifyEdDsaJwsCompact(compactJws, expectedPayload, publicKey) {
+export function verifyEdDsaJwsCompact(compactJws, expectedPayload, publicKey, expectedKeyId) {
   const parts = String(compactJws).split(".");
   if (parts.length !== 3) {
     return { ok: false, error: "JWS compact serialization must contain three segments" };
@@ -259,6 +260,21 @@ export function verifyEdDsaJwsCompact(compactJws, expectedPayload, publicKey) {
     return {
       ok: false,
       error: `Unsupported JWS alg "${protectedHeader?.alg ?? "missing"}" (expected "${DEFINITION_SIGNING_ALG}")`,
+    };
+  }
+  if (
+    protectedHeader?.typ !== undefined &&
+    protectedHeader.typ !== DEFINITION_SIGNING_JWS_TYP
+  ) {
+    return {
+      ok: false,
+      error: `Unsupported JWS typ "${protectedHeader.typ}" (expected "${DEFINITION_SIGNING_JWS_TYP}")`,
+    };
+  }
+  if (expectedKeyId !== undefined && protectedHeader?.kid !== expectedKeyId) {
+    return {
+      ok: false,
+      error: `JWS protected header kid "${protectedHeader?.kid ?? "missing"}" does not match signature keyId "${expectedKeyId}"`,
     };
   }
   const payloadBytes = base64UrlDecode(payloadB64);
@@ -319,7 +335,7 @@ function verifySignatureBlock(signature, payload, publicKeysById) {
     if (!key) {
       return { ok: false, error: `Unknown signature keyId "${signature.keyId}"` };
     }
-    return verifyEdDsaJwsCompact(signature.value, payload, key);
+    return verifyEdDsaJwsCompact(signature.value, payload, key, signature.keyId);
   }
   for (const keyId of keyIds) {
     const result = verifyEdDsaJwsCompact(signature.value, payload, publicKeysById[keyId]);

--- a/packages/engine/src/index.mjs
+++ b/packages/engine/src/index.mjs
@@ -8,6 +8,12 @@
 export * from "./validate.mjs";
 export { verifyDefinitionSignature, extractDefinitionSignature } from "./definition-signing.mjs";
 export {
+  createCompositeSecretResolver,
+  createDefaultSecretResolver,
+  createEnvSecretResolver,
+  createFileSecretResolver,
+} from "./security/secret-resolver.mjs";
+export {
   redactSecretsInPayload,
   isSecretPayloadKey,
   SECRET_PAYLOAD_KEY_NAMES,

--- a/packages/engine/src/index.mjs
+++ b/packages/engine/src/index.mjs
@@ -6,7 +6,15 @@
  * @typedef {import("./orchestrator/activity-executor.mjs").ActivityExecutor} ActivityExecutor
  */
 export * from "./validate.mjs";
-export { verifyDefinitionSignature, extractDefinitionSignature } from "./definition-signing.mjs";
+export { verifyDefinitionSignature, extractDefinitionSignature, stripDefinitionSignature } from "./definition-signing.mjs";
+export {
+  resolveDefinitionSigningPolicyFromEnv,
+  resolveSigningPublicKeysFromEnv,
+  resolveDefinitionSigningOptions,
+  DEFINITION_SIGNING_ALG,
+  DEFINITION_SIGNING_MODE_ENV,
+  DEFINITION_SIGNING_PUBLIC_KEYS_ENV,
+} from "./definition-signing.mjs";
 export {
   createCompositeSecretResolver,
   createDefaultSecretResolver,

--- a/packages/engine/src/index.mjs
+++ b/packages/engine/src/index.mjs
@@ -126,6 +126,19 @@ export {
 } from "./adapters/transport-response.mjs";
 export { MCP_ADAPTER_ERROR, McpAdapterError } from "./adapters/mcp/errors.mjs";
 export {
+  CONTROL_PLANE_SCOPES,
+  TOOL_REQUIRED_SCOPE,
+  authorizeRestRequest,
+  authorizeScope,
+  authorizeToolCall,
+  buildControlPlaneAuthConfig,
+  extractBearerToken,
+  loadControlPlaneAuthConfigFromEnv,
+  parseControlPlaneAuthTokensConfig,
+  resolveRestRouteScope,
+  WORKFLOW_ENGINE_AUTH_TOKENS_ENV,
+} from "./security/control-plane-auth.mjs";
+export {
   normalizeMcpOperatorManifest,
   readAndValidateMcpOperatorManifestFile,
   resolveMcpOperatorManifestPath,

--- a/packages/engine/src/mcp-stdio-server.mjs
+++ b/packages/engine/src/mcp-stdio-server.mjs
@@ -10,6 +10,7 @@ import {
   resolveWorkflowEngineMcpConfigPath,
 } from "./adapters/mcp/stdio-server-config.mjs";
 import { MemoryExecutionHistoryStore } from "./persistence/memory-history-store.mjs";
+import { loadControlPlaneAuthConfigFromEnv } from "./security/control-plane-auth.mjs";
 
 async function main() {
   const args = process.argv.slice(2);
@@ -102,6 +103,12 @@ async function main() {
   process.on("unhandledRejection", (reason) => {
     process.stderr.write(`[engine-mcp-stdio] unhandled rejection: ${reason instanceof Error ? reason.message : String(reason)}\n`);
   });
+
+  if (loadControlPlaneAuthConfigFromEnv().enabled) {
+    process.stderr.write(
+      "[engine-mcp-stdio] WORKFLOW_ENGINE_AUTH_TOKENS is set but stdio does not enforce bearer auth; use OS process isolation. REST enforces tokens.\n"
+    );
+  }
 
   await server.start();
 }

--- a/packages/engine/src/mcp-stdio-server.mjs
+++ b/packages/engine/src/mcp-stdio-server.mjs
@@ -6,6 +6,7 @@ import {
   formatMcpManifestValidationErrors,
   loadProductionActivityExecutor,
   loadProductionDelegateExecutor,
+  resolveTransportValidationOptionsFromEnv,
   resolveWorkflowEngineMcpConfigPath,
 } from "./adapters/mcp/stdio-server-config.mjs";
 import { MemoryExecutionHistoryStore } from "./persistence/memory-history-store.mjs";
@@ -30,7 +31,11 @@ async function main() {
         "  WORKFLOW_ENGINE_MCP_CONFIG — operator manifest delegateAgents for mcp protocol (same path as tool_call).\n" +
         "  When none are set, agent_delegate uses MockA2ADelegateExecutor (local demo only; set\n" +
         "  WORKFLOW_ENGINE_PROFILE=demo to enable mock fallback for unconfigured protocols inside a partial composite).\n" +
-        "  Manifest schema: same as `workflows-engine mcp-manifest validate` (mcpServers stdio subset).\n"
+        "  Manifest schema: same as `workflows-engine mcp-manifest validate` (mcpServers stdio subset).\n" +
+        "\n" +
+        "Definition signing (v1 JWS Ed25519 profile):\n" +
+        "  WORKFLOW_ENGINE_DEFINITION_SIGNING_MODE — optional (default) or require.\n" +
+        "  WORKFLOW_ENGINE_SIGNING_PUBLIC_KEYS — inline JSON map { keyId: base64url-spki-or-raw-pub } or file:path.\n"
     );
     return;
   }
@@ -83,7 +88,8 @@ async function main() {
     ...(activityExecutor ? { activityExecutor } : {}),
     ...(delegateExecutor ? { delegateExecutor } : {}),
   });
-  const server = createMcpWorkflowStdioServer(workflowPort);
+  const transportValidation = resolveTransportValidationOptionsFromEnv();
+  const server = createMcpWorkflowStdioServer(workflowPort, { transportValidation });
 
   process.on("uncaughtException", (error) => {
     process.stderr.write(`[engine-mcp-stdio] uncaught exception: ${error instanceof Error ? error.message : String(error)}\n`);

--- a/packages/engine/src/mcp-stdio-server.mjs
+++ b/packages/engine/src/mcp-stdio-server.mjs
@@ -35,7 +35,12 @@ async function main() {
         "\n" +
         "Definition signing (v1 JWS Ed25519 profile):\n" +
         "  WORKFLOW_ENGINE_DEFINITION_SIGNING_MODE — optional (default) or require.\n" +
-        "  WORKFLOW_ENGINE_SIGNING_PUBLIC_KEYS — inline JSON map { keyId: base64url-spki-or-raw-pub } or file:path.\n"
+        "  WORKFLOW_ENGINE_SIGNING_PUBLIC_KEYS — inline JSON map { keyId: base64url-spki-or-raw-pub } or file:path.\n" +
+        "\n" +
+        "Control-plane auth (stdio boundary):\n" +
+        "  MCP stdio has no Authorization header channel — rely on OS process isolation between host and engine.\n" +
+        "  When WORKFLOW_ENGINE_AUTH_TOKENS is set, REST (`workflows-engine-rest`) enforces Bearer tokens;\n" +
+        "  stdio does not require tokens (backward compatible for local dev). See docs/security/mcp-control-plane-auth.md.\n"
     );
     return;
   }

--- a/packages/engine/src/orchestrator/a2a-delegate-executor.mjs
+++ b/packages/engine/src/orchestrator/a2a-delegate-executor.mjs
@@ -1,8 +1,7 @@
 /**
  * Production A2A delegate executor for `agent_delegate` nodes with `protocol: "a2a"`.
  *
- * Credentials and A2A base URL come from operator config (env / future vault refs), not workflow JSON (RFC-07 §7.3).
- * Full `apiKeySecretRef` vault resolution is deferred to BEN-103.
+ * Credentials and A2A base URL come from operator config (env / secret refs), not workflow JSON (RFC-07 §7.3).
  *
  * @see docs/user/a2a-delegate-mapping.md
  */
@@ -15,7 +14,7 @@ import { mintDelegateCorrelationId } from "./delegate-executor.mjs";
  * @typedef {object} A2AOperatorConfig
  * @property {string} [baseUrl] A2A HTTP API base URL (required for production executor).
  * @property {string} [apiKeyEnv] Env var name holding the Bearer token.
- * @property {string} [apiKeySecretRef] Vault secret ref (full resolver in BEN-103).
+ * @property {string} [apiKeySecretRef] Secret ref (`env:VAR` or `file:path`); resolved at invocation via {@link SecretResolver}.
  * @property {number} [pollIntervalMs] Poll interval when task is not terminal (default 500).
  * @property {number} [pollTimeoutMs] Max wait for terminal task status (default 120_000).
  */
@@ -46,10 +45,12 @@ import { mintDelegateCorrelationId } from "./delegate-executor.mjs";
 
 /**
  * @param {A2AOperatorConfig | undefined} operatorConfig
- * @param {NodeJS.ProcessEnv} [env]
- * @returns {{ ok: true, apiKey: string } | { ok: false, error: string, code: "A2A_CREDENTIALS_MISSING" }}
+ * @param {{ env?: NodeJS.ProcessEnv; secretResolver?: import("../security/secret-resolver.mjs").SecretResolver }} [options]
+ * @returns {Promise<{ ok: true, apiKey: string } | { ok: false, error: string, code: "A2A_CREDENTIALS_MISSING" }>}
  */
-export function resolveA2AApiKey(operatorConfig, env = process.env) {
+export async function resolveA2AApiKey(operatorConfig, options = {}) {
+  const env = options.env ?? process.env;
+  const secretResolver = options.secretResolver;
   const cfg = operatorConfig && typeof operatorConfig === "object" ? operatorConfig : {};
   const apiKeyEnv = typeof cfg.apiKeyEnv === "string" ? cfg.apiKeyEnv.trim() : "";
   if (apiKeyEnv) {
@@ -65,11 +66,31 @@ export function resolveA2AApiKey(operatorConfig, env = process.env) {
   }
   const secretRef = typeof cfg.apiKeySecretRef === "string" ? cfg.apiKeySecretRef.trim() : "";
   if (secretRef) {
-    return {
-      ok: false,
-      error: `apiKeySecretRef "${secretRef}" requires vault resolution (planned in BEN-103); set apiKeyEnv for now`,
-      code: "A2A_CREDENTIALS_MISSING",
-    };
+    if (!secretResolver) {
+      return {
+        ok: false,
+        error: `apiKeySecretRef "${secretRef}" requires a secretResolver`,
+        code: "A2A_CREDENTIALS_MISSING",
+      };
+    }
+    try {
+      const value = await secretResolver.resolve(secretRef);
+      if (typeof value === "string" && value.trim() !== "") {
+        return { ok: true, apiKey: value };
+      }
+      return {
+        ok: false,
+        error: `apiKeySecretRef "${secretRef}" resolved to an empty value`,
+        code: "A2A_CREDENTIALS_MISSING",
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        ok: false,
+        error: `apiKeySecretRef "${secretRef}" could not be resolved: ${message}`,
+        code: "A2A_CREDENTIALS_MISSING",
+      };
+    }
   }
   return {
     ok: false,
@@ -246,11 +267,13 @@ export class A2ADelegateExecutor {
    *   operatorConfig?: A2AOperatorConfig;
    *   transport?: A2ATransport;
    *   env?: NodeJS.ProcessEnv;
+   *   secretResolver?: import("../security/secret-resolver.mjs").SecretResolver;
    * }} [opts]
    */
   constructor(opts = {}) {
     this.operatorConfig = opts.operatorConfig ?? {};
     this.env = opts.env ?? process.env;
+    this.secretResolver = opts.secretResolver;
     this.transport = opts.transport;
   }
 
@@ -275,7 +298,10 @@ export class A2ADelegateExecutor {
       return { ok: false, error: parsedCfg.error, code: parsedCfg.code };
     }
 
-    const keyResult = resolveA2AApiKey(this.operatorConfig, this.env);
+    const keyResult = await resolveA2AApiKey(this.operatorConfig, {
+      env: this.env,
+      secretResolver: this.secretResolver,
+    });
     if (!keyResult.ok) {
       return { ok: false, error: keyResult.error, code: keyResult.code };
     }

--- a/packages/engine/src/orchestrator/a2a-delegate-executor.mjs
+++ b/packages/engine/src/orchestrator/a2a-delegate-executor.mjs
@@ -46,13 +46,21 @@ import { mintDelegateCorrelationId } from "./delegate-executor.mjs";
 /**
  * @param {A2AOperatorConfig | undefined} operatorConfig
  * @param {{ env?: NodeJS.ProcessEnv; secretResolver?: import("../security/secret-resolver.mjs").SecretResolver }} [options]
- * @returns {Promise<{ ok: true, apiKey: string } | { ok: false, error: string, code: "A2A_CREDENTIALS_MISSING" }>}
+ * @returns {Promise<{ ok: true, apiKey: string } | { ok: false, error: string, code: "A2A_CONFIG_INVALID" | "A2A_CREDENTIALS_MISSING" }>}
  */
 export async function resolveA2AApiKey(operatorConfig, options = {}) {
   const env = options.env ?? process.env;
   const secretResolver = options.secretResolver;
   const cfg = operatorConfig && typeof operatorConfig === "object" ? operatorConfig : {};
   const apiKeyEnv = typeof cfg.apiKeyEnv === "string" ? cfg.apiKeyEnv.trim() : "";
+  const secretRef = typeof cfg.apiKeySecretRef === "string" ? cfg.apiKeySecretRef.trim() : "";
+  if (apiKeyEnv && secretRef) {
+    return {
+      ok: false,
+      error: "operator config must set only one of apiKeyEnv or apiKeySecretRef",
+      code: "A2A_CONFIG_INVALID",
+    };
+  }
   if (apiKeyEnv) {
     const value = env[apiKeyEnv];
     if (typeof value === "string" && value.trim() !== "") {
@@ -64,7 +72,6 @@ export async function resolveA2AApiKey(operatorConfig, options = {}) {
       code: "A2A_CREDENTIALS_MISSING",
     };
   }
-  const secretRef = typeof cfg.apiKeySecretRef === "string" ? cfg.apiKeySecretRef.trim() : "";
   if (secretRef) {
     if (!secretResolver) {
       return {

--- a/packages/engine/src/orchestrator/llm-activity-executor.mjs
+++ b/packages/engine/src/orchestrator/llm-activity-executor.mjs
@@ -46,13 +46,21 @@ import Ajv2020 from "ajv/dist/2020.js";
 /**
  * @param {LlmOperatorConfig | undefined} operatorConfig
  * @param {{ env?: NodeJS.ProcessEnv; secretResolver?: import("../security/secret-resolver.mjs").SecretResolver }} [options]
- * @returns {Promise<{ ok: true, apiKey: string } | { ok: false, error: string, code: "LLM_CREDENTIALS_MISSING" }>}
+ * @returns {Promise<{ ok: true, apiKey: string } | { ok: false, error: string, code: "LLM_CONFIG_INVALID" | "LLM_CREDENTIALS_MISSING" }>}
  */
 export async function resolveLlmApiKey(operatorConfig, options = {}) {
   const env = options.env ?? process.env;
   const secretResolver = options.secretResolver;
   const cfg = operatorConfig && typeof operatorConfig === "object" ? operatorConfig : {};
   const apiKeyEnv = typeof cfg.apiKeyEnv === "string" ? cfg.apiKeyEnv.trim() : "";
+  const secretRef = typeof cfg.apiKeySecretRef === "string" ? cfg.apiKeySecretRef.trim() : "";
+  if (apiKeyEnv && secretRef) {
+    return {
+      ok: false,
+      error: "operator config must set only one of apiKeyEnv or apiKeySecretRef",
+      code: "LLM_CONFIG_INVALID",
+    };
+  }
   if (apiKeyEnv) {
     const value = env[apiKeyEnv];
     if (typeof value === "string" && value.trim() !== "") {
@@ -64,7 +72,6 @@ export async function resolveLlmApiKey(operatorConfig, options = {}) {
       code: "LLM_CREDENTIALS_MISSING",
     };
   }
-  const secretRef = typeof cfg.apiKeySecretRef === "string" ? cfg.apiKeySecretRef.trim() : "";
   if (secretRef) {
     if (!secretResolver) {
       return {

--- a/packages/engine/src/orchestrator/llm-activity-executor.mjs
+++ b/packages/engine/src/orchestrator/llm-activity-executor.mjs
@@ -1,8 +1,7 @@
 /**
  * Engine-direct LLM activity executor for `llm_call` nodes (OpenAI-compatible chat completions).
  *
- * Credentials and provider endpoints come from operator config (env / future vault refs), not workflow JSON (RFC-07 §7.3).
- * Full `apiKeySecretRef` vault resolution is deferred to BEN-103.
+ * Credentials and provider endpoints come from operator config (env / secret refs), not workflow JSON (RFC-07 §7.3).
  */
 
 import Ajv2020 from "ajv/dist/2020.js";
@@ -14,7 +13,7 @@ import Ajv2020 from "ajv/dist/2020.js";
  *
  * @typedef {object} LlmOperatorConfig
  * @property {string} [apiKeyEnv] Env var name holding the provider API key.
- * @property {string} [apiKeySecretRef] Vault secret ref (full resolver in BEN-103).
+ * @property {string} [apiKeySecretRef] Secret ref (`env:VAR` or `file:path`); resolved at invocation via {@link SecretResolver}.
  * @property {string} [baseUrl] OpenAI-compatible API base URL (default `https://api.openai.com/v1`).
  */
 
@@ -46,10 +45,12 @@ import Ajv2020 from "ajv/dist/2020.js";
 
 /**
  * @param {LlmOperatorConfig | undefined} operatorConfig
- * @param {NodeJS.ProcessEnv} [env]
- * @returns {{ ok: true, apiKey: string } | { ok: false, error: string, code: "LLM_CREDENTIALS_MISSING" }}
+ * @param {{ env?: NodeJS.ProcessEnv; secretResolver?: import("../security/secret-resolver.mjs").SecretResolver }} [options]
+ * @returns {Promise<{ ok: true, apiKey: string } | { ok: false, error: string, code: "LLM_CREDENTIALS_MISSING" }>}
  */
-export function resolveLlmApiKey(operatorConfig, env = process.env) {
+export async function resolveLlmApiKey(operatorConfig, options = {}) {
+  const env = options.env ?? process.env;
+  const secretResolver = options.secretResolver;
   const cfg = operatorConfig && typeof operatorConfig === "object" ? operatorConfig : {};
   const apiKeyEnv = typeof cfg.apiKeyEnv === "string" ? cfg.apiKeyEnv.trim() : "";
   if (apiKeyEnv) {
@@ -65,11 +66,31 @@ export function resolveLlmApiKey(operatorConfig, env = process.env) {
   }
   const secretRef = typeof cfg.apiKeySecretRef === "string" ? cfg.apiKeySecretRef.trim() : "";
   if (secretRef) {
-    return {
-      ok: false,
-      error: `apiKeySecretRef "${secretRef}" requires vault resolution (planned in BEN-103); set apiKeyEnv for now`,
-      code: "LLM_CREDENTIALS_MISSING",
-    };
+    if (!secretResolver) {
+      return {
+        ok: false,
+        error: `apiKeySecretRef "${secretRef}" requires a secretResolver`,
+        code: "LLM_CREDENTIALS_MISSING",
+      };
+    }
+    try {
+      const value = await secretResolver.resolve(secretRef);
+      if (typeof value === "string" && value.trim() !== "") {
+        return { ok: true, apiKey: value };
+      }
+      return {
+        ok: false,
+        error: `apiKeySecretRef "${secretRef}" resolved to an empty value`,
+        code: "LLM_CREDENTIALS_MISSING",
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        ok: false,
+        error: `apiKeySecretRef "${secretRef}" could not be resolved: ${message}`,
+        code: "LLM_CREDENTIALS_MISSING",
+      };
+    }
   }
   return {
     ok: false,
@@ -251,11 +272,13 @@ export class LlmActivityExecutor {
    *   operatorConfig?: LlmOperatorConfig;
    *   provider?: LlmProvider;
    *   env?: NodeJS.ProcessEnv;
+   *   secretResolver?: import("../security/secret-resolver.mjs").SecretResolver;
    * }} [opts]
    */
   constructor(opts = {}) {
     this.operatorConfig = opts.operatorConfig ?? {};
     this.env = opts.env ?? process.env;
+    this.secretResolver = opts.secretResolver;
     this.provider =
       opts.provider ??
       new OpenAiCompatibleLlmProvider({
@@ -280,7 +303,10 @@ export class LlmActivityExecutor {
     if (!parsedCfg.ok) {
       return { ok: false, error: parsedCfg.error, code: parsedCfg.code };
     }
-    const keyResult = resolveLlmApiKey(this.operatorConfig, this.env);
+    const keyResult = await resolveLlmApiKey(this.operatorConfig, {
+      env: this.env,
+      secretResolver: this.secretResolver,
+    });
     if (!keyResult.ok) {
       return { ok: false, error: keyResult.error, code: keyResult.code };
     }

--- a/packages/engine/src/rest-server.mjs
+++ b/packages/engine/src/rest-server.mjs
@@ -12,6 +12,7 @@ import {
   resolveWorkflowEngineMcpConfigPath,
 } from "./adapters/mcp/stdio-server-config.mjs";
 import { MemoryExecutionHistoryStore } from "./persistence/memory-history-store.mjs";
+import { loadControlPlaneAuthConfigFromEnv } from "./security/control-plane-auth.mjs";
 
 /**
  * @param {string[]} argv
@@ -46,6 +47,7 @@ async function main() {
         "  WORKFLOW_ENGINE_MCP_CONFIG — operator manifest for in-process activity/delegate routing\n" +
         "  WORKFLOW_ENGINE_DEFINITION_SIGNING_MODE — optional (default) or require\n" +
         "  WORKFLOW_ENGINE_SIGNING_PUBLIC_KEYS — inline JSON or file:path public key map\n" +
+        "  WORKFLOW_ENGINE_AUTH_TOKENS — inline JSON array or file:path of scoped bearer tokens (REST enforcement)\n" +
         "\n" +
         "OpenAPI: packages/engine/openapi/openapi.yaml\n"
     );
@@ -96,13 +98,19 @@ async function main() {
 
   const store = new MemoryExecutionHistoryStore();
   const transportValidation = resolveTransportValidationOptionsFromEnv();
+  const authConfig = loadControlPlaneAuthConfigFromEnv();
   const definitionRegistry = new DefinitionRegistry({ transportValidation });
   const workflowPort = createWorkflowApplicationPort({
     store,
     ...(activityExecutor ? { activityExecutor } : {}),
     ...(delegateExecutor ? { delegateExecutor } : {}),
   });
-  const handler = createRestWorkflowHandler(workflowPort, { definitionRegistry, store, transportValidation });
+  const handler = createRestWorkflowHandler(workflowPort, {
+    definitionRegistry,
+    store,
+    transportValidation,
+    authConfig,
+  });
   const port = parsePort(args);
   const server = createServer((req, res) => {
     handler(req, res).catch((error) => {

--- a/packages/engine/src/rest-server.mjs
+++ b/packages/engine/src/rest-server.mjs
@@ -8,6 +8,7 @@ import {
   formatMcpManifestValidationErrors,
   loadProductionActivityExecutor,
   loadProductionDelegateExecutor,
+  resolveTransportValidationOptionsFromEnv,
   resolveWorkflowEngineMcpConfigPath,
 } from "./adapters/mcp/stdio-server-config.mjs";
 import { MemoryExecutionHistoryStore } from "./persistence/memory-history-store.mjs";
@@ -43,6 +44,8 @@ async function main() {
         "Environment:\n" +
         "  WORKFLOW_ENGINE_REST_PORT — listen port (default 8787)\n" +
         "  WORKFLOW_ENGINE_MCP_CONFIG — operator manifest for in-process activity/delegate routing\n" +
+        "  WORKFLOW_ENGINE_DEFINITION_SIGNING_MODE — optional (default) or require\n" +
+        "  WORKFLOW_ENGINE_SIGNING_PUBLIC_KEYS — inline JSON or file:path public key map\n" +
         "\n" +
         "OpenAPI: packages/engine/openapi/openapi.yaml\n"
     );
@@ -92,13 +95,14 @@ async function main() {
   }
 
   const store = new MemoryExecutionHistoryStore();
-  const definitionRegistry = new DefinitionRegistry();
+  const transportValidation = resolveTransportValidationOptionsFromEnv();
+  const definitionRegistry = new DefinitionRegistry({ transportValidation });
   const workflowPort = createWorkflowApplicationPort({
     store,
     ...(activityExecutor ? { activityExecutor } : {}),
     ...(delegateExecutor ? { delegateExecutor } : {}),
   });
-  const handler = createRestWorkflowHandler(workflowPort, { definitionRegistry, store });
+  const handler = createRestWorkflowHandler(workflowPort, { definitionRegistry, store, transportValidation });
   const port = parsePort(args);
   const server = createServer((req, res) => {
     handler(req, res).catch((error) => {

--- a/packages/engine/src/security/control-plane-auth.mjs
+++ b/packages/engine/src/security/control-plane-auth.mjs
@@ -5,6 +5,7 @@
  * @see docs/architecture/adr/ADR-0005-mcp-control-plane-auth.md
  */
 
+import { createHash, timingSafeEqual } from "node:crypto";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { MCP_ADAPTER_ERROR } from "../adapters/mcp/errors.mjs";
@@ -40,14 +41,20 @@ export const TOOL_REQUIRED_SCOPE = {
  */
 
 /**
+ * @typedef {object} ControlPlaneAuthTokenEntry
+ * @property {Buffer} tokenHash SHA-256 digest of the bearer token (constant-time lookup)
+ * @property {Set<ControlPlaneScope>} scopes
+ */
+
+/**
  * @typedef {object} ControlPlaneAuthConfig
  * @property {boolean} enabled
- * @property {Map<string, Set<ControlPlaneScope>>} tokensByValue
+ * @property {ControlPlaneAuthTokenEntry[]} tokenEntries
  */
 
 /**
  * @typedef {{ ok: true }} AuthorizeOk
- * @typedef {{ ok: false; code: typeof MCP_ADAPTER_ERROR.AUTH_ERROR; message: string; details?: unknown }} AuthorizeFail
+ * @typedef {{ ok: false; code: typeof MCP_ADAPTER_ERROR.AUTH_ERROR | typeof MCP_ADAPTER_ERROR.AUTH_FORBIDDEN; message: string; details?: unknown }} AuthorizeFail
  * @typedef {AuthorizeOk | AuthorizeFail} AuthorizeResult
  */
 
@@ -59,11 +66,20 @@ export function extractBearerToken(headerValue) {
   if (headerValue === null || headerValue === undefined || String(headerValue).trim() === "") {
     return null;
   }
-  const match = String(headerValue).trim().match(/^Bearer\s+(.+)$/i);
-  if (!match) {
+  const trimmed = String(headerValue).trim();
+  const bearerPrefix = "Bearer";
+  if (
+    trimmed.length < bearerPrefix.length ||
+    trimmed.slice(0, bearerPrefix.length).toLowerCase() !== bearerPrefix.toLowerCase()
+  ) {
     return null;
   }
-  const token = match[1].trim();
+  const afterPrefix = trimmed.slice(bearerPrefix.length);
+  const withoutLeadingWs = afterPrefix.trimStart();
+  if (withoutLeadingWs.length === 0 || withoutLeadingWs.length === afterPrefix.length) {
+    return null;
+  }
+  const token = withoutLeadingWs.trim();
   return token === "" ? null : token;
 }
 
@@ -144,22 +160,38 @@ export function parseControlPlaneAuthTokensConfig(raw, cwd = process.cwd()) {
 }
 
 /**
+ * @param {string} token
+ * @returns {Buffer}
+ */
+function hashToken(token) {
+  return createHash("sha256").update(token, "utf8").digest();
+}
+
+/**
  * @param {ControlPlaneAuthTokenRecord[]} records
  * @returns {ControlPlaneAuthConfig}
  */
 export function buildControlPlaneAuthConfig(records) {
-  /** @type {Map<string, Set<ControlPlaneScope>>} */
-  const tokensByValue = new Map();
+  /** @type {ControlPlaneAuthTokenEntry[]} */
+  const tokenEntries = [];
+  /** @type {Map<string, number>} */
+  const indexByHashHex = new Map();
   for (const record of records) {
-    const scopeSet = tokensByValue.get(record.token) ?? new Set();
-    for (const scope of record.scopes) {
-      scopeSet.add(scope);
+    const tokenHash = hashToken(record.token);
+    const hashHex = tokenHash.toString("hex");
+    const existingIndex = indexByHashHex.get(hashHex);
+    if (existingIndex !== undefined) {
+      for (const scope of record.scopes) {
+        tokenEntries[existingIndex].scopes.add(scope);
+      }
+      continue;
     }
-    tokensByValue.set(record.token, scopeSet);
+    indexByHashHex.set(hashHex, tokenEntries.length);
+    tokenEntries.push({ tokenHash, scopes: new Set(record.scopes) });
   }
   return {
-    enabled: tokensByValue.size > 0,
-    tokensByValue,
+    enabled: tokenEntries.length > 0,
+    tokenEntries,
   };
 }
 
@@ -186,7 +218,13 @@ function scopesForToken(token, authConfig) {
   if (!token || token.trim() === "") {
     return null;
   }
-  return authConfig.tokensByValue.get(token.trim()) ?? null;
+  const presentedHash = hashToken(token.trim());
+  for (const entry of authConfig.tokenEntries) {
+    if (timingSafeEqual(entry.tokenHash, presentedHash)) {
+      return entry.scopes;
+    }
+  }
+  return null;
 }
 
 /**
@@ -205,14 +243,19 @@ export function authorizeScope(requiredScope, token, authConfig) {
       ok: false,
       code: MCP_ADAPTER_ERROR.AUTH_ERROR,
       message: "Missing or invalid bearer token.",
+      details: { reason: "missing_or_invalid" },
     };
   }
   if (!granted.has(requiredScope)) {
     return {
       ok: false,
-      code: MCP_ADAPTER_ERROR.AUTH_ERROR,
+      code: MCP_ADAPTER_ERROR.AUTH_FORBIDDEN,
       message: `Token lacks required scope "${requiredScope}".`,
-      details: { required_scope: requiredScope, granted_scopes: [...granted] },
+      details: {
+        reason: "insufficient_scope",
+        required_scope: requiredScope,
+        granted_scopes: [...granted],
+      },
     };
   }
   return { ok: true };

--- a/packages/engine/src/security/control-plane-auth.mjs
+++ b/packages/engine/src/security/control-plane-auth.mjs
@@ -1,0 +1,294 @@
+/**
+ * Scoped bearer tokens for workflow control-plane adapters (REST primary; MCP HTTP hook).
+ *
+ * @see docs/security/mcp-control-plane-auth.md
+ * @see docs/architecture/adr/ADR-0005-mcp-control-plane-auth.md
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { MCP_ADAPTER_ERROR } from "../adapters/mcp/errors.mjs";
+
+export const WORKFLOW_ENGINE_AUTH_TOKENS_ENV = "WORKFLOW_ENGINE_AUTH_TOKENS";
+
+/** @typedef {"start" | "resume" | "read_history" | "submit_activity"} ControlPlaneScope */
+
+/** @type {readonly ControlPlaneScope[]} */
+export const CONTROL_PLANE_SCOPES = ["start", "resume", "read_history", "submit_activity"];
+
+/**
+ * MCP tool name → required scope. Control-plane extensions map onto the four core scopes.
+ *
+ * @type {Record<string, ControlPlaneScope>}
+ */
+export const TOOL_REQUIRED_SCOPE = {
+  workflow_start: "start",
+  workflow_resume: "resume",
+  workflow_status: "read_history",
+  workflow_list: "read_history",
+  workflow_submit_activity: "submit_activity",
+  /** Signal delivery unblocks wait nodes — same privilege class as activity submit. */
+  workflow_signal: "submit_activity",
+  /** Cooperative cancel is a lifecycle control action — same privilege class as start. */
+  workflow_cancel: "start",
+};
+
+/**
+ * @typedef {object} ControlPlaneAuthTokenRecord
+ * @property {string} token
+ * @property {ControlPlaneScope[]} scopes
+ */
+
+/**
+ * @typedef {object} ControlPlaneAuthConfig
+ * @property {boolean} enabled
+ * @property {Map<string, Set<ControlPlaneScope>>} tokensByValue
+ */
+
+/**
+ * @typedef {{ ok: true }} AuthorizeOk
+ * @typedef {{ ok: false; code: typeof MCP_ADAPTER_ERROR.AUTH_ERROR; message: string; details?: unknown }} AuthorizeFail
+ * @typedef {AuthorizeOk | AuthorizeFail} AuthorizeResult
+ */
+
+/**
+ * @param {string | null | undefined} headerValue
+ * @returns {string | null}
+ */
+export function extractBearerToken(headerValue) {
+  if (headerValue === null || headerValue === undefined || String(headerValue).trim() === "") {
+    return null;
+  }
+  const match = String(headerValue).trim().match(/^Bearer\s+(.+)$/i);
+  if (!match) {
+    return null;
+  }
+  const token = match[1].trim();
+  return token === "" ? null : token;
+}
+
+/**
+ * @param {unknown} scope
+ * @returns {scope is ControlPlaneScope}
+ */
+function isControlPlaneScope(scope) {
+  return typeof scope === "string" && CONTROL_PLANE_SCOPES.includes(/** @type {ControlPlaneScope} */ (scope));
+}
+
+/**
+ * @param {unknown} entry
+ * @param {number} index
+ * @returns {ControlPlaneAuthTokenRecord}
+ */
+function parseTokenRecord(entry, index) {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    throw new Error(`${WORKFLOW_ENGINE_AUTH_TOKENS_ENV}[${index}] must be an object with token and scopes`);
+  }
+  const record = /** @type {{ token?: unknown; scopes?: unknown }} */ (entry);
+  if (typeof record.token !== "string" || record.token.trim() === "") {
+    throw new Error(`${WORKFLOW_ENGINE_AUTH_TOKENS_ENV}[${index}].token must be a non-empty string`);
+  }
+  if (!Array.isArray(record.scopes) || record.scopes.length === 0) {
+    throw new Error(`${WORKFLOW_ENGINE_AUTH_TOKENS_ENV}[${index}].scopes must be a non-empty array`);
+  }
+  /** @type {ControlPlaneScope[]} */
+  const scopes = [];
+  for (const scope of record.scopes) {
+    if (!isControlPlaneScope(scope)) {
+      throw new Error(
+        `${WORKFLOW_ENGINE_AUTH_TOKENS_ENV}[${index}].scopes contains invalid scope "${String(scope)}"`
+      );
+    }
+    if (!scopes.includes(scope)) {
+      scopes.push(scope);
+    }
+  }
+  return { token: record.token.trim(), scopes };
+}
+
+/**
+ * @param {string} raw
+ * @param {string} cwd
+ * @returns {ControlPlaneAuthTokenRecord[]}
+ */
+export function parseControlPlaneAuthTokensConfig(raw, cwd = process.cwd()) {
+  const trimmed = String(raw).trim();
+  if (trimmed === "") {
+    return [];
+  }
+  let text;
+  if (trimmed.startsWith("file:")) {
+    const rel = trimmed.slice(5).trim();
+    if (!rel) {
+      throw new Error(`${WORKFLOW_ENGINE_AUTH_TOKENS_ENV} file ref is missing path`);
+    }
+    const target = path.isAbsolute(rel) ? rel : path.resolve(cwd, rel);
+    text = readFileSync(target, "utf8");
+  } else if (trimmed.startsWith("[")) {
+    text = trimmed;
+  } else {
+    const target = path.isAbsolute(trimmed) ? trimmed : path.resolve(cwd, trimmed);
+    text = readFileSync(target, "utf8");
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`${WORKFLOW_ENGINE_AUTH_TOKENS_ENV} is not valid JSON: ${message}`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${WORKFLOW_ENGINE_AUTH_TOKENS_ENV} must be a JSON array of { token, scopes } records`);
+  }
+  return parsed.map((entry, index) => parseTokenRecord(entry, index));
+}
+
+/**
+ * @param {ControlPlaneAuthTokenRecord[]} records
+ * @returns {ControlPlaneAuthConfig}
+ */
+export function buildControlPlaneAuthConfig(records) {
+  /** @type {Map<string, Set<ControlPlaneScope>>} */
+  const tokensByValue = new Map();
+  for (const record of records) {
+    const scopeSet = tokensByValue.get(record.token) ?? new Set();
+    for (const scope of record.scopes) {
+      scopeSet.add(scope);
+    }
+    tokensByValue.set(record.token, scopeSet);
+  }
+  return {
+    enabled: tokensByValue.size > 0,
+    tokensByValue,
+  };
+}
+
+/**
+ * @param {NodeJS.ProcessEnv} [env]
+ * @param {string} [cwd]
+ * @returns {ControlPlaneAuthConfig}
+ */
+export function loadControlPlaneAuthConfigFromEnv(env = process.env, cwd = process.cwd()) {
+  const raw = env[WORKFLOW_ENGINE_AUTH_TOKENS_ENV];
+  if (raw === undefined || raw === null || String(raw).trim() === "") {
+    return buildControlPlaneAuthConfig([]);
+  }
+  const records = parseControlPlaneAuthTokensConfig(raw, cwd);
+  return buildControlPlaneAuthConfig(records);
+}
+
+/**
+ * @param {string | null | undefined} token
+ * @param {ControlPlaneAuthConfig} authConfig
+ * @returns {Set<ControlPlaneScope> | null}
+ */
+function scopesForToken(token, authConfig) {
+  if (!token || token.trim() === "") {
+    return null;
+  }
+  return authConfig.tokensByValue.get(token.trim()) ?? null;
+}
+
+/**
+ * @param {ControlPlaneScope} requiredScope
+ * @param {string | null | undefined} token
+ * @param {ControlPlaneAuthConfig} authConfig
+ * @returns {AuthorizeResult}
+ */
+export function authorizeScope(requiredScope, token, authConfig) {
+  if (!authConfig.enabled) {
+    return { ok: true };
+  }
+  const granted = scopesForToken(token, authConfig);
+  if (!granted) {
+    return {
+      ok: false,
+      code: MCP_ADAPTER_ERROR.AUTH_ERROR,
+      message: "Missing or invalid bearer token.",
+    };
+  }
+  if (!granted.has(requiredScope)) {
+    return {
+      ok: false,
+      code: MCP_ADAPTER_ERROR.AUTH_ERROR,
+      message: `Token lacks required scope "${requiredScope}".`,
+      details: { required_scope: requiredScope, granted_scopes: [...granted] },
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * @param {string} toolName
+ * @param {string | null | undefined} token
+ * @param {ControlPlaneAuthConfig} authConfig
+ * @returns {AuthorizeResult}
+ */
+export function authorizeToolCall(toolName, token, authConfig) {
+  if (!authConfig.enabled) {
+    return { ok: true };
+  }
+  const requiredScope = TOOL_REQUIRED_SCOPE[toolName];
+  if (!requiredScope) {
+    return {
+      ok: false,
+      code: MCP_ADAPTER_ERROR.AUTH_ERROR,
+      message: `Unknown control-plane tool "${toolName}".`,
+    };
+  }
+  return authorizeScope(requiredScope, token, authConfig);
+}
+
+/**
+ * Resolve required scope for an RFC-05 REST route. Returns `null` when the route is unknown
+ * (caller should emit NOT_FOUND without auth).
+ *
+ * @param {string} method
+ * @param {string} pathname
+ * @returns {ControlPlaneScope | null}
+ */
+export function resolveRestRouteScope(method, pathname) {
+  if (method === "POST" && pathname === "/v1/workflows") {
+    return "start";
+  }
+  if (method === "GET" && /^\/v1\/workflows\/[^/]+$/.test(pathname)) {
+    return "read_history";
+  }
+  if (method === "POST" && /^\/v1\/workflows\/[^/]+\/executions$/.test(pathname)) {
+    return "start";
+  }
+  if (method === "GET" && /^\/v1\/executions\/[^/]+$/.test(pathname)) {
+    return "read_history";
+  }
+  if (method === "GET" && /^\/v1\/executions\/[^/]+\/events$/.test(pathname)) {
+    return "read_history";
+  }
+  if (method === "POST" && /^\/v1\/executions\/[^/]+:resume$/.test(pathname)) {
+    return "resume";
+  }
+  if (method === "POST" && /^\/v1\/executions\/[^/]+:submit_activity$/.test(pathname)) {
+    return "submit_activity";
+  }
+  if (method === "POST" && /^\/v1\/executions\/[^/]+:cancel$/.test(pathname)) {
+    return "start";
+  }
+  if (method === "GET" && /^\/v1\/executions\/[^/]+\/checkpoint$/.test(pathname)) {
+    return "read_history";
+  }
+  return null;
+}
+
+/**
+ * @param {string} method
+ * @param {string} pathname
+ * @param {string | null | undefined} token
+ * @param {ControlPlaneAuthConfig} authConfig
+ * @returns {AuthorizeResult}
+ */
+export function authorizeRestRequest(method, pathname, token, authConfig) {
+  const scope = resolveRestRouteScope(method, pathname);
+  if (scope === null) {
+    return { ok: true };
+  }
+  return authorizeScope(scope, token, authConfig);
+}

--- a/packages/engine/src/security/secret-resolver.mjs
+++ b/packages/engine/src/security/secret-resolver.mjs
@@ -1,0 +1,100 @@
+/**
+ * Operator-side secret resolution for activity invocation boundaries (RFC-07 §7.3).
+ * Ref format: `env:VAR_NAME` or `file:relative/path` (relative to baseDir).
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * @typedef {object} SecretResolver
+ * @property {(ref: string) => Promise<string>} resolve
+ */
+
+/**
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {SecretResolver}
+ */
+export function createEnvSecretResolver(env = process.env) {
+  return {
+    async resolve(ref) {
+      const trimmed = String(ref).trim();
+      if (!trimmed.startsWith("env:")) {
+        throw new Error(`env secret resolver does not support ref "${ref}"`);
+      }
+      const varName = trimmed.slice(4).trim();
+      if (!varName) {
+        throw new Error(`env secret ref "${ref}" missing variable name`);
+      }
+      const value = env[varName];
+      if (typeof value !== "string" || value.trim() === "") {
+        throw new Error(`env var "${varName}" is unset or empty`);
+      }
+      return value.trim();
+    },
+  };
+}
+
+/**
+ * @param {string} baseDir
+ * @returns {SecretResolver}
+ */
+export function createFileSecretResolver(baseDir) {
+  const resolvedBase = path.resolve(baseDir);
+  return {
+    async resolve(ref) {
+      const trimmed = String(ref).trim();
+      if (!trimmed.startsWith("file:")) {
+        throw new Error(`file secret resolver does not support ref "${ref}"`);
+      }
+      const rel = trimmed.slice(5).trim();
+      if (!rel) {
+        throw new Error(`file secret ref "${ref}" missing path`);
+      }
+      const target = path.resolve(resolvedBase, rel);
+      const relative = path.relative(resolvedBase, target);
+      if (relative.startsWith("..") || path.isAbsolute(relative)) {
+        throw new Error(`file secret ref "${ref}" escapes base directory`);
+      }
+      const content = readFileSync(target, "utf8");
+      const value = content.trim();
+      if (value === "") {
+        throw new Error(`file secret at "${rel}" is empty`);
+      }
+      return value;
+    },
+  };
+}
+
+/**
+ * @param {SecretResolver[]} resolvers
+ * @returns {SecretResolver}
+ */
+export function createCompositeSecretResolver(resolvers) {
+  return {
+    async resolve(ref) {
+      /** @type {Error | undefined} */
+      let lastError;
+      for (const resolver of resolvers) {
+        try {
+          return await resolver.resolve(ref);
+        } catch (err) {
+          lastError = err instanceof Error ? err : new Error(String(err));
+        }
+      }
+      throw lastError ?? new Error(`no secret resolver could resolve ref "${ref}"`);
+    },
+  };
+}
+
+/**
+ * Default composite: env provider first, then file provider under `baseDir`.
+ *
+ * @param {{ env?: NodeJS.ProcessEnv; baseDir?: string; cwd?: string }} [options]
+ * @returns {SecretResolver}
+ */
+export function createDefaultSecretResolver(options = {}) {
+  const env = options.env ?? process.env;
+  const baseDir = options.baseDir ?? options.cwd ?? process.cwd();
+  return createCompositeSecretResolver([createEnvSecretResolver(env), createFileSecretResolver(baseDir)]);
+}

--- a/packages/engine/test/a2a-delegate-executor.test.mjs
+++ b/packages/engine/test/a2a-delegate-executor.test.mjs
@@ -15,6 +15,7 @@ import {
   pollA2ATaskUntilTerminal,
   resolveA2AApiKey,
 } from "../src/orchestrator/a2a-delegate-executor.mjs";
+import { createEnvSecretResolver } from "../src/security/secret-resolver.mjs";
 import {
   clearWorkflowRefs,
   registerWorkflowRef,
@@ -41,16 +42,26 @@ async function withMockA2AServer(mock, fn) {
 }
 
 describe("resolveA2AApiKey", () => {
-  it("reads api key from apiKeyEnv", () => {
-    const r = resolveA2AApiKey({ apiKeyEnv: "A2A_API_KEY" }, { A2A_API_KEY: "token-1" });
+  it("reads api key from apiKeyEnv", async () => {
+    const r = await resolveA2AApiKey({ apiKeyEnv: "A2A_API_KEY" }, { env: { A2A_API_KEY: "token-1" } });
     assert.equal(r.ok, true);
     if (r.ok) assert.equal(r.apiKey, "token-1");
   });
 
-  it("fails when env var is missing", () => {
-    const r = resolveA2AApiKey({ apiKeyEnv: "MISSING_A2A_KEY" }, {});
+  it("fails when env var is missing", async () => {
+    const r = await resolveA2AApiKey({ apiKeyEnv: "MISSING_A2A_KEY" }, { env: {} });
     assert.equal(r.ok, false);
     if (!r.ok) assert.equal(r.code, "A2A_CREDENTIALS_MISSING");
+  });
+
+  it("resolves apiKeySecretRef via secretResolver", async () => {
+    const secretResolver = createEnvSecretResolver({ A2A_API_KEY: "token-ref" });
+    const r = await resolveA2AApiKey(
+      { apiKeySecretRef: "env:A2A_API_KEY" },
+      { env: {}, secretResolver }
+    );
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.apiKey, "token-ref");
   });
 });
 
@@ -146,6 +157,31 @@ describe("A2ADelegateExecutor", () => {
         assert.equal(r.output.delegate_status, "completed");
       }
       assert.equal(mock.tasks.size, 1);
+    });
+  });
+
+  it("submits task using apiKeySecretRef credentials", async () => {
+    const mock = createA2AMockHttpServer({ workingPolls: 0 });
+    await withMockA2AServer(mock, async (baseUrl) => {
+      const secretResolver = createEnvSecretResolver({ A2A_TEST_KEY: "secret-ref" });
+      const ex = new A2ADelegateExecutor({
+        operatorConfig: {
+          baseUrl,
+          apiKeySecretRef: "env:A2A_TEST_KEY",
+          pollIntervalMs: 10,
+          pollTimeoutMs: 5_000,
+        },
+        env: {},
+        secretResolver,
+      });
+      const r = await ex.executeDelegate({
+        executionId: "e-ref",
+        node: { id: "implement", type: "agent_delegate", config: { agent_id: "coder" } },
+        state: {},
+        delegateInput: { task: "via ref" },
+        protocol: "a2a",
+      });
+      assert.equal(r.ok, true);
     });
   });
 

--- a/packages/engine/test/a2a-delegate-executor.test.mjs
+++ b/packages/engine/test/a2a-delegate-executor.test.mjs
@@ -63,6 +63,19 @@ describe("resolveA2AApiKey", () => {
     assert.equal(r.ok, true);
     if (r.ok) assert.equal(r.apiKey, "token-ref");
   });
+
+  it("rejects when both apiKeyEnv and apiKeySecretRef are set", async () => {
+    const secretResolver = createEnvSecretResolver({ A2A_API_KEY: "token-ref" });
+    const r = await resolveA2AApiKey(
+      { apiKeyEnv: "A2A_API_KEY", apiKeySecretRef: "env:A2A_API_KEY" },
+      { env: { A2A_API_KEY: "token-1" }, secretResolver }
+    );
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.code, "A2A_CONFIG_INVALID");
+      assert.match(r.error, /only one of apiKeyEnv or apiKeySecretRef/);
+    }
+  });
 });
 
 describe("parseA2AOperatorConfig", () => {

--- a/packages/engine/test/control-plane-auth.test.mjs
+++ b/packages/engine/test/control-plane-auth.test.mjs
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { MCP_ADAPTER_ERROR } from "../src/adapters/mcp/errors.mjs";
+import { createMcpWorkflowToolHandlers } from "../src/adapters/mcp/workflow-tools.mjs";
+import {
+  authorizeRestRequest,
+  authorizeScope,
+  authorizeToolCall,
+  buildControlPlaneAuthConfig,
+  extractBearerToken,
+  loadControlPlaneAuthConfigFromEnv,
+  parseControlPlaneAuthTokensConfig,
+  resolveRestRouteScope,
+  TOOL_REQUIRED_SCOPE,
+} from "../src/security/control-plane-auth.mjs";
+
+const readOnlyAuth = buildControlPlaneAuthConfig([
+  { token: "read-token", scopes: ["read_history"] },
+]);
+
+const startAuth = buildControlPlaneAuthConfig([
+  { token: "start-token", scopes: ["start"] },
+]);
+
+const fullAuth = buildControlPlaneAuthConfig([
+  { token: "admin-token", scopes: ["start", "resume", "read_history", "submit_activity"] },
+]);
+
+describe("control-plane auth", () => {
+  it("disables auth when WORKFLOW_ENGINE_AUTH_TOKENS is unset or empty", () => {
+    const config = loadControlPlaneAuthConfigFromEnv({});
+    assert.equal(config.enabled, false);
+    assert.deepEqual(authorizeToolCall("workflow_start", null, config), { ok: true });
+  });
+
+  it("parses inline JSON token array from env", () => {
+    const config = loadControlPlaneAuthConfigFromEnv({
+      WORKFLOW_ENGINE_AUTH_TOKENS: '[{"token":"t1","scopes":["start","read_history"]}]',
+    });
+    assert.equal(config.enabled, true);
+    assert.ok(config.tokensByValue.get("t1")?.has("start"));
+    assert.ok(config.tokensByValue.get("t1")?.has("read_history"));
+  });
+
+  it("extracts bearer token from Authorization header", () => {
+    assert.equal(extractBearerToken("Bearer abc.def"), "abc.def");
+    assert.equal(extractBearerToken("bearer xyz"), "xyz");
+    assert.equal(extractBearerToken("Basic abc"), null);
+    assert.equal(extractBearerToken(""), null);
+  });
+
+  it("maps MCP tools to the four core scopes", () => {
+    assert.equal(TOOL_REQUIRED_SCOPE.workflow_start, "start");
+    assert.equal(TOOL_REQUIRED_SCOPE.workflow_resume, "resume");
+    assert.equal(TOOL_REQUIRED_SCOPE.workflow_status, "read_history");
+    assert.equal(TOOL_REQUIRED_SCOPE.workflow_list, "read_history");
+    assert.equal(TOOL_REQUIRED_SCOPE.workflow_submit_activity, "submit_activity");
+    assert.equal(TOOL_REQUIRED_SCOPE.workflow_signal, "submit_activity");
+    assert.equal(TOOL_REQUIRED_SCOPE.workflow_cancel, "start");
+  });
+
+  it("authorizeToolCall rejects missing token when auth enabled", () => {
+    const result = authorizeToolCall("workflow_start", null, startAuth);
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.code, MCP_ADAPTER_ERROR.AUTH_ERROR);
+    }
+  });
+
+  it("authorizeToolCall rejects token without required scope", () => {
+    const result = authorizeToolCall("workflow_start", "read-token", readOnlyAuth);
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.code, MCP_ADAPTER_ERROR.AUTH_ERROR);
+      assert.match(result.message, /start/);
+    }
+  });
+
+  it("authorizeToolCall allows token with required scope", () => {
+    assert.deepEqual(authorizeToolCall("workflow_status", "read-token", readOnlyAuth), { ok: true });
+    assert.deepEqual(authorizeToolCall("workflow_cancel", "start-token", startAuth), { ok: true });
+  });
+
+  it("resolveRestRouteScope maps RFC-05 paths to scopes", () => {
+    assert.equal(resolveRestRouteScope("POST", "/v1/workflows"), "start");
+    assert.equal(resolveRestRouteScope("GET", "/v1/workflows/demo"), "read_history");
+    assert.equal(resolveRestRouteScope("POST", "/v1/workflows/demo/executions"), "start");
+    assert.equal(resolveRestRouteScope("GET", "/v1/executions/ex-1"), "read_history");
+    assert.equal(resolveRestRouteScope("GET", "/v1/executions/ex-1/events"), "read_history");
+    assert.equal(resolveRestRouteScope("POST", "/v1/executions/ex-1:resume"), "resume");
+    assert.equal(resolveRestRouteScope("POST", "/v1/executions/ex-1:submit_activity"), "submit_activity");
+    assert.equal(resolveRestRouteScope("POST", "/v1/executions/ex-1:cancel"), "start");
+    assert.equal(resolveRestRouteScope("GET", "/v1/executions/ex-1/checkpoint"), "read_history");
+    assert.equal(resolveRestRouteScope("GET", "/v1/unknown"), null);
+  });
+
+  it("authorizeRestRequest enforces bearer token on workflow routes", () => {
+    const denied = authorizeRestRequest("GET", "/v1/executions/ex-1", null, readOnlyAuth);
+    assert.equal(denied.ok, false);
+    const allowed = authorizeRestRequest("GET", "/v1/executions/ex-1", "read-token", readOnlyAuth);
+    assert.deepEqual(allowed, { ok: true });
+    const wrongScope = authorizeRestRequest(
+      "POST",
+      "/v1/workflows/demo/executions",
+      "read-token",
+      readOnlyAuth
+    );
+    assert.equal(wrongScope.ok, false);
+  });
+
+  it("parseControlPlaneAuthTokensConfig rejects invalid scope values", () => {
+    assert.throws(
+      () => parseControlPlaneAuthTokensConfig('[{"token":"t","scopes":["admin"]}]'),
+      /invalid scope/
+    );
+  });
+
+  it("MCP workflow tools return AUTH_ERROR when enforce authContext lacks token", async () => {
+    const port = {
+      startWorkflow: async () => {
+        throw new Error("should not be called");
+      },
+      getWorkflowStatus: async () => ({}),
+      resumeWorkflow: async () => ({}),
+      submitWorkflowActivity: async () => ({}),
+      signalWorkflow: async () => ({}),
+      cancelWorkflow: async () => ({}),
+      listWorkflowExecutions: async () => ({ executions: [] }),
+    };
+    const handlers = createMcpWorkflowToolHandlers(port, { authConfig: startAuth });
+    const result = await handlers.workflow_start(
+      {
+        execution_id: "x",
+        definition: {
+          document: {
+            schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
+            name: "auth-test",
+            version: "1.0.0",
+          },
+          state_schema: { type: "object" },
+          nodes: [
+            { id: "start", type: "start" },
+            { id: "end", type: "end" },
+          ],
+          edges: [
+            { source: "__start__", target: "start" },
+            { source: "start", target: "end" },
+          ],
+        },
+        input: {},
+      },
+      { enforce: true }
+    );
+    assert.equal(result.isError, true);
+    assert.match(result.content[0].text, /AUTH_ERROR/);
+    assert.equal(result.structuredContent.error.code, MCP_ADAPTER_ERROR.AUTH_ERROR);
+  });
+
+  it("MCP workflow tools skip auth when enforce is not set (stdio boundary)", async () => {
+    let called = false;
+    const port = {
+      startWorkflow: async () => {
+        called = true;
+        return { executionId: "x", status: "completed" };
+      },
+      getWorkflowStatus: async () => ({}),
+      resumeWorkflow: async () => ({}),
+      submitWorkflowActivity: async () => ({}),
+      signalWorkflow: async () => ({}),
+      cancelWorkflow: async () => ({}),
+      listWorkflowExecutions: async () => ({ executions: [] }),
+    };
+    const handlers = createMcpWorkflowToolHandlers(port, { authConfig: startAuth });
+    const result = await handlers.workflow_start(
+      {
+        execution_id: "x",
+        definition: {
+          document: {
+            schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
+            name: "auth-test",
+            version: "1.0.0",
+          },
+          state_schema: { type: "object" },
+          nodes: [
+            { id: "start", type: "start" },
+            { id: "end", type: "end" },
+          ],
+          edges: [
+            { source: "__start__", target: "start" },
+            { source: "start", target: "end" },
+          ],
+        },
+        input: {},
+      }
+    );
+    assert.equal(called, true);
+    assert.notEqual(result.isError, true);
+  });
+
+  it("authorizeScope allows admin token across scopes", () => {
+    for (const scope of ["start", "resume", "read_history", "submit_activity"]) {
+      assert.deepEqual(authorizeScope(scope, "admin-token", fullAuth), { ok: true });
+    }
+  });
+});

--- a/packages/engine/test/control-plane-auth.test.mjs
+++ b/packages/engine/test/control-plane-auth.test.mjs
@@ -38,8 +38,8 @@ describe("control-plane auth", () => {
       WORKFLOW_ENGINE_AUTH_TOKENS: '[{"token":"t1","scopes":["start","read_history"]}]',
     });
     assert.equal(config.enabled, true);
-    assert.ok(config.tokensByValue.get("t1")?.has("start"));
-    assert.ok(config.tokensByValue.get("t1")?.has("read_history"));
+    assert.deepEqual(authorizeScope("start", "t1", config), { ok: true });
+    assert.deepEqual(authorizeScope("read_history", "t1", config), { ok: true });
   });
 
   it("extracts bearer token from Authorization header", () => {
@@ -71,8 +71,9 @@ describe("control-plane auth", () => {
     const result = authorizeToolCall("workflow_start", "read-token", readOnlyAuth);
     assert.equal(result.ok, false);
     if (!result.ok) {
-      assert.equal(result.code, MCP_ADAPTER_ERROR.AUTH_ERROR);
+      assert.equal(result.code, MCP_ADAPTER_ERROR.AUTH_FORBIDDEN);
       assert.match(result.message, /start/);
+      assert.equal(result.details?.reason, "insufficient_scope");
     }
   });
 

--- a/packages/engine/test/definition-signing.test.mjs
+++ b/packages/engine/test/definition-signing.test.mjs
@@ -1,16 +1,47 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, it } from "node:test";
+import { MCP_ADAPTER_ERROR } from "../src/adapters/mcp/errors.mjs";
 import {
-  extractDefinitionSignature,
+  assertValidWorkflowDefinitionAtTransport,
+  validateWorkflowStartTransportPayload,
+} from "../src/adapters/mcp/transport-validation.mjs";
+import {
+  buildDefinitionSigningPayload,
+  importEd25519PublicKey,
+  loadPublicKeysFromConfig,
+  parseSigningPublicKeysConfig,
+  resolveDefinitionSigningPolicyFromEnv,
   verifyDefinitionSignature,
+  verifyEdDsaJwsCompact,
+  createEdDsaJwsCompact,
+  importEd25519PrivateKey,
 } from "../src/definition-signing.mjs";
+import {
+  signDefinitionForTest,
+  TEST_SIGNING_KEY_ID,
+  TEST_SIGNING_PRIVATE_KEY_PKCS8_B64URL,
+  TEST_SIGNING_PUBLIC_KEY_SPKI_B64URL,
+} from "./helpers/definition-signing-test-helpers.mjs";
 
-describe("definition signing stub", () => {
-  it("unsigned definitions pass verification", () => {
-    const r = verifyDefinitionSignature({
-      document: { schema: "https://agent-workflow.dev/schemas/workflow-definition.json", name: "x", version: "1" },
-      nodes: [],
-      edges: [],
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../../..");
+const minimalDefinition = JSON.parse(
+  readFileSync(path.join(repoRoot, "examples/fixtures.valid/minimal-linear.workflow.json"), "utf8")
+);
+
+const testPrivateKey = importEd25519PrivateKey(TEST_SIGNING_PRIVATE_KEY_PKCS8_B64URL);
+const testPublicKeys = loadPublicKeysFromConfig({
+  [TEST_SIGNING_KEY_ID]: TEST_SIGNING_PUBLIC_KEY_SPKI_B64URL,
+});
+
+describe("definition signing v1 (JWS Ed25519)", () => {
+  it("unsigned definitions pass in optional mode", () => {
+    const r = verifyDefinitionSignature(minimalDefinition, {
+      policy: { mode: "optional" },
+      publicKeysById: testPublicKeys,
     });
     assert.equal(r.ok, true);
     if (r.ok) {
@@ -19,23 +50,164 @@ describe("definition signing stub", () => {
     }
   });
 
-  it("signed definitions pass stub verify hook", () => {
-    const definition = {
-      document: {
-        schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
-        name: "signed",
-        version: "1",
-        signature: { alg: "none", value: "stub" },
-      },
-      nodes: [],
-      edges: [],
-    };
-    assert.ok(extractDefinitionSignature(definition));
-    const r = verifyDefinitionSignature(definition);
+  it("unsigned definitions fail in require mode", () => {
+    const r = verifyDefinitionSignature(minimalDefinition, {
+      policy: { mode: "require" },
+      publicKeysById: testPublicKeys,
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.match(r.error, /required/i);
+    }
+  });
+
+  it("valid signed definition verifies with configured public key", () => {
+    const signed = signDefinitionForTest(minimalDefinition, testPrivateKey);
+    const r = verifyDefinitionSignature(signed, {
+      policy: { mode: "optional" },
+      publicKeysById: testPublicKeys,
+    });
     assert.equal(r.ok, true);
     if (r.ok) {
+      assert.equal(r.verified, true);
       assert.equal(r.signaturePresent, true);
-      assert.equal(r.verified, false);
     }
+  });
+
+  it("valid signed definition passes require mode", () => {
+    const signed = signDefinitionForTest(minimalDefinition, testPrivateKey);
+    const r = verifyDefinitionSignature(signed, {
+      policy: { mode: "require" },
+      publicKeysById: testPublicKeys,
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.verified, true);
+    }
+  });
+
+  it("tampered signature value fails verification", () => {
+    const signed = signDefinitionForTest(minimalDefinition, testPrivateKey);
+    signed.document.signature.value = signed.document.signature.value.replace(/.$/, "X");
+    const r = verifyDefinitionSignature(signed, {
+      policy: { mode: "optional" },
+      publicKeysById: testPublicKeys,
+    });
+    assert.equal(r.ok, false);
+  });
+
+  it("tampered definition body fails verification", () => {
+    const signed = signDefinitionForTest(minimalDefinition, testPrivateKey);
+    signed.document.version = "9.9.9";
+    const r = verifyDefinitionSignature(signed, {
+      policy: { mode: "optional" },
+      publicKeysById: testPublicKeys,
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.match(r.error, /payload/i);
+    }
+  });
+
+  it("signed definition without configured keys fails", () => {
+    const signed = signDefinitionForTest(minimalDefinition, testPrivateKey);
+    const r = verifyDefinitionSignature(signed, {
+      policy: { mode: "optional" },
+      publicKeysById: {},
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.match(r.error, /no verification public keys/i);
+    }
+  });
+
+  it("unknown keyId fails verification", () => {
+    const signed = signDefinitionForTest(minimalDefinition, testPrivateKey, { keyId: "missing-key" });
+    const r = verifyDefinitionSignature(signed, {
+      policy: { mode: "optional" },
+      publicKeysById: testPublicKeys,
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.match(r.error, /Unknown signature keyId/);
+    }
+  });
+
+  it("supports top-level signature placement", () => {
+    const signed = signDefinitionForTest(minimalDefinition, testPrivateKey, {
+      signaturePlacement: "top-level",
+    });
+    const r = verifyDefinitionSignature(signed, {
+      policy: { mode: "optional" },
+      publicKeysById: testPublicKeys,
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.verified, true);
+    }
+  });
+
+  it("buildDefinitionSigningPayload excludes signature field", () => {
+    const signed = signDefinitionForTest(minimalDefinition, testPrivateKey);
+    const payload = buildDefinitionSigningPayload(signed);
+    assert.doesNotMatch(payload, /signature/);
+    assert.equal(payload, buildDefinitionSigningPayload(minimalDefinition));
+  });
+
+  it("verifyEdDsaJwsCompact round-trips with createEdDsaJwsCompact", () => {
+    const payload = buildDefinitionSigningPayload(minimalDefinition);
+    const jws = createEdDsaJwsCompact(testPrivateKey, payload, TEST_SIGNING_KEY_ID);
+    const pub = importEd25519PublicKey(TEST_SIGNING_PUBLIC_KEY_SPKI_B64URL);
+    const r = verifyEdDsaJwsCompact(jws, payload, pub);
+    assert.equal(r.ok, true);
+  });
+
+  it("parseSigningPublicKeysConfig accepts inline JSON", () => {
+    const map = parseSigningPublicKeysConfig(
+      JSON.stringify({ [TEST_SIGNING_KEY_ID]: TEST_SIGNING_PUBLIC_KEY_SPKI_B64URL }),
+      process.cwd()
+    );
+    assert.equal(Object.keys(map).length, 1);
+  });
+
+  it("resolveDefinitionSigningPolicyFromEnv defaults to optional", () => {
+    const env = { ...process.env };
+    delete env.WORKFLOW_ENGINE_DEFINITION_SIGNING_MODE;
+    assert.deepEqual(resolveDefinitionSigningPolicyFromEnv(env), { mode: "optional" });
+  });
+
+  it("resolveDefinitionSigningPolicyFromEnv accepts require", () => {
+    assert.deepEqual(
+      resolveDefinitionSigningPolicyFromEnv({ WORKFLOW_ENGINE_DEFINITION_SIGNING_MODE: "require" }),
+      { mode: "require" }
+    );
+  });
+
+  it("transport validation strips signature before schema check", () => {
+    const signed = signDefinitionForTest(minimalDefinition, testPrivateKey);
+    assert.doesNotThrow(() =>
+      assertValidWorkflowDefinitionAtTransport(signed, {
+        signing: { policy: { mode: "optional" }, publicKeysById: testPublicKeys },
+      })
+    );
+  });
+
+  it("transport rejects unsigned definition when policy is require", () => {
+    assert.throws(
+      () =>
+        validateWorkflowStartTransportPayload(minimalDefinition, {}, {
+          signing: { policy: { mode: "require" }, publicKeysById: testPublicKeys },
+        }),
+      (err) => err.code === MCP_ADAPTER_ERROR.VALIDATION_ERROR
+    );
+  });
+
+  it("transport accepts valid signed definition when policy is require", () => {
+    const signed = signDefinitionForTest(minimalDefinition, testPrivateKey);
+    assert.doesNotThrow(() =>
+      validateWorkflowStartTransportPayload(signed, {}, {
+        signing: { policy: { mode: "require" }, publicKeysById: testPublicKeys },
+      })
+    );
   });
 });

--- a/packages/engine/test/definition-signing.test.mjs
+++ b/packages/engine/test/definition-signing.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { sign } from "node:crypto";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -130,6 +131,41 @@ describe("definition signing v1 (JWS Ed25519)", () => {
     assert.equal(r.ok, false);
     if (!r.ok) {
       assert.match(r.error, /Unknown signature keyId/);
+    }
+  });
+
+  it("signature keyId must match JWS protected header kid", () => {
+    const signed = signDefinitionForTest(minimalDefinition, testPrivateKey);
+    const payload = buildDefinitionSigningPayload(signed);
+    signed.document.signature.value = createEdDsaJwsCompact(
+      testPrivateKey,
+      payload,
+      "other-kid-in-jws"
+    );
+    const r = verifyDefinitionSignature(signed, {
+      policy: { mode: "optional" },
+      publicKeysById: testPublicKeys,
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.match(r.error, /kid.*does not match signature keyId/i);
+    }
+  });
+
+  it("verifyEdDsaJwsCompact rejects unsupported typ in protected header", () => {
+    const payload = buildDefinitionSigningPayload(minimalDefinition);
+    const validJws = createEdDsaJwsCompact(testPrivateKey, payload, TEST_SIGNING_KEY_ID);
+    const [, payloadB64] = validJws.split(".");
+    const badHeader = { alg: "EdDSA", typ: "JWT", kid: TEST_SIGNING_KEY_ID };
+    const protectedB64 = Buffer.from(JSON.stringify(badHeader), "utf8").toString("base64url");
+    const signingInput = `${protectedB64}.${payloadB64}`;
+    const signature = sign(null, Buffer.from(signingInput, "ascii"), testPrivateKey);
+    const jws = `${signingInput}.${signature.toString("base64url")}`;
+    const pub = importEd25519PublicKey(TEST_SIGNING_PUBLIC_KEY_SPKI_B64URL);
+    const r = verifyEdDsaJwsCompact(jws, payload, pub);
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.match(r.error, /Unsupported JWS typ/);
     }
   });
 

--- a/packages/engine/test/definition-signing.test.mjs
+++ b/packages/engine/test/definition-signing.test.mjs
@@ -134,6 +134,20 @@ describe("definition signing v1 (JWS Ed25519)", () => {
     }
   });
 
+  it("missing JWS kid fails verification", () => {
+    const signed = signDefinitionForTest(minimalDefinition, testPrivateKey);
+    const payload = buildDefinitionSigningPayload(signed);
+    signed.document.signature.value = createEdDsaJwsCompact(testPrivateKey, payload);
+    const r = verifyDefinitionSignature(signed, {
+      policy: { mode: "optional" },
+      publicKeysById: testPublicKeys,
+    });
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.match(r.error, /missing required kid/i);
+    }
+  });
+
   it("verifies when signature keyId is omitted but JWS kid is present", () => {
     const signed = signDefinitionForTest(minimalDefinition, testPrivateKey);
     delete signed.document.signature.keyId;

--- a/packages/engine/test/definition-signing.test.mjs
+++ b/packages/engine/test/definition-signing.test.mjs
@@ -122,7 +122,7 @@ describe("definition signing v1 (JWS Ed25519)", () => {
     }
   });
 
-  it("unknown keyId fails verification", () => {
+  it("unknown JWS kid fails verification", () => {
     const signed = signDefinitionForTest(minimalDefinition, testPrivateKey, { keyId: "missing-key" });
     const r = verifyDefinitionSignature(signed, {
       policy: { mode: "optional" },
@@ -130,7 +130,20 @@ describe("definition signing v1 (JWS Ed25519)", () => {
     });
     assert.equal(r.ok, false);
     if (!r.ok) {
-      assert.match(r.error, /Unknown signature keyId/);
+      assert.match(r.error, /Unknown JWS kid/);
+    }
+  });
+
+  it("verifies when signature keyId is omitted but JWS kid is present", () => {
+    const signed = signDefinitionForTest(minimalDefinition, testPrivateKey);
+    delete signed.document.signature.keyId;
+    const r = verifyDefinitionSignature(signed, {
+      policy: { mode: "optional" },
+      publicKeysById: testPublicKeys,
+    });
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.verified, true);
     }
   });
 
@@ -148,7 +161,7 @@ describe("definition signing v1 (JWS Ed25519)", () => {
     });
     assert.equal(r.ok, false);
     if (!r.ok) {
-      assert.match(r.error, /kid.*does not match signature keyId/i);
+      assert.match(r.error, /signature keyId.*does not match JWS protected header kid/i);
     }
   });
 

--- a/packages/engine/test/helpers/definition-signing-test-helpers.mjs
+++ b/packages/engine/test/helpers/definition-signing-test-helpers.mjs
@@ -1,0 +1,48 @@
+/**
+ * Test-only helpers for generating signed workflow definition fixtures.
+ */
+
+import {
+  buildDefinitionSigningPayload,
+  createEdDsaJwsCompact,
+  DEFINITION_SIGNING_ALG,
+  importEd25519PrivateKey,
+  stripDefinitionSignature,
+} from "../../src/definition-signing.mjs";
+
+/** Conformance / unit-test Ed25519 private key (PKCS8 DER, base64url). */
+export const TEST_SIGNING_PRIVATE_KEY_PKCS8_B64URL =
+  "MC4CAQAwBQYDK2VwBCIEINoeGH3uTJB4vlquXo3VT41lyC_El-h1NOTC-4-Gyk1F";
+
+/** Matching public key (SPKI DER, base64url). */
+export const TEST_SIGNING_PUBLIC_KEY_SPKI_B64URL =
+  "MCowBQYDK2VwAyEA-_wc6pHan2aD2MyBvmSWwoarQ0EWXjtZ-tr3LF_ujOI";
+
+export const TEST_SIGNING_KEY_ID = "test-key-1";
+
+/**
+ * @param {Record<string, unknown>} definition Unsigned workflow definition object.
+ * @param {import("node:crypto").KeyObject | string} privateKey
+ * @param {{ keyId?: string; signaturePlacement?: "document" | "top-level" }} [options]
+ * @returns {Record<string, unknown>}
+ */
+export function signDefinitionForTest(definition, privateKey, options = {}) {
+  const key =
+    typeof privateKey === "string" ? importEd25519PrivateKey(privateKey) : privateKey;
+  const keyId = options.keyId ?? TEST_SIGNING_KEY_ID;
+  const unsigned = stripDefinitionSignature(definition);
+  const payload = buildDefinitionSigningPayload(unsigned);
+  const jws = createEdDsaJwsCompact(key, payload, keyId);
+  const signed = structuredClone(unsigned);
+  const block = { alg: DEFINITION_SIGNING_ALG, value: jws, keyId };
+  const placement = options.signaturePlacement ?? "document";
+  if (placement === "top-level") {
+    signed.signature = block;
+  } else {
+    if (!signed.document || typeof signed.document !== "object") {
+      throw new Error("signDefinitionForTest requires document metadata for document.signature placement");
+    }
+    signed.document = { ...signed.document, signature: block };
+  }
+  return signed;
+}

--- a/packages/engine/test/llm-activity-executor.test.mjs
+++ b/packages/engine/test/llm-activity-executor.test.mjs
@@ -43,6 +43,19 @@ describe("resolveLlmApiKey", () => {
       assert.match(r.error, /secretResolver/);
     }
   });
+
+  it("rejects when both apiKeyEnv and apiKeySecretRef are set", async () => {
+    const secretResolver = createEnvSecretResolver({ OPENAI_API_KEY: "sk-from-ref" });
+    const r = await resolveLlmApiKey(
+      { apiKeyEnv: "OPENAI_API_KEY", apiKeySecretRef: "env:OPENAI_API_KEY" },
+      { env: {}, secretResolver }
+    );
+    assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.equal(r.code, "LLM_CONFIG_INVALID");
+      assert.match(r.error, /only one of apiKeyEnv or apiKeySecretRef/);
+    }
+  });
 });
 
 describe("parseLlmCallNodeConfig", () => {

--- a/packages/engine/test/llm-activity-executor.test.mjs
+++ b/packages/engine/test/llm-activity-executor.test.mjs
@@ -10,26 +10,37 @@ import {
   resolveLlmApiKey,
   validateLlmStructuredOutput,
 } from "../src/orchestrator/llm-activity-executor.mjs";
+import { createEnvSecretResolver } from "../src/security/secret-resolver.mjs";
 
 describe("resolveLlmApiKey", () => {
-  it("reads api key from apiKeyEnv", () => {
-    const r = resolveLlmApiKey({ apiKeyEnv: "OPENAI_API_KEY" }, { OPENAI_API_KEY: "sk-test" });
+  it("reads api key from apiKeyEnv", async () => {
+    const r = await resolveLlmApiKey({ apiKeyEnv: "OPENAI_API_KEY" }, { env: { OPENAI_API_KEY: "sk-test" } });
     assert.equal(r.ok, true);
     if (r.ok) assert.equal(r.apiKey, "sk-test");
   });
 
-  it("fails when env var is missing", () => {
-    const r = resolveLlmApiKey({ apiKeyEnv: "MISSING_KEY" }, {});
+  it("fails when env var is missing", async () => {
+    const r = await resolveLlmApiKey({ apiKeyEnv: "MISSING_KEY" }, { env: {} });
     assert.equal(r.ok, false);
     if (!r.ok) assert.equal(r.code, "LLM_CREDENTIALS_MISSING");
   });
 
-  it("fails for apiKeySecretRef until BEN-103 vault resolver", () => {
-    const r = resolveLlmApiKey({ apiKeySecretRef: "vault/openai" }, {});
+  it("resolves apiKeySecretRef via secretResolver", async () => {
+    const secretResolver = createEnvSecretResolver({ OPENAI_API_KEY: "sk-from-ref" });
+    const r = await resolveLlmApiKey(
+      { apiKeySecretRef: "env:OPENAI_API_KEY" },
+      { env: {}, secretResolver }
+    );
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.apiKey, "sk-from-ref");
+  });
+
+  it("fails for apiKeySecretRef without secretResolver", async () => {
+    const r = await resolveLlmApiKey({ apiKeySecretRef: "env:OPENAI_API_KEY" }, { env: {} });
     assert.equal(r.ok, false);
     if (!r.ok) {
       assert.equal(r.code, "LLM_CREDENTIALS_MISSING");
-      assert.match(r.error, /BEN-103/);
+      assert.match(r.error, /secretResolver/);
     }
   });
 });
@@ -147,6 +158,7 @@ describe("LlmActivityExecutor", () => {
     }
   });
 
+
   it("validates structured output from mocked provider", async () => {
     /** @type {import("../src/orchestrator/llm-activity-executor.mjs").LlmProvider} */
     const provider = {
@@ -184,6 +196,29 @@ describe("LlmActivityExecutor", () => {
       assert.equal(r.output.intent, "billing");
       assert.equal(r.output.confidence, 0.95);
     }
+  });
+
+  it("resolves apiKeySecretRef at invocation boundary", async () => {
+    /** @type {import("../src/orchestrator/llm-activity-executor.mjs").LlmProvider} */
+    const provider = {
+      async chatCompletion(req) {
+        assert.equal(req.apiKey, "sk-from-ref");
+        return { content: JSON.stringify({ ok: true }) };
+      },
+    };
+    const secretResolver = createEnvSecretResolver({ LLM_KEY: "sk-from-ref" });
+    const ex = new LlmActivityExecutor({
+      operatorConfig: { apiKeySecretRef: "env:LLM_KEY" },
+      env: {},
+      secretResolver,
+      provider,
+    });
+    const r = await ex.executeActivity({
+      executionId: "e1",
+      node: { id: "n1", type: "llm_call", config: { model: "m" } },
+      state: {},
+    });
+    assert.equal(r.ok, true);
   });
 
   it("returns LLM_OUTPUT_VALIDATION_FAILED for schema mismatch", async () => {

--- a/packages/engine/test/mcp-stdio-entrypoint.test.mjs
+++ b/packages/engine/test/mcp-stdio-entrypoint.test.mjs
@@ -36,4 +36,22 @@ describe("MCP stdio entrypoint", () => {
     );
     assert.match(run.stderr, /\[engine-mcp-stdio\] demo stub fallback: inactive/);
   });
+
+  it("warns when WORKFLOW_ENGINE_AUTH_TOKENS is set", () => {
+    const scriptPath = path.resolve(__dirname, "../src/mcp-stdio-server.mjs");
+    const run = spawnSync(process.execPath, [scriptPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        WORKFLOW_ENGINE_AUTH_TOKENS: '[{"token":"t1","scopes":["start"]}]',
+        WORKFLOW_ENGINE_MCP_CONFIG: "",
+      },
+      timeout: 2000,
+    });
+
+    assert.match(
+      run.stderr,
+      /WORKFLOW_ENGINE_AUTH_TOKENS is set but stdio does not enforce bearer auth/
+    );
+  });
 });

--- a/packages/engine/test/rest-adapter.test.mjs
+++ b/packages/engine/test/rest-adapter.test.mjs
@@ -315,7 +315,7 @@ describe("REST workflow adapter", () => {
     );
   });
 
-  it("returns 401 AUTH_ERROR when token lacks required scope", async () => {
+  it("returns 403 AUTH_FORBIDDEN when token lacks required scope", async () => {
     const authConfig = buildControlPlaneAuthConfig([
       { token: "read-token", scopes: ["read_history"] },
       { token: "start-token", scopes: ["start"] },
@@ -330,8 +330,9 @@ describe("REST workflow adapter", () => {
           { definition },
           { authorization: "Bearer read-token" }
         );
-        assert.equal(registered.status, 401);
-        assert.equal(registered.body.error.code, MCP_ADAPTER_ERROR.AUTH_ERROR);
+        assert.equal(registered.status, 403);
+        assert.equal(registered.body.error.code, MCP_ADAPTER_ERROR.AUTH_FORBIDDEN);
+        assert.equal(registered.body.error.details?.reason, "insufficient_scope");
 
         const allowed = await requestJson(
           port,

--- a/packages/engine/test/rest-adapter.test.mjs
+++ b/packages/engine/test/rest-adapter.test.mjs
@@ -6,6 +6,8 @@ import { fileURLToPath } from "node:url";
 import { describe, it } from "node:test";
 import { createRestWorkflowHandler } from "../src/adapters/rest/rest-handler.mjs";
 import { DefinitionRegistry } from "../src/adapters/rest/definition-registry.mjs";
+import { MCP_ADAPTER_ERROR } from "../src/adapters/mcp/errors.mjs";
+import { buildControlPlaneAuthConfig } from "../src/security/control-plane-auth.mjs";
 import { createWorkflowApplicationPort } from "../src/application/workflow-application-port.mjs";
 import { MemoryExecutionHistoryStore } from "../src/persistence/memory-history-store.mjs";
 import { findWorkflowRepoRoot } from "../src/validate.mjs";
@@ -68,12 +70,17 @@ function loadLighthouse() {
 
 /**
  * @param {(port: number) => Promise<void>} run
+ * @param {{ authConfig?: import("../src/security/control-plane-auth.mjs").ControlPlaneAuthConfig }} [options]
  */
-async function withRestServer(run) {
+async function withRestServer(run, options = {}) {
   const store = new MemoryExecutionHistoryStore();
   const definitionRegistry = new DefinitionRegistry();
   const workflowPort = createWorkflowApplicationPort({ store });
-  const handler = createRestWorkflowHandler(workflowPort, { definitionRegistry, store });
+  const handler = createRestWorkflowHandler(workflowPort, {
+    definitionRegistry,
+    store,
+    authConfig: options.authConfig,
+  });
   const server = createServer((req, res) => {
     handler(req, res).catch((error) => {
       if (!res.headersSent) {
@@ -100,12 +107,20 @@ async function withRestServer(run) {
  * @param {string} method
  * @param {string} pathname
  * @param {unknown} [body]
+ * @param {{ authorization?: string }} [options]
  */
-async function requestJson(port, method, pathname, body) {
+async function requestJson(port, method, pathname, body, options = {}) {
   // codeql[js/file-access-to-http]: test posts fixture JSON to in-process localhost only
+  const headers = {};
+  if (body !== undefined) {
+    headers["content-type"] = "application/json";
+  }
+  if (options.authorization) {
+    headers.authorization = options.authorization;
+  }
   const response = await fetch(`http://127.0.0.1:${port}${pathname}`, {
     method,
-    headers: body !== undefined ? { "content-type": "application/json" } : undefined,
+    headers: Object.keys(headers).length > 0 ? headers : undefined,
     body: body !== undefined ? JSON.stringify(body) : undefined,
   });
   const text = await response.text();
@@ -284,5 +299,50 @@ describe("REST workflow adapter", () => {
       assert.equal(response.status, 404);
       assert.equal(response.body.error.code, "EXECUTION_NOT_FOUND");
     });
+  });
+
+  it("returns 401 AUTH_ERROR when auth enabled and bearer token is missing", async () => {
+    const authConfig = buildControlPlaneAuthConfig([
+      { token: "read-token", scopes: ["read_history"] },
+    ]);
+    await withRestServer(
+      async (port) => {
+        const response = await requestJson(port, "GET", "/v1/executions/missing-exec");
+        assert.equal(response.status, 401);
+        assert.equal(response.body.error.code, MCP_ADAPTER_ERROR.AUTH_ERROR);
+      },
+      { authConfig }
+    );
+  });
+
+  it("returns 401 AUTH_ERROR when token lacks required scope", async () => {
+    const authConfig = buildControlPlaneAuthConfig([
+      { token: "read-token", scopes: ["read_history"] },
+      { token: "start-token", scopes: ["start"] },
+    ]);
+    await withRestServer(
+      async (port) => {
+        const definition = minimalValidWorkflowDefinition("rest-auth-scope");
+        const registered = await requestJson(
+          port,
+          "POST",
+          "/v1/workflows",
+          { definition },
+          { authorization: "Bearer read-token" }
+        );
+        assert.equal(registered.status, 401);
+        assert.equal(registered.body.error.code, MCP_ADAPTER_ERROR.AUTH_ERROR);
+
+        const allowed = await requestJson(
+          port,
+          "POST",
+          "/v1/workflows",
+          { definition },
+          { authorization: "Bearer start-token" }
+        );
+        assert.equal(allowed.status, 201);
+      },
+      { authConfig }
+    );
   });
 });

--- a/packages/engine/test/secret-redaction.test.mjs
+++ b/packages/engine/test/secret-redaction.test.mjs
@@ -3,6 +3,9 @@ import { describe, it } from "node:test";
 import { MemoryExecutionHistoryStore } from "../src/persistence/memory-history-store.mjs";
 import { RedactingExecutionHistoryStore } from "../src/persistence/redacting-history-store.mjs";
 import { REDACTED_VALUE, redactSecretsInPayload } from "../src/persistence/secret-redaction.mjs";
+import { runLinearWorkflow } from "../src/orchestrator/linear-runner.mjs";
+import { LlmActivityExecutor } from "../src/orchestrator/llm-activity-executor.mjs";
+import { createEnvSecretResolver } from "../src/security/secret-resolver.mjs";
 
 describe("redactSecretsInPayload", () => {
   it("redacts known secret keys at any depth", () => {
@@ -40,5 +43,50 @@ describe("RedactingExecutionHistoryStore", () => {
     const rows = store.listByExecution("exec-1");
     assert.equal(rows.length, 1);
     assert.deepEqual(rows[0].payload.output, { apiKey: REDACTED_VALUE });
+  });
+
+  it("does not persist resolved LLM api keys from secret_ref at activity boundary", async () => {
+    const inner = new MemoryExecutionHistoryStore();
+    const store = new RedactingExecutionHistoryStore(inner);
+    const resolvedSecret = "sk-resolved-never-persist";
+    const secretResolver = createEnvSecretResolver({ LLM_SECRET: resolvedSecret });
+    const definition = {
+      document: {
+        schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
+        name: "secret-redaction-llm",
+        version: "1.0.0",
+      },
+      state_schema: { type: "object", properties: {} },
+      nodes: [
+        { id: "begin", type: "start", config: { input_schema: { type: "object" } } },
+        { id: "classify", type: "llm_call", config: { model: "m", user_prompt: "u" } },
+        { id: "finish", type: "end", config: { output_mapping: "{ ok: true }" } },
+      ],
+      edges: [
+        { source: "__start__", target: "begin" },
+        { source: "begin", target: "classify" },
+        { source: "classify", target: "finish" },
+      ],
+    };
+    const executor = new LlmActivityExecutor({
+      operatorConfig: { apiKeySecretRef: "env:LLM_SECRET" },
+      env: {},
+      secretResolver,
+      provider: {
+        async chatCompletion() {
+          return { content: JSON.stringify({ result: "ok" }) };
+        },
+      },
+    });
+    const executionId = "exec-secret-ref";
+    await runLinearWorkflow({
+      definition,
+      input: {},
+      executionId,
+      store,
+      activityExecutor: executor,
+    });
+    const serialized = JSON.stringify(store.listByExecution(executionId));
+    assert.doesNotMatch(serialized, new RegExp(resolvedSecret.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   });
 });

--- a/packages/engine/test/secret-resolver.test.mjs
+++ b/packages/engine/test/secret-resolver.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import {
+  createCompositeSecretResolver,
+  createDefaultSecretResolver,
+  createEnvSecretResolver,
+  createFileSecretResolver,
+} from "../src/security/secret-resolver.mjs";
+
+describe("createEnvSecretResolver", () => {
+  it("resolves env:VAR refs", async () => {
+    const resolver = createEnvSecretResolver({ MY_KEY: "  sk-secret  " });
+    const value = await resolver.resolve("env:MY_KEY");
+    assert.equal(value, "sk-secret");
+  });
+
+  it("throws when env var is missing", async () => {
+    const resolver = createEnvSecretResolver({});
+    await assert.rejects(() => resolver.resolve("env:MISSING"), /unset or empty/);
+  });
+
+  it("rejects non-env refs", async () => {
+    const resolver = createEnvSecretResolver({ X: "y" });
+    await assert.rejects(() => resolver.resolve("file:x"), /does not support ref/);
+  });
+});
+
+describe("createFileSecretResolver", () => {
+  it("resolves file:relative/path refs", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-secret-"));
+    writeFileSync(path.join(dir, "key.txt"), "  file-token\n");
+    const resolver = createFileSecretResolver(dir);
+    const value = await resolver.resolve("file:key.txt");
+    assert.equal(value, "file-token");
+  });
+
+  it("rejects path traversal", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-secret-"));
+    const resolver = createFileSecretResolver(dir);
+    await assert.rejects(() => resolver.resolve("file:../outside"), /escapes base directory/);
+  });
+
+  it("rejects non-file refs", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-secret-"));
+    const resolver = createFileSecretResolver(dir);
+    await assert.rejects(() => resolver.resolve("env:X"), /does not support ref/);
+  });
+});
+
+describe("createCompositeSecretResolver", () => {
+  it("tries providers in order", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-secret-"));
+    writeFileSync(path.join(dir, "token"), "from-file");
+    const resolver = createCompositeSecretResolver([
+      createEnvSecretResolver({}),
+      createFileSecretResolver(dir),
+    ]);
+    const value = await resolver.resolve("file:token");
+    assert.equal(value, "from-file");
+  });
+
+  it("prefers env over file when env matches", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-secret-"));
+    writeFileSync(path.join(dir, "K"), "from-file");
+    const resolver = createCompositeSecretResolver([
+      createEnvSecretResolver({ K: "from-env" }),
+      createFileSecretResolver(dir),
+    ]);
+    const value = await resolver.resolve("env:K");
+    assert.equal(value, "from-env");
+  });
+});
+
+describe("createDefaultSecretResolver", () => {
+  it("composes env and file providers", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-secret-"));
+    const resolver = createDefaultSecretResolver({ env: { OPENAI: "ok" }, cwd: dir });
+    assert.equal(await resolver.resolve("env:OPENAI"), "ok");
+  });
+});


### PR DESCRIPTION
## Summary

- **BEN-103:** `SecretResolver` port (`env:` / `file:` providers) wired into LLM and A2A activity executors; operator config documented in `docs/security/secret-ref-operator-config.md`
- **BEN-104:** JWS compact Ed25519 definition signing v1 profile with `optional`/`require` policy via `WORKFLOW_ENGINE_DEFINITION_SIGNING_MODE`; 4 conformance signing vectors
- **BEN-105:** Scoped bearer token auth on REST control plane (`start`, `resume`, `read_history`, `submit_activity`); `AUTH_ERROR` code; ADR-0005; stdio documents OS isolation boundary

Linear epic: [BEN-86](https://linear.app/ben-van-den-bergh/issue/BEN-86/epic-security-v1-secret-ref-signing-verify-mcp-auth)

## What changed

- New security modules: `secret-resolver.mjs`, `control-plane-auth.mjs`; real crypto in `definition-signing.mjs`
- REST adapter enforces Bearer auth when `WORKFLOW_ENGINE_AUTH_TOKENS` configured
- Security docs, ADR-0005, alpha baseline and gap register updates

## Why this change

Closes the next GA 1.0 blocker epic under BEN-81 (runtime stub replacement): security v1 baseline required before v1.0.0 tag per R4 milestone.

## Roadmap alignment

- Linked issue: BEN-86 (child: BEN-103, BEN-104, BEN-105)
- Target release: `R4`
- Type: `feature`
- RFC trace links:
  - RFC-07 §7.2 (control-plane auth), §7.3 (secret_ref)

## Spec and architecture traceability

- Spec artifact link: `docs/security/secret-ref-operator-config.md`, `docs/security/definition-signing-v1-profile.md`, `docs/security/mcp-control-plane-auth.md`
- Architecture decision link: `docs/architecture/adr/ADR-0005-mcp-control-plane-auth.md`
- [x] Scope reviewed against `docs/engine-profile.md` and RFC-07
- [x] Security baseline docs updated in this PR

## Architecture runway impact

- [x] No runway impact

## Validation

- [x] `npm run validate-workflows`
- [x] `npm run conformance` (59/59 pass, incl. 4 signing vectors)
- [x] `npm test` (275/275 pass)
- [x] Docs updated

## Risk and rollback

- Risk level: `medium` (new auth/signing env vars; defaults preserve backward-compatible dev posture when unset)
- Rollback/fallback plan: revert PR; auth/signing disabled when env vars unset