### PR TITLE
feat(engine): BEN-87 orchestration policy — node retry and timeout enforcement

### DIFF
--- a/conformance/runner.mjs
+++ b/conformance/runner.mjs
@@ -5,6 +5,7 @@ import {
   MemoryExecutionHistoryStore,
   RejectingActivityExecutor,
   RejectingDelegateExecutor,
+  RetryCountingStepExecutor,
   resumeGraphWorkflow,
   runGraphWorkflow,
   StepActivityExecutor,
@@ -36,6 +37,7 @@ const vectorsRoot = path.join(__dirname, "vectors");
  *   activityExecutionMode?: "in_process" | "host_mediated";
  *   assertNoActivityExecutorInvocation?: boolean;
  *   stepHandlers?: Record<string, Record<string, unknown>>;
+ *   retryCountingExecutor?: { failCount?: number; successOutput?: Record<string, unknown>; errorCode?: string };
  *   assertNoSubworkflowInvocation?: boolean;
  *   assertNoDelegateExecutorInvocation?: boolean;
  *   resumePayload?: Record<string, unknown>;
@@ -240,6 +242,14 @@ async function runReplayVector(vector) {
   const assertNoSubworkflowInvocation = vector.assertNoSubworkflowInvocation === true;
   const assertNoDelegateExecutorInvocation = vector.assertNoDelegateExecutorInvocation === true;
   let activityExecutor = assertNoActivityExecutorInvocation ? new RejectingActivityExecutor() : undefined;
+  if (
+    !activityExecutor &&
+    vector.retryCountingExecutor &&
+    typeof vector.retryCountingExecutor === "object" &&
+    !Array.isArray(vector.retryCountingExecutor)
+  ) {
+    activityExecutor = new RetryCountingStepExecutor(vector.retryCountingExecutor);
+  }
   if (
     !activityExecutor &&
     vector.stepHandlers &&

--- a/conformance/vectors/replay/orchestration-policy/activity-retry-fail-twice-succeed-third.vector.json
+++ b/conformance/vectors/replay/orchestration-policy/activity-retry-fail-twice-succeed-third.vector.json
@@ -1,0 +1,28 @@
+{
+  "id": "replay.orchestration_policy.activity_retry_fail_twice_succeed_third",
+  "description": "in_process step with max_attempts 3: executor fails twice then succeeds on third attempt; events record attempt numbers and willRetry on intermediate failures.",
+  "kind": "replay",
+  "definition": "examples/conformance-retry-step.workflow.json",
+  "input": {},
+  "activityExecutionMode": "in_process",
+  "retryCountingExecutor": {
+    "failCount": 2,
+    "successOutput": { "result": "ok" }
+  },
+  "expect": {
+    "status": "completed",
+    "tailCommands": [
+      { "name": "ScheduleNode", "nodeId": "start" },
+      { "name": "CompleteNode", "nodeId": "start" },
+      { "name": "ScheduleNode", "nodeId": "work" },
+      { "name": "CompleteNode", "nodeId": "work" },
+      { "name": "ScheduleNode", "nodeId": "end" },
+      { "name": "CompleteNode", "nodeId": "end" }
+    ],
+    "eventCardinality": {
+      "ActivityRequested": { "work": 3 },
+      "ActivityFailed": { "work": 2 },
+      "ActivityCompleted": { "work": 1 }
+    }
+  }
+}

--- a/docs/engine-profile.md
+++ b/docs/engine-profile.md
@@ -109,7 +109,7 @@ After reducer application, engines **SHOULD** validate state against `state_sche
 
 ## 5. Retry, timeout, checkpointing
 
-- **Retry and timeout** on nodes follow [RFC-03 §3.8](RFC/rfc-03-workflow-definition-schema.md#38-retry-and-timeout); this profile **MUST** accept at least `retry.max_attempts` (≥ 1) and common duration forms the engine documents.
+- **Retry and timeout** on nodes follow [RFC-03 §3.8](RFC/rfc-03-workflow-definition-schema.md#38-retry-and-timeout); this profile **MUST** accept at least `retry.max_attempts` (≥ 1) and common duration forms the engine documents. The reference engine **applies** both for `step`, `llm_call`, and `tool_call` (in-process race; host-mediated `timeoutMs` on `ActivityRequested`).
 - **Checkpointing** ([RFC-03 §3.9](RFC/rfc-03-workflow-definition-schema.md#39-checkpointing-block), [RFC-04 §4.10](RFC/rfc-04-execution-model.md#410-checkpointing)) — the reference engine emits `CheckpointWritten` after selected node boundaries (switch completion, interrupt raised, parallel join, wait, `set_state`, and post-resume steps). The optional top-level `checkpointing` object **MAY** set execution policy:
   - `strategy` (or alias `policy`): `after_each_node` (default when omitted or when `checkpointing` is absent), `every_n_nodes` (requires integer `n` ≥ 1), or `disabled` (no checkpoints).
   - For `every_n_nodes`, checkpoint emission uses the same boundary points as `after_each_node`, but only every *n*th opportunity (deterministic ordering of boundaries as implemented by the engine).

--- a/docs/profile-model.md
+++ b/docs/profile-model.md
@@ -38,7 +38,7 @@ This document formalizes what adopters **must** implement for **core profile** i
 | `CheckpointWritten` + `definitionHash` binding | Core | Supported | Canonical JSON hash; resume/submit/continuation verify definition. See BEN-78. |
 | `interrupt` inside `parallel` branch | Refused | Validate + runtime refuse | Code `INTERRUPT_IN_PARALLEL_BRANCH`; invariant in `workflow-graph-invariants.mjs`. See BEN-77. |
 | `wait` `kind: signal` | Optional (host) | Runtime error without host | Requires host `workflow_signal`; not bare engine. |
-| Per-node `retry` / `timeout` | Optional | **Not applied** | Schema accepts; walker does not schedule retries or node timeouts yet. |
+| Per-node `retry` / `timeout` | Optional | **Retry applied**; timeout not applied | Walker schedules retries per `retry.max_attempts`; `timeout` still ignored |
 | Top-level `checkpointing` policy | Optional | Supported | Default `after_each_node`; `disabled` / `every_n_nodes`. |
 | `tool_call` delegation bridge | Optional (legacy) | Supported | Prefer native `agent_delegate` for GA; see migration doc. |
 | Definition signing | Optional | Not implemented | R4 security story (BEN-10). |
@@ -50,7 +50,7 @@ This document formalizes what adopters **must** implement for **core profile** i
 ## Runtime gaps called out for GA adopters
 
 1. **`wait.signal`** — Document and validate; execute only with a host that implements signal delivery and correlation (RFC-04 `EmitSignal` / host contract). Bare engine fails fast with a clear message.
-2. **`retry` / `timeout`** — Treat as forward-compatible document fields until the walker implements policy engines and conformance vectors for backoff and deadlines.
+2. **`retry` / `timeout`** — `retry` is applied by the walker (linear minimum backoff). `timeout` remains a forward-compatible document field until BEN-107.
 3. **`interrupt` in `parallel`** — Do not author; validators and runtime refuse. Resume-safe correlation inside branches is a follow-on (separate story if promoted to optional).
 
 ---

--- a/docs/profile-model.md
+++ b/docs/profile-model.md
@@ -38,7 +38,7 @@ This document formalizes what adopters **must** implement for **core profile** i
 | `CheckpointWritten` + `definitionHash` binding | Core | Supported | Canonical JSON hash; resume/submit/continuation verify definition. See BEN-78. |
 | `interrupt` inside `parallel` branch | Refused | Validate + runtime refuse | Code `INTERRUPT_IN_PARALLEL_BRANCH`; invariant in `workflow-graph-invariants.mjs`. See BEN-77. |
 | `wait` `kind: signal` | Optional (host) | Runtime error without host | Requires host `workflow_signal`; not bare engine. |
-| Per-node `retry` / `timeout` | Optional | **Retry applied**; timeout not applied | Walker schedules retries per `retry.max_attempts`; `timeout` still ignored |
+| Per-node `retry` / `timeout` | Optional | **Applied** | Walker enforces `timeout` on activity nodes; retries per `retry.max_attempts` |
 | Top-level `checkpointing` policy | Optional | Supported | Default `after_each_node`; `disabled` / `every_n_nodes`. |
 | `tool_call` delegation bridge | Optional (legacy) | Supported | Prefer native `agent_delegate` for GA; see migration doc. |
 | Definition signing | Optional | Not implemented | R4 security story (BEN-10). |
@@ -50,7 +50,7 @@ This document formalizes what adopters **must** implement for **core profile** i
 ## Runtime gaps called out for GA adopters
 
 1. **`wait.signal`** — Document and validate; execute only with a host that implements signal delivery and correlation (RFC-04 `EmitSignal` / host contract). Bare engine fails fast with a clear message.
-2. **`retry` / `timeout`** — `retry` is applied by the walker (linear minimum backoff). `timeout` remains a forward-compatible document field until BEN-107.
+2. **`retry` / `timeout`** — Both are applied by the walker for `step`, `llm_call`, and `tool_call`. `timeout` is a duration string; in-process runs race the activity port; host-mediated runs include `timeoutMs` on `ActivityRequested` for the host to honor.
 3. **`interrupt` in `parallel`** — Do not author; validators and runtime refuse. Resume-safe correlation inside branches is a follow-on (separate story if promoted to optional).
 
 ---

--- a/docs/user/compatibility.md
+++ b/docs/user/compatibility.md
@@ -22,14 +22,14 @@ What the reference engine (`@agent-workflow/engine`) supports today versus what 
 | Checkpointing + `definitionHash` | Core | Supported | Resume/submit verify definition |
 | `interrupt` in `parallel` branch | Refused | Validate + runtime refuse | `INTERRUPT_IN_PARALLEL_BRANCH` |
 | `wait` `kind: signal` | Optional (host) | Runtime error without host | Needs `workflow_signal` host |
-| Per-node `retry` / `timeout` | Optional | **Not applied** | Schema accepts; walker ignores |
+| Per-node `retry` / `timeout` | Optional | **Retry applied**; timeout not applied | Walker honors `retry.max_attempts` and backoff; `timeout` still ignored |
 | `tool_call` delegation bridge | Optional (legacy) | Supported | Prefer `agent_delegate` |
 | Definition signing | Optional | Not implemented | R4 security story |
 | REST / SDK parity | Optional | Partial | MCP stdio is reference surface |
 
 ## Author guidance
 
-1. **Validates ≠ runs** — `retry`, `timeout`, and `wait.signal` may pass schema but fail or no-op at runtime.
+1. **Validates ≠ runs** — `timeout` and `wait.signal` may pass schema but fail or no-op at runtime. `retry` is applied for activity nodes.
 2. **Register subworkflow refs** — packaged npm installs do not auto-discover child URNs from disk.
 3. **Delegate protocols** — production A2A, MCP, and SDK delegate executors ship in the package; wire via application port or MCP operator profile. Mock A2A remains the zero-config default.
 

--- a/docs/user/compatibility.md
+++ b/docs/user/compatibility.md
@@ -22,14 +22,14 @@ What the reference engine (`@agent-workflow/engine`) supports today versus what 
 | Checkpointing + `definitionHash` | Core | Supported | Resume/submit verify definition |
 | `interrupt` in `parallel` branch | Refused | Validate + runtime refuse | `INTERRUPT_IN_PARALLEL_BRANCH` |
 | `wait` `kind: signal` | Optional (host) | Runtime error without host | Needs `workflow_signal` host |
-| Per-node `retry` / `timeout` | Optional | **Retry applied**; timeout not applied | Walker honors `retry.max_attempts` and backoff; `timeout` still ignored |
+| Per-node `retry` / `timeout` | Optional | **Applied** | Walker honors `retry.max_attempts`, backoff, and per-node `timeout` |
 | `tool_call` delegation bridge | Optional (legacy) | Supported | Prefer `agent_delegate` |
 | Definition signing | Optional | Not implemented | R4 security story |
 | REST / SDK parity | Optional | Partial | MCP stdio is reference surface |
 
 ## Author guidance
 
-1. **Validates ≠ runs** — `timeout` and `wait.signal` may pass schema but fail or no-op at runtime. `retry` is applied for activity nodes.
+1. **Validates ≠ runs** — `wait.signal` may pass schema but fail at runtime without a signal host. `retry` and `timeout` are applied for activity nodes.
 2. **Register subworkflow refs** — packaged npm installs do not auto-discover child URNs from disk.
 3. **Delegate protocols** — production A2A, MCP, and SDK delegate executors ship in the package; wire via application port or MCP operator profile. Mock A2A remains the zero-config default.
 

--- a/docs/user/host-mediated-activities.md
+++ b/docs/user/host-mediated-activities.md
@@ -56,7 +56,7 @@ Expected response: `status: "awaiting_activity"` with `node_id: "classify"` (fir
 
 For each activity boundary the engine yields **`awaiting_activity`**. The host loop is:
 
-1. **Read pending context** — from the tool result or `workflow_status`: `execution_id`, `node_id`, optional `parallel_span`, workflow `state`, and for **`agent_delegate`** nodes also `agent_id`, `protocol`, `delegate_input`, and `delegate_correlation_id`.
+1. **Read pending context** — from the tool result or `workflow_status`: `execution_id`, `node_id`, optional `parallel_span`, workflow `state`, optional **`timeout_ms`** (deadline for this activity when the node defines `timeout`), and for **`agent_delegate`** nodes also `agent_id`, `protocol`, `delegate_input`, and `delegate_correlation_id`.
 2. **Resolve the node** — look up `node_id` in the same `definition` object passed to `workflow_start` (type: `step`, `llm_call`, `tool_call`, or `agent_delegate`; `config` holds model, tool, handler URN, or delegate target).
 3. **Perform work out of band** — invoke the host's LLM API, MCP `tools/call`, registered step handler, or external agent runtime (A2A/MCP/SDK per `agent_delegate` `protocol`). Credentials and side effects stay on the host; the engine does not call your tools or agents in this mode.
 4. **Submit the outcome** — call `workflow_submit_activity` with the **same** `definition` and `input` as the original start, matching `node_id`, and a typed `outcome`.
@@ -79,6 +79,16 @@ For each activity boundary the engine yields **`awaiting_activity`**. The host l
 ```
 
 Success outcomes use `{ "ok": true, "result": { ... } }` (merged into workflow state per node completion). Failures use `{ "ok": false, "error": "...", "code": "..." }`.
+
+## Per-node timeout (host responsibility)
+
+When the workflow node defines **`timeout`** (duration string, e.g. `30s`), the engine records **`timeoutMs`** (milliseconds) on the pending **`ActivityRequested`** event and exposes it on `awaiting_activity` / `workflow_status` responses. The engine does **not** cancel host-side work in this mode — the host **SHOULD**:
+
+1. Track the deadline from `timeout_ms` / `timeoutMs` when the activity is requested.
+2. If work cannot complete in time, stop or abandon the external call and submit `{ "ok": false, "error": "Activity timed out", "code": "TIMEOUT" }` via `workflow_submit_activity`.
+3. On retry (`ActivityRequested` with a higher `attempt`), apply the same deadline policy to the new attempt (each request carries a fresh `timeoutMs`).
+
+In-process runs (`activity_execution_mode: "in_process"`) enforce the same deadline inside the engine by racing the activity port.
 
 For **`agent_delegate`** nodes, include the **`delegate_correlation_id`** from the pending `ActivityRequested` (also exposed on start/status responses). Optionally pass **`external_task_id`** for the host-side agent task reference. The engine validates that the submitted correlation id matches the pending request before recording `ActivityCompleted`.
 

--- a/docs/user/node-reference.md
+++ b/docs/user/node-reference.md
@@ -11,7 +11,7 @@ All nodes may include:
 | `id` | string | Unique in document |
 | `type` | string | Discriminator (see below) |
 | `config` | object | Type-specific |
-| `retry` | object | Accepted by schema; **not applied** by engine yet |
+| `retry` | object | Applied by engine (`max_attempts`, backoff, `non_retryable_errors`) |
 | `timeout` | object | Accepted by schema; **not applied** by engine yet |
 | `metadata` | object | Opaque annotations |
 

--- a/docs/user/node-reference.md
+++ b/docs/user/node-reference.md
@@ -12,7 +12,7 @@ All nodes may include:
 | `type` | string | Discriminator (see below) |
 | `config` | object | Type-specific |
 | `retry` | object | Applied by engine (`max_attempts`, backoff, `non_retryable_errors`) |
-| `timeout` | object | Accepted by schema; **not applied** by engine yet |
+| `timeout` | string | Per-activity deadline (`30s`, `500ms`, …); enforced in-process; advertised on `ActivityRequested` for host-mediated |
 | `metadata` | object | Opaque annotations |
 
 ---

--- a/examples/conformance-retry-step.workflow.json
+++ b/examples/conformance-retry-step.workflow.json
@@ -1,0 +1,30 @@
+{
+  "document": {
+    "schema": "https://agent-workflow.dev/schemas/workflow-definition.json",
+    "name": "conformance-retry-step",
+    "version": "1.0.0"
+  },
+  "state_schema": {
+    "type": "object",
+    "properties": {
+      "result": { "type": "string" }
+    }
+  },
+  "nodes": [
+    { "id": "start", "type": "start" },
+    {
+      "id": "work",
+      "type": "tool_call",
+      "config": { "server": "demo-mcp", "tool": "stub", "arguments": {} },
+      "retry": {
+        "max_attempts": 3
+      }
+    },
+    { "id": "end", "type": "end", "config": { "output_mapping": ".result" } }
+  ],
+  "edges": [
+    { "source": "__start__", "target": "start" },
+    { "source": "start", "target": "work" },
+    { "source": "work", "target": "end" }
+  ]
+}

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -310,7 +310,9 @@ Phases: **validate** (bundled workflow schema + reject `state_schema.properties.
 
 **Activity boundary:** `step`, `llm_call`, and `tool_call` are executed through an **`ActivityExecutor`** port (`executeActivity(ctx)` → success with `output` or failure with `error` / optional `code`). The walker only calls this port (no MCP, HTTP, or provider SDKs inside the runner). **`StubActivityExecutor`** is the default when `activityExecutor` is omitted: deterministic, returns `{}` or per-node outputs from an `outputsByNodeId` map (library demos and tests). **`CompositeActivityExecutor`** routes production workloads to configured sub-executors; pass `activityExecutor` to inject real adapters; pass `stubActivityOutputs` only affects the default stub when `activityExecutor` is omitted.
 
-**Limitation:** Per-node **`retry`** and **`timeout`** settings from the workflow definition are **not** applied by this runner yet; failures return immediately after a single `executeActivity` call.
+**Retry:** Per-node **`retry`** settings (`max_attempts`, `initial_interval`, `backoff_coefficient`, `max_interval`, `non_retryable_errors`) are applied for `step`, `llm_call`, and `tool_call` in the graph walker and linear runner. Intermediate failures emit `ActivityFailed` with `attempt` (1-based) and `willRetry: true`; the next attempt emits `ActivityRequested` with an incremented `attempt`. Replay uses the last `ActivityCompleted` per node and does not re-invoke the activity port.
+
+**Limitation:** Per-node **`timeout`** settings from the workflow definition are **not** applied by this runner yet.
 
 **Node types in this runner:** `start`, `end`, and **`step` / `llm_call` / `tool_call`** behind the activity executor. Default stub outputs are `{}`; override per node id with `stubActivityOutputs[nodeId]` (merged into state via reducers).
 

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -312,7 +312,7 @@ Phases: **validate** (bundled workflow schema + reject `state_schema.properties.
 
 **Retry:** Per-node **`retry`** settings (`max_attempts`, `initial_interval`, `backoff_coefficient`, `max_interval`, `non_retryable_errors`) are applied for `step`, `llm_call`, and `tool_call` in the graph walker and linear runner. Intermediate failures emit `ActivityFailed` with `attempt` (1-based) and `willRetry: true`; the next attempt emits `ActivityRequested` with an incremented `attempt`. Replay uses the last `ActivityCompleted` per node and does not re-invoke the activity port.
 
-**Limitation:** Per-node **`timeout`** settings from the workflow definition are **not** applied by this runner yet.
+**Timeout:** Per-node **`timeout`** duration strings (`500ms`, `30s`, `1m`, `1h`) are enforced for the same activity node types. In-process execution races the activity port against the deadline and records `ActivityFailed` with code **`TIMEOUT`** when exceeded. **`McpManifestActivityExecutor`** passes `min(node timeout, defaultTimeoutMs)` to MCP `tools/call`. Host-mediated runs include **`timeoutMs`** on `ActivityRequested` so the host can fail the submit with code **`TIMEOUT`** if work exceeds the deadline (see [`docs/user/host-mediated-activities.md`](../../docs/user/host-mediated-activities.md)).
 
 **Node types in this runner:** `start`, `end`, and **`step` / `llm_call` / `tool_call`** behind the activity executor. Default stub outputs are `{}`; override per node id with `stubActivityOutputs[nodeId]` (merged into state via reducers).
 

--- a/packages/engine/src/index.mjs
+++ b/packages/engine/src/index.mjs
@@ -40,7 +40,7 @@ export {
   resolveMcpCommandAllowlistFromEnv,
   DEFAULT_MCP_COMMAND_ALLOWLIST,
 } from "./orchestrator/mcp-stdio-activity-executor.mjs";
-export { RejectingActivityExecutor, StubActivityExecutor } from "./orchestrator/activity-executor.mjs";
+export { RejectingActivityExecutor, RetryCountingStepExecutor, StubActivityExecutor } from "./orchestrator/activity-executor.mjs";
 export {
   MockA2ADelegateExecutor,
   RejectingDelegateExecutor,

--- a/packages/engine/src/orchestrator/activity-executor.mjs
+++ b/packages/engine/src/orchestrator/activity-executor.mjs
@@ -65,3 +65,36 @@ export class RejectingActivityExecutor {
     };
   }
 }
+
+/**
+ * Fails the first `failCount` invocations, then returns success. Used in retry conformance and unit tests.
+ *
+ * @implements {ActivityExecutor}
+ */
+export class RetryCountingStepExecutor {
+  /**
+   * @param {{ failCount?: number; successOutput?: Record<string, unknown>; errorCode?: string }} [options]
+   */
+  constructor(options = {}) {
+    this.failCount = options.failCount ?? 2;
+    this.successOutput = options.successOutput ?? {};
+    this.errorCode = options.errorCode ?? "TRANSIENT";
+    this.invocationCount = 0;
+  }
+
+  /**
+   * @param {ActivityExecutorContext} ctx
+   * @returns {Promise<ActivityExecutorResult>}
+   */
+  async executeActivity(ctx) {
+    this.invocationCount += 1;
+    if (this.invocationCount <= this.failCount) {
+      return {
+        ok: false,
+        error: `transient failure on invocation ${this.invocationCount}`,
+        code: this.errorCode,
+      };
+    }
+    return { ok: true, output: { ...this.successOutput } };
+  }
+}

--- a/packages/engine/src/orchestrator/activity-executor.mjs
+++ b/packages/engine/src/orchestrator/activity-executor.mjs
@@ -7,8 +7,9 @@
  *
  * @typedef {object} ActivityExecutorContext
  * @property {string} executionId
- * @property {{ id: string; type: string; config?: object }} node Full node from the workflow definition (`id`, `type`, optional `config`).
+ * @property {{ id: string; type: string; config?: object; timeout?: string }} node Full node from the workflow definition (`id`, `type`, optional `config`, optional `timeout`).
  * @property {Record<string, unknown>} state Workflow state at the boundary (treat as read-only; do not rely on orchestrator seeing mutations).
+ * @property {number} [timeoutMs] Resolved per-node deadline in milliseconds when the walker enforces `node.timeout`.
  */
 
 /**

--- a/packages/engine/src/orchestrator/linear-runner.mjs
+++ b/packages/engine/src/orchestrator/linear-runner.mjs
@@ -8,8 +8,10 @@ import { StubActivityExecutor } from "./activity-executor.mjs";
 import {
   computeRetryBackoffMs,
   delay as policyDelay,
+  executeActivityWithTimeout,
   getRetryPolicy,
   resolveMaxAttempts,
+  resolveNodeTimeoutMs,
   shouldRetryAfterFailure,
 } from "./orchestration-policy.mjs";
 
@@ -338,15 +340,25 @@ export async function runLinearWorkflow(options) {
       } else if (PLACEHOLDER_TYPES.has(node.type)) {
         const maxAttempts = resolveMaxAttempts(/** @type {{ retry?: object }} */ (node));
         const retryPolicy = getRetryPolicy(/** @type {{ retry?: object }} */ (node));
+        const timeoutMs = resolveNodeTimeoutMs(/** @type {{ timeout?: string }} */ (node));
         let activityResult = /** @type {import("./activity-executor.mjs").ActivityExecutorResult | undefined} */ (undefined);
 
         for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-          appendEvt("ActivityRequested", { nodeId, nodeType: node.type, attempt });
-          activityResult = await executor.executeActivity({
-            executionId,
-            node: /** @type {{ id: string; type: string; config?: object }} */ (node),
-            state,
+          appendEvt("ActivityRequested", {
+            nodeId,
+            nodeType: node.type,
+            attempt,
+            ...(timeoutMs !== undefined ? { timeoutMs } : {}),
           });
+          activityResult = await executeActivityWithTimeout(
+            executor,
+            {
+              executionId,
+              node: /** @type {{ id: string; type: string; config?: object; timeout?: string }} */ (node),
+              state,
+            },
+            timeoutMs
+          );
           if (!activityResult.ok) {
             const willRetry = shouldRetryAfterFailure(attempt, maxAttempts, activityResult.code, retryPolicy);
             appendEvt("ActivityFailed", {

--- a/packages/engine/src/orchestrator/linear-runner.mjs
+++ b/packages/engine/src/orchestrator/linear-runner.mjs
@@ -5,6 +5,13 @@ import Ajv2020 from "ajv/dist/2020.js";
 import { createRequire } from "node:module";
 import { validateWorkflowDefinition } from "../validate.mjs";
 import { StubActivityExecutor } from "./activity-executor.mjs";
+import {
+  computeRetryBackoffMs,
+  delay as policyDelay,
+  getRetryPolicy,
+  resolveMaxAttempts,
+  shouldRetryAfterFailure,
+} from "./orchestration-policy.mjs";
 
 const require = createRequire(import.meta.url);
 
@@ -329,28 +336,55 @@ export async function runLinearWorkflow(options) {
       if (node.type === "start" || node.type === "end") {
         output = {};
       } else if (PLACEHOLDER_TYPES.has(node.type)) {
-        appendEvt("ActivityRequested", { nodeId, nodeType: node.type });
-        const activityResult = await executor.executeActivity({
-          executionId,
-          node: /** @type {{ id: string; type: string; config?: object }} */ (node),
-          state,
-        });
-        if (!activityResult.ok) {
-          const { error, code } = activityResult;
-          appendEvt("ActivityFailed", { nodeId, error, ...(code !== undefined ? { code } : {}) });
-          appendCmd("FailNode", {
-            nodeId,
-            reason: "activity_failed",
-            message: error,
-            ...(code !== undefined ? { code } : {}),
+        const maxAttempts = resolveMaxAttempts(/** @type {{ retry?: object }} */ (node));
+        const retryPolicy = getRetryPolicy(/** @type {{ retry?: object }} */ (node));
+        let activityResult = /** @type {import("./activity-executor.mjs").ActivityExecutorResult | undefined} */ (undefined);
+
+        for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+          appendEvt("ActivityRequested", { nodeId, nodeType: node.type, attempt });
+          activityResult = await executor.executeActivity({
+            executionId,
+            node: /** @type {{ id: string; type: string; config?: object }} */ (node),
+            state,
           });
-          appendEvt("ExecutionFailed", { error });
-          return {
-            status: "failed",
-            error,
-            finalState: state,
-          };
+          if (!activityResult.ok) {
+            const willRetry = shouldRetryAfterFailure(attempt, maxAttempts, activityResult.code, retryPolicy);
+            appendEvt("ActivityFailed", {
+              nodeId,
+              error: activityResult.error,
+              attempt,
+              ...(activityResult.code !== undefined ? { code: activityResult.code } : {}),
+              ...(willRetry ? { willRetry: true } : {}),
+            });
+            if (!willRetry) {
+              appendCmd("FailNode", {
+                nodeId,
+                reason: "activity_failed",
+                message: activityResult.error,
+                ...(activityResult.code !== undefined ? { code: activityResult.code } : {}),
+              });
+              appendEvt("ExecutionFailed", { error: activityResult.error });
+              return {
+                status: "failed",
+                error: activityResult.error,
+                finalState: state,
+              };
+            }
+            const backoffMs = computeRetryBackoffMs(attempt, retryPolicy);
+            if (backoffMs > 0) await policyDelay(backoffMs);
+            continue;
+          }
+          break;
         }
+
+        if (!activityResult?.ok) {
+          const error = activityResult?.error ?? "activity failed after exhausting retry attempts";
+          appendEvt("ActivityFailed", { nodeId, error, attempt: maxAttempts });
+          appendCmd("FailNode", { nodeId, reason: "activity_failed", message: error });
+          appendEvt("ExecutionFailed", { error });
+          return { status: "failed", error, finalState: state };
+        }
+
         output = activityResult.output;
         appendEvt("ActivityCompleted", { nodeId, result: output });
       } else {

--- a/packages/engine/src/orchestrator/mcp-stdio-activity-executor.mjs
+++ b/packages/engine/src/orchestrator/mcp-stdio-activity-executor.mjs
@@ -15,6 +15,7 @@ import path from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { resolveNodeTimeoutMs } from "./orchestration-policy.mjs";
 
 /** Basenames allowed when WORKFLOW_ENGINE_MCP_ALLOW_COMMANDS is unset. */
 export const DEFAULT_MCP_COMMAND_ALLOWLIST = new Set(["node", "npx"]);
@@ -253,8 +254,11 @@ export class McpManifestActivityExecutor {
         ? /** @type {Record<string, unknown>} */ ({ ...cfg.arguments })
         : {};
     const signal = this.getAbortSignal?.();
+    const nodeTimeoutMs = ctx.timeoutMs ?? resolveNodeTimeoutMs(/** @type {{ timeout?: string }} */ (node));
+    const timeoutMs =
+      nodeTimeoutMs !== undefined ? Math.min(nodeTimeoutMs, this.defaultTimeoutMs) : this.defaultTimeoutMs;
     return callMcpToolStdio(serverDef, toolName, toolArguments, {
-      timeoutMs: this.defaultTimeoutMs,
+      timeoutMs,
       signal,
       clientName: this.clientName,
       clientVersion: this.clientVersion,

--- a/packages/engine/src/orchestrator/orchestration-policy.mjs
+++ b/packages/engine/src/orchestrator/orchestration-policy.mjs
@@ -1,5 +1,5 @@
 /**
- * Node-level orchestration policy helpers (retry backoff; timeout is BEN-107).
+ * Node-level orchestration policy helpers (retry backoff and activity timeouts).
  */
 
 /**
@@ -98,4 +98,43 @@ export function shouldRetryAfterFailure(attempt, maxAttempts, code, retryPolicy)
  */
 export function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * @param {{ timeout?: string }} node
+ * @returns {number | undefined}
+ */
+export function resolveNodeTimeoutMs(node) {
+  const raw = node?.timeout;
+  if (typeof raw !== "string" || !raw.trim()) {
+    return undefined;
+  }
+  return parseDurationMs(raw);
+}
+
+/**
+ * Invokes the activity port, racing against a node-level deadline when `timeoutMs` is set.
+ *
+ * @param {import("./activity-executor.mjs").ActivityExecutor} executor
+ * @param {import("./activity-executor.mjs").ActivityExecutorContext} ctx
+ * @param {number | undefined} timeoutMs
+ * @returns {Promise<import("./activity-executor.mjs").ActivityExecutorResult>}
+ */
+export async function executeActivityWithTimeout(executor, ctx, timeoutMs) {
+  const ctxWithTimeout = timeoutMs !== undefined ? { ...ctx, timeoutMs } : ctx;
+  if (timeoutMs === undefined) {
+    return executor.executeActivity(ctxWithTimeout);
+  }
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let timer;
+  const timeoutPromise = new Promise((resolve) => {
+    timer = setTimeout(() => {
+      resolve({ ok: false, error: "Activity timed out", code: "TIMEOUT" });
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([executor.executeActivity(ctxWithTimeout), timeoutPromise]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
 }

--- a/packages/engine/src/orchestrator/orchestration-policy.mjs
+++ b/packages/engine/src/orchestrator/orchestration-policy.mjs
@@ -1,0 +1,101 @@
+/**
+ * Node-level orchestration policy helpers (retry backoff; timeout is BEN-107).
+ */
+
+/**
+ * @param {string} durationString
+ * @returns {number}
+ */
+export function parseDurationMs(durationString) {
+  const s = typeof durationString === "string" ? durationString.trim() : "";
+  if (!s) {
+    throw new Error('duration: expected non-empty duration string (e.g. "500ms", "30s")');
+  }
+  const m = /^(\d+)\s*(ms|s|m|h)?$/i.exec(s);
+  if (!m) {
+    throw new Error(`duration: cannot parse duration string "${s}"`);
+  }
+  const n = Number(m[1]);
+  const u = (m[2] || "ms").toLowerCase();
+  const mult = u === "h" ? 3_600_000 : u === "m" ? 60_000 : u === "s" ? 1000 : 1;
+  return n * mult;
+}
+
+/**
+ * @param {{ retry?: { max_attempts?: number } }} node
+ * @returns {number}
+ */
+export function resolveMaxAttempts(node) {
+  const retry = node?.retry;
+  if (retry && typeof retry === "object" && typeof retry.max_attempts === "number" && retry.max_attempts >= 1) {
+    return retry.max_attempts;
+  }
+  return 1;
+}
+
+/**
+ * @param {{ retry?: object }} node
+ * @returns {object | undefined}
+ */
+export function getRetryPolicy(node) {
+  const retry = node?.retry;
+  return retry && typeof retry === "object" ? retry : undefined;
+}
+
+/**
+ * @param {string | undefined} code
+ * @param {object | undefined} retryPolicy
+ * @returns {boolean}
+ */
+export function isNonRetryableError(code, retryPolicy) {
+  if (!code || !retryPolicy || typeof retryPolicy !== "object") return false;
+  const list = retryPolicy.non_retryable_errors;
+  if (!Array.isArray(list)) return false;
+  return list.includes(code);
+}
+
+/**
+ * Linear minimum backoff: `initial_interval` (default 0) × `backoff_coefficient`^(attempt−1), capped by `max_interval`.
+ *
+ * @param {number} attemptNumber 1-based failed attempt before scheduling the next try
+ * @param {object | undefined} retryPolicy
+ * @returns {number}
+ */
+export function computeRetryBackoffMs(attemptNumber, retryPolicy) {
+  const policy = retryPolicy && typeof retryPolicy === "object" ? retryPolicy : {};
+  let initialMs = 0;
+  if (typeof policy.initial_interval === "string" && policy.initial_interval.trim()) {
+    initialMs = parseDurationMs(policy.initial_interval);
+  }
+  const coefficient =
+    typeof policy.backoff_coefficient === "number" && policy.backoff_coefficient >= 0
+      ? policy.backoff_coefficient
+      : 1;
+  let maxMs = Number.POSITIVE_INFINITY;
+  if (typeof policy.max_interval === "string" && policy.max_interval.trim()) {
+    maxMs = parseDurationMs(policy.max_interval);
+  }
+  const backoff = initialMs * coefficient ** (attemptNumber - 1);
+  return Math.min(backoff, maxMs);
+}
+
+/**
+ * @param {number} attempt 1-based attempt that failed
+ * @param {number} maxAttempts
+ * @param {string | undefined} code
+ * @param {object | undefined} retryPolicy
+ * @returns {boolean}
+ */
+export function shouldRetryAfterFailure(attempt, maxAttempts, code, retryPolicy) {
+  if (attempt >= maxAttempts) return false;
+  if (isNonRetryableError(code, retryPolicy)) return false;
+  return true;
+}
+
+/**
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+export function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/engine/src/orchestrator/parallel-join-runtime.mjs
+++ b/packages/engine/src/orchestrator/parallel-join-runtime.mjs
@@ -252,7 +252,6 @@ export function createParallelJoinRuntime(params) {
         }
         if (!activityResult.ok) {
           const { error, code } = activityResult;
-          hooks.appendEvt("ActivityFailed", { nodeId: cur, error, ...(code !== undefined ? { code } : {}) });
           hooks.appendCmd("FailNode", {
             nodeId: cur,
             reason: "activity_failed",

--- a/packages/engine/src/orchestrator/workflow-graph-walker.mjs
+++ b/packages/engine/src/orchestrator/workflow-graph-walker.mjs
@@ -12,6 +12,7 @@ import {
   delay as policyDelay,
   getRetryPolicy,
   resolveMaxAttempts,
+  resolveNodeTimeoutMs,
   shouldRetryAfterFailure,
 } from "./orchestration-policy.mjs";
 import {
@@ -1692,11 +1693,12 @@ export async function submitActivityOutcome(options) {
   if (!outcome.ok) {
     const { error, code } = outcome;
     const attempt = typeof last.payload?.attempt === "number" && last.payload.attempt >= 1 ? last.payload.attempt : 1;
-    const activityNode = /** @type {{ nodes?: Array<{ id: string; retry?: object }> }} */ (definition).nodes?.find(
+    const activityNode = /** @type {{ nodes?: Array<{ id: string; retry?: object; timeout?: string }> }} */ (definition).nodes?.find(
       (n) => n.id === nodeId
     );
     const maxAttempts = resolveMaxAttempts(activityNode ?? {});
     const retryPolicy = getRetryPolicy(activityNode ?? {});
+    const timeoutMs = resolveNodeTimeoutMs(activityNode ?? {});
     const willRetry = shouldRetryAfterFailure(attempt, maxAttempts, code, retryPolicy);
 
     store.append(executionId, {
@@ -1731,6 +1733,7 @@ export async function submitActivityOutcome(options) {
           nodeId,
           ...(pendingNodeType ? { nodeType: pendingNodeType } : {}),
           attempt: nextAttempt,
+          ...(timeoutMs !== undefined ? { timeoutMs } : {}),
           ...(isParallelSpanPayload(reqSpan) ? { parallelSpan: { ...reqSpan } } : {}),
           ...(typeof last.payload?.delegateCorrelationId === "string"
             ? { delegateCorrelationId: last.payload.delegateCorrelationId }

--- a/packages/engine/src/orchestrator/workflow-graph-walker.mjs
+++ b/packages/engine/src/orchestrator/workflow-graph-walker.mjs
@@ -8,6 +8,13 @@ import { createRequire } from "node:module";
 import { validateWorkflowDefinition } from "../validate.mjs";
 import { StubActivityExecutor } from "./activity-executor.mjs";
 import {
+  computeRetryBackoffMs,
+  delay as policyDelay,
+  getRetryPolicy,
+  resolveMaxAttempts,
+  shouldRetryAfterFailure,
+} from "./orchestration-policy.mjs";
+import {
   assertNoCustomReducers,
   applyOutputWithReducers,
   stateSchemaForValidation,
@@ -767,7 +774,6 @@ export async function runGraphWorkflow(options) {
         }
         if (step.kind === "failed") {
           const { error, code } = step;
-          appendEvt("ActivityFailed", { nodeId: current, error, ...(code !== undefined ? { code } : {}) });
           appendCmd("FailNode", {
             nodeId: current,
             reason: "activity_failed",
@@ -1483,7 +1489,6 @@ export async function resumeGraphWorkflow(options) {
         }
         if (step.kind === "failed") {
           const { error, code } = step;
-          appendEvt("ActivityFailed", { nodeId: current, error, ...(code !== undefined ? { code } : {}) });
           appendCmd("FailNode", {
             nodeId: current,
             reason: "activity_failed",
@@ -1686,11 +1691,63 @@ export async function submitActivityOutcome(options) {
 
   if (!outcome.ok) {
     const { error, code } = outcome;
+    const attempt = typeof last.payload?.attempt === "number" && last.payload.attempt >= 1 ? last.payload.attempt : 1;
+    const activityNode = /** @type {{ nodes?: Array<{ id: string; retry?: object }> }} */ (definition).nodes?.find(
+      (n) => n.id === nodeId
+    );
+    const maxAttempts = resolveMaxAttempts(activityNode ?? {});
+    const retryPolicy = getRetryPolicy(activityNode ?? {});
+    const willRetry = shouldRetryAfterFailure(attempt, maxAttempts, code, retryPolicy);
+
     store.append(executionId, {
       kind: "event",
       name: "ActivityFailed",
-      payload: { executionId, nodeId, error, ...(code !== undefined ? { code } : {}) },
+      payload: {
+        executionId,
+        nodeId,
+        error,
+        attempt,
+        ...(code !== undefined ? { code } : {}),
+        ...(willRetry ? { willRetry: true } : {}),
+      },
     });
+
+    if (willRetry) {
+      const backoffMs = computeRetryBackoffMs(attempt, retryPolicy);
+      if (backoffMs > 0) await policyDelay(backoffMs);
+
+      const nextAttempt = attempt + 1;
+      const pendingNodeType =
+        typeof last.payload?.nodeType === "string"
+          ? last.payload.nodeType
+          : activityNode && "type" in activityNode && typeof activityNode.type === "string"
+            ? activityNode.type
+            : undefined;
+      store.append(executionId, {
+        kind: "event",
+        name: "ActivityRequested",
+        payload: {
+          executionId,
+          nodeId,
+          ...(pendingNodeType ? { nodeType: pendingNodeType } : {}),
+          attempt: nextAttempt,
+          ...(isParallelSpanPayload(reqSpan) ? { parallelSpan: { ...reqSpan } } : {}),
+          ...(typeof last.payload?.delegateCorrelationId === "string"
+            ? { delegateCorrelationId: last.payload.delegateCorrelationId }
+            : {}),
+        },
+      });
+
+      const histState = latestStateFromHistory(store.listByExecution(executionId));
+      return {
+        status: "awaiting_activity",
+        executionId,
+        nodeId,
+        state: histState ? { ...histState } : { ...input },
+        ...(isParallelSpanPayload(reqSpan) ? { parallelSpan: { ...reqSpan } } : {}),
+      };
+    }
+
     store.append(executionId, {
       kind: "command",
       name: "FailNode",

--- a/packages/engine/src/orchestrator/workflow-node-execution.mjs
+++ b/packages/engine/src/orchestrator/workflow-node-execution.mjs
@@ -5,8 +5,10 @@
 import {
   computeRetryBackoffMs,
   delay as policyDelay,
+  executeActivityWithTimeout,
   getRetryPolicy,
   resolveMaxAttempts,
+  resolveNodeTimeoutMs,
   shouldRetryAfterFailure,
 } from "./orchestration-policy.mjs";
 
@@ -186,9 +188,14 @@ export async function runPlaceholderActivityStep(args) {
 
   const maxAttempts = resolveMaxAttempts(/** @type {{ retry?: object }} */ (node));
   const retryPolicy = getRetryPolicy(/** @type {{ retry?: object }} */ (node));
+  const timeoutMs = resolveNodeTimeoutMs(/** @type {{ timeout?: string }} */ (node));
 
   /** @type {Record<string, unknown>} */
-  const baseReqPayload = { nodeId: node.id, nodeType: node.type };
+  const baseReqPayload = {
+    nodeId: node.id,
+    nodeType: node.type,
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+  };
   if (
     parallelSpan &&
     typeof parallelSpan.parallelNodeId === "string" &&
@@ -217,11 +224,15 @@ export async function runPlaceholderActivityStep(args) {
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     appendEvt("ActivityRequested", { ...baseReqPayload, attempt });
 
-    const activityResult = await executor.executeActivity({
-      executionId,
-      node: /** @type {{ id: string; type: string; config?: object }} */ (node),
-      state,
-    });
+    const activityResult = await executeActivityWithTimeout(
+      executor,
+      {
+        executionId,
+        node: /** @type {{ id: string; type: string; config?: object; timeout?: string }} */ (node),
+        state,
+      },
+      timeoutMs
+    );
     if (!activityResult.ok) {
       const willRetry = shouldRetryAfterFailure(attempt, maxAttempts, activityResult.code, retryPolicy);
       appendEvt("ActivityFailed", {

--- a/packages/engine/src/orchestrator/workflow-node-execution.mjs
+++ b/packages/engine/src/orchestrator/workflow-node-execution.mjs
@@ -2,6 +2,13 @@
  * Node-level execution helpers for the workflow graph walker (switch routing, timers,
  * set_state, and the activity boundary for step / llm_call / tool_call).
  */
+import {
+  computeRetryBackoffMs,
+  delay as policyDelay,
+  getRetryPolicy,
+  resolveMaxAttempts,
+  shouldRetryAfterFailure,
+} from "./orchestration-policy.mjs";
 
 /**
  * @param {unknown} jqResult
@@ -177,8 +184,11 @@ export async function runPlaceholderActivityStep(args) {
     return { kind: "completed", output };
   }
 
+  const maxAttempts = resolveMaxAttempts(/** @type {{ retry?: object }} */ (node));
+  const retryPolicy = getRetryPolicy(/** @type {{ retry?: object }} */ (node));
+
   /** @type {Record<string, unknown>} */
-  const reqPayload = { nodeId: node.id, nodeType: node.type };
+  const baseReqPayload = { nodeId: node.id, nodeType: node.type };
   if (
     parallelSpan &&
     typeof parallelSpan.parallelNodeId === "string" &&
@@ -186,11 +196,11 @@ export async function runPlaceholderActivityStep(args) {
     typeof parallelSpan.branchName === "string" &&
     typeof parallelSpan.branchEntryNodeId === "string"
   ) {
-    reqPayload.parallelSpan = { ...parallelSpan };
+    baseReqPayload.parallelSpan = { ...parallelSpan };
   }
-  appendEvt("ActivityRequested", reqPayload);
 
   if (activityExecutionMode === "host_mediated") {
+    appendEvt("ActivityRequested", { ...baseReqPayload, attempt: 1 });
     return {
       kind: "awaiting_activity",
       nodeId: node.id,
@@ -204,20 +214,39 @@ export async function runPlaceholderActivityStep(args) {
     };
   }
 
-  const activityResult = await executor.executeActivity({
-    executionId,
-    node: /** @type {{ id: string; type: string; config?: object }} */ (node),
-    state,
-  });
-  if (!activityResult.ok) {
-    return {
-      kind: "failed",
-      error: activityResult.error,
-      ...(activityResult.code !== undefined ? { code: activityResult.code } : {}),
-    };
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    appendEvt("ActivityRequested", { ...baseReqPayload, attempt });
+
+    const activityResult = await executor.executeActivity({
+      executionId,
+      node: /** @type {{ id: string; type: string; config?: object }} */ (node),
+      state,
+    });
+    if (!activityResult.ok) {
+      const willRetry = shouldRetryAfterFailure(attempt, maxAttempts, activityResult.code, retryPolicy);
+      appendEvt("ActivityFailed", {
+        nodeId: node.id,
+        error: activityResult.error,
+        attempt,
+        ...(activityResult.code !== undefined ? { code: activityResult.code } : {}),
+        ...(willRetry ? { willRetry: true } : {}),
+      });
+      if (!willRetry) {
+        return {
+          kind: "failed",
+          error: activityResult.error,
+          ...(activityResult.code !== undefined ? { code: activityResult.code } : {}),
+        };
+      }
+      const backoffMs = computeRetryBackoffMs(attempt, retryPolicy);
+      if (backoffMs > 0) await policyDelay(backoffMs);
+      continue;
+    }
+    appendEvt("ActivityCompleted", { nodeId: node.id, result: activityResult.output });
+    return { kind: "completed", output: activityResult.output };
   }
-  appendEvt("ActivityCompleted", { nodeId: node.id, result: activityResult.output });
-  return { kind: "completed", output: activityResult.output };
+
+  return { kind: "failed", error: "activity failed after exhausting retry attempts" };
 }
 
 /**

--- a/packages/engine/test/orchestration-policy-retry.test.mjs
+++ b/packages/engine/test/orchestration-policy-retry.test.mjs
@@ -1,0 +1,255 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+import { RetryCountingStepExecutor, RejectingActivityExecutor } from "../src/orchestrator/activity-executor.mjs";
+import { MemoryExecutionHistoryStore } from "../src/persistence/memory-history-store.mjs";
+import { runGraphWorkflow, submitActivityOutcome } from "../src/orchestrator/workflow-graph-walker.mjs";
+import {
+  computeRetryBackoffMs,
+  isNonRetryableError,
+  parseDurationMs,
+  resolveMaxAttempts,
+  shouldRetryAfterFailure,
+} from "../src/orchestrator/orchestration-policy.mjs";
+import { findWorkflowRepoRoot } from "../src/validate.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function loadRetryConformanceWorkflow() {
+  const root = findWorkflowRepoRoot(__dirname);
+  const p = path.join(root, "examples", "conformance-retry-step.workflow.json");
+  return JSON.parse(readFileSync(p, "utf8"));
+}
+
+describe("orchestration-policy retry", () => {
+  it("parseDurationMs accepts ms/s/m/h suffixes", () => {
+    assert.equal(parseDurationMs("500ms"), 500);
+    assert.equal(parseDurationMs("2s"), 2000);
+    assert.equal(parseDurationMs("1m"), 60_000);
+    assert.equal(parseDurationMs("1h"), 3_600_000);
+  });
+
+  it("computeRetryBackoffMs applies linear minimum with cap", () => {
+    const policy = { initial_interval: "1s", backoff_coefficient: 2, max_interval: "3s" };
+    assert.equal(computeRetryBackoffMs(1, policy), 1000);
+    assert.equal(computeRetryBackoffMs(2, policy), 2000);
+    assert.equal(computeRetryBackoffMs(3, policy), 3000);
+  });
+
+  it("isNonRetryableError respects non_retryable_errors", () => {
+    const policy = { non_retryable_errors: ["FATAL", "VALIDATION"] };
+    assert.equal(isNonRetryableError("FATAL", policy), true);
+    assert.equal(isNonRetryableError("TRANSIENT", policy), false);
+  });
+
+  it("resolveMaxAttempts defaults to 1 without retry policy", () => {
+    assert.equal(resolveMaxAttempts({}), 1);
+    assert.equal(resolveMaxAttempts({ retry: { max_attempts: 3 } }), 3);
+  });
+
+  it("shouldRetryAfterFailure stops at max_attempts and non_retryable_errors", () => {
+    const policy = { non_retryable_errors: ["FATAL"] };
+    assert.equal(shouldRetryAfterFailure(1, 3, "TRANSIENT", policy), true);
+    assert.equal(shouldRetryAfterFailure(3, 3, "TRANSIENT", policy), false);
+    assert.equal(shouldRetryAfterFailure(1, 3, "FATAL", policy), false);
+  });
+
+  it("in_process: fail twice succeed third with attempt events", async () => {
+    const definition = loadRetryConformanceWorkflow();
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "retry-fail-twice-succeed-third";
+    const executor = new RetryCountingStepExecutor({ failCount: 2, successOutput: { result: "ok" } });
+
+    const out = await runGraphWorkflow({
+      definition,
+      input: {},
+      executionId,
+      store,
+      activityExecutor: executor,
+      activityExecutionMode: "in_process",
+    });
+
+    assert.equal(out.status, "completed");
+    assert.equal(executor.invocationCount, 3);
+
+    const events = store.listByExecution(executionId).filter((r) => r.kind === "event");
+    const requested = events.filter((r) => r.name === "ActivityRequested" && r.payload?.nodeId === "work");
+    const failed = events.filter((r) => r.name === "ActivityFailed" && r.payload?.nodeId === "work");
+    const completed = events.filter((r) => r.name === "ActivityCompleted" && r.payload?.nodeId === "work");
+
+    assert.equal(requested.length, 3);
+    assert.deepEqual(requested.map((r) => r.payload.attempt), [1, 2, 3]);
+    assert.equal(failed.length, 2);
+    assert.equal(failed.every((r) => r.payload.willRetry === true), true);
+    assert.equal(completed.length, 1);
+  });
+
+  it("non_retryable_errors stops early without exhausting max_attempts", async () => {
+    const definition = loadRetryConformanceWorkflow();
+    definition.nodes = definition.nodes.map((n) =>
+      n.id === "work"
+        ? {
+            ...n,
+            retry: { max_attempts: 5, non_retryable_errors: ["FATAL"] },
+          }
+        : n
+    );
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "retry-non-retryable";
+
+    class FatalFirstExecutor {
+      invocationCount = 0;
+      async executeActivity() {
+        this.invocationCount += 1;
+        return { ok: false, error: "fatal", code: "FATAL" };
+      }
+    }
+    const executor = new FatalFirstExecutor();
+
+    const out = await runGraphWorkflow({
+      definition,
+      input: {},
+      executionId,
+      store,
+      activityExecutor: executor,
+      activityExecutionMode: "in_process",
+    });
+
+    assert.equal(out.status, "failed");
+    assert.equal(executor.invocationCount, 1);
+    const failed = store
+      .listByExecution(executionId)
+      .filter((r) => r.kind === "event" && r.name === "ActivityFailed" && r.payload?.nodeId === "work");
+    assert.equal(failed.length, 1);
+    assert.equal(failed[0].payload.attempt, 1);
+    assert.equal(failed[0].payload.willRetry, undefined);
+  });
+
+  it("max_attempts 1 behaves as single attempt without willRetry", async () => {
+    const definition = loadRetryConformanceWorkflow();
+    definition.nodes = definition.nodes.map((n) =>
+      n.id === "work" ? { ...n, retry: { max_attempts: 1 } } : n
+    );
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "retry-max-1";
+
+    class AlwaysFailExecutor {
+      async executeActivity() {
+        return { ok: false, error: "once", code: "TRANSIENT" };
+      }
+    }
+
+    const out = await runGraphWorkflow({
+      definition,
+      input: {},
+      executionId,
+      store,
+      activityExecutor: new AlwaysFailExecutor(),
+      activityExecutionMode: "in_process",
+    });
+
+    assert.equal(out.status, "failed");
+    const events = store.listByExecution(executionId).filter((r) => r.kind === "event");
+    assert.equal(events.filter((r) => r.name === "ActivityRequested").length, 1);
+    const failed = events.find((r) => r.name === "ActivityFailed");
+    assert.equal(failed?.payload?.attempt, 1);
+    assert.equal(failed?.payload?.willRetry, undefined);
+  });
+
+  it("replay prefix through 2 failures + 1 success does not re-invoke executor", async () => {
+    const definition = loadRetryConformanceWorkflow();
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "retry-replay-no-double-invoke";
+
+    const prefix = [
+      { kind: "event", name: "ExecutionStarted", payload: { workflowName: "conformance-retry-step", inputKeys: [] } },
+      { kind: "command", name: "ScheduleNode", payload: { nodeId: "start" } },
+      { kind: "event", name: "NodeScheduled", payload: { nodeId: "start" } },
+      { kind: "command", name: "CompleteNode", payload: { nodeId: "start", output: {} } },
+      { kind: "event", name: "StateUpdated", payload: { nodeId: "start", state: {} } },
+      { kind: "command", name: "ScheduleNode", payload: { nodeId: "work" } },
+      { kind: "event", name: "NodeScheduled", payload: { nodeId: "work" } },
+      { kind: "event", name: "ActivityRequested", payload: { nodeId: "work", nodeType: "tool_call", attempt: 1 } },
+      { kind: "event", name: "ActivityFailed", payload: { nodeId: "work", error: "e1", attempt: 1, willRetry: true } },
+      { kind: "event", name: "ActivityRequested", payload: { nodeId: "work", nodeType: "tool_call", attempt: 2 } },
+      { kind: "event", name: "ActivityFailed", payload: { nodeId: "work", error: "e2", attempt: 2, willRetry: true } },
+      { kind: "event", name: "ActivityRequested", payload: { nodeId: "work", nodeType: "tool_call", attempt: 3 } },
+      {
+        kind: "event",
+        name: "ActivityCompleted",
+        payload: { nodeId: "work", result: { result: "ok" } },
+      },
+    ];
+    for (const row of prefix) {
+      store.append(executionId, {
+        kind: /** @type {"command" | "event"} */ (row.kind),
+        name: row.name,
+        payload: { executionId, ...row.payload },
+      });
+    }
+
+    const out = await runGraphWorkflow({
+      definition,
+      input: {},
+      executionId,
+      store,
+      activityExecutor: new RejectingActivityExecutor(),
+      activityExecutionMode: "in_process",
+    });
+
+    assert.equal(out.status, "completed");
+    assert.equal(out.result, "ok");
+  });
+
+  it("host_mediated: submit failure retries then succeeds", async () => {
+    const definition = loadRetryConformanceWorkflow();
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "retry-host-mediated";
+
+    const first = await runGraphWorkflow({
+      definition,
+      input: {},
+      executionId,
+      store,
+      activityExecutionMode: "host_mediated",
+    });
+    assert.equal(first.status, "awaiting_activity");
+    assert.equal(first.nodeId, "work");
+
+    const fail1 = await submitActivityOutcome({
+      definition,
+      executionId,
+      store,
+      input: {},
+      nodeId: "work",
+      outcome: { ok: false, error: "e1", code: "TRANSIENT" },
+    });
+    assert.equal(fail1.status, "awaiting_activity");
+
+    const fail2 = await submitActivityOutcome({
+      definition,
+      executionId,
+      store,
+      input: {},
+      nodeId: "work",
+      outcome: { ok: false, error: "e2", code: "TRANSIENT" },
+    });
+    assert.equal(fail2.status, "awaiting_activity");
+
+    const done = await submitActivityOutcome({
+      definition,
+      executionId,
+      store,
+      input: {},
+      nodeId: "work",
+      outcome: { ok: true, result: { result: "ok" } },
+    });
+    assert.equal(done.status, "completed");
+
+    const events = store.listByExecution(executionId).filter((r) => r.kind === "event");
+    const requested = events.filter((r) => r.name === "ActivityRequested" && r.payload?.nodeId === "work");
+    assert.deepEqual(requested.map((r) => r.payload.attempt), [1, 2, 3]);
+  });
+});

--- a/packages/engine/test/orchestration-policy-timeout.test.mjs
+++ b/packages/engine/test/orchestration-policy-timeout.test.mjs
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+import { MemoryExecutionHistoryStore } from "../src/persistence/memory-history-store.mjs";
+import { runGraphWorkflow } from "../src/orchestrator/workflow-graph-walker.mjs";
+import {
+  executeActivityWithTimeout,
+  parseDurationMs,
+  resolveNodeTimeoutMs,
+} from "../src/orchestrator/orchestration-policy.mjs";
+import { findWorkflowRepoRoot } from "../src/validate.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function loadRetryConformanceWorkflow() {
+  const root = findWorkflowRepoRoot(__dirname);
+  const p = path.join(root, "examples", "conformance-retry-step.workflow.json");
+  return JSON.parse(readFileSync(p, "utf8"));
+}
+
+function workflowWithTimeout(timeout) {
+  const definition = loadRetryConformanceWorkflow();
+  definition.nodes = definition.nodes.map((n) => (n.id === "work" ? { ...n, timeout, retry: undefined } : n));
+  return definition;
+}
+
+class DelayedExecutor {
+  /**
+   * @param {number} delayMs
+   */
+  constructor(delayMs) {
+    this.delayMs = delayMs;
+    this.invocationCount = 0;
+  }
+
+  async executeActivity() {
+    this.invocationCount += 1;
+    await new Promise((resolve) => setTimeout(resolve, this.delayMs));
+    return { ok: true, output: { result: "ok" } };
+  }
+}
+
+describe("orchestration-policy timeout", () => {
+  it("resolveNodeTimeoutMs parses duration strings and returns undefined when absent", () => {
+    assert.equal(resolveNodeTimeoutMs({}), undefined);
+    assert.equal(resolveNodeTimeoutMs({ timeout: "  " }), undefined);
+    assert.equal(resolveNodeTimeoutMs({ timeout: "500ms" }), 500);
+    assert.equal(parseDurationMs("2s"), 2000);
+  });
+
+  it("executeActivityWithTimeout returns TIMEOUT when executor exceeds deadline", async () => {
+    const executor = new DelayedExecutor(200);
+    const result = await executeActivityWithTimeout(
+      executor,
+      { executionId: "e1", node: { id: "work", type: "step" }, state: {} },
+      50
+    );
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.code, "TIMEOUT");
+      assert.match(result.error, /timed out/i);
+    }
+  });
+
+  it("in_process: slow executor exceeds node timeout → TIMEOUT failure", async () => {
+    const definition = workflowWithTimeout("50ms");
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "timeout-slow-fail";
+    const executor = new DelayedExecutor(200);
+
+    const out = await runGraphWorkflow({
+      definition,
+      input: {},
+      executionId,
+      store,
+      activityExecutor: executor,
+      activityExecutionMode: "in_process",
+    });
+
+    assert.equal(out.status, "failed");
+    assert.equal(executor.invocationCount, 1);
+    const failed = store
+      .listByExecution(executionId)
+      .find((r) => r.kind === "event" && r.name === "ActivityFailed" && r.payload?.nodeId === "work");
+    assert.equal(failed?.payload?.code, "TIMEOUT");
+  });
+
+  it("in_process: fast executor within node timeout → success", async () => {
+    const definition = workflowWithTimeout("200ms");
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "timeout-fast-ok";
+    const executor = new DelayedExecutor(20);
+
+    const out = await runGraphWorkflow({
+      definition,
+      input: {},
+      executionId,
+      store,
+      activityExecutor: executor,
+      activityExecutionMode: "in_process",
+    });
+
+    assert.equal(out.status, "completed");
+    assert.equal(executor.invocationCount, 1);
+    const completed = store
+      .listByExecution(executionId)
+      .find((r) => r.kind === "event" && r.name === "ActivityCompleted" && r.payload?.nodeId === "work");
+    assert.ok(completed);
+  });
+
+  it("in_process: node without timeout does not impose walker deadline", async () => {
+    const definition = loadRetryConformanceWorkflow();
+    definition.nodes = definition.nodes.map((n) =>
+      n.id === "work" ? { ...n, retry: undefined, timeout: undefined } : n
+    );
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "timeout-absent";
+    const executor = new DelayedExecutor(20);
+
+    const out = await runGraphWorkflow({
+      definition,
+      input: {},
+      executionId,
+      store,
+      activityExecutor: executor,
+      activityExecutionMode: "in_process",
+    });
+
+    assert.equal(out.status, "completed");
+    assert.equal(executor.invocationCount, 1);
+  });
+
+  it("host_mediated: ActivityRequested includes timeoutMs when node has timeout", async () => {
+    const definition = workflowWithTimeout("30s");
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "timeout-host-mediated";
+
+    const out = await runGraphWorkflow({
+      definition,
+      input: {},
+      executionId,
+      store,
+      activityExecutionMode: "host_mediated",
+    });
+
+    assert.equal(out.status, "awaiting_activity");
+    const requested = store
+      .listByExecution(executionId)
+      .find((r) => r.kind === "event" && r.name === "ActivityRequested" && r.payload?.nodeId === "work");
+    assert.equal(requested?.payload?.timeoutMs, 30_000);
+  });
+});


### PR DESCRIPTION
## Summary

- Implement node-level **retry policy** in the graph walker and linear runner (BEN-106): `max_attempts`, linear-minimum backoff, `attempt`/`willRetry` on activity events, host-mediated submit retries, replay-safe re-invocation, and a conformance vector (fail twice, succeed third).
- Implement node-level **timeout enforcement** (BEN-107): parse `node.timeout` durations, in-process `TIMEOUT` via `executeActivityWithTimeout`, MCP executor `min(node, default)` timeout, and host-mediated deadline guidance on `ActivityRequested`.
- Add `orchestration-policy.mjs` as the shared policy module; update engine-profile, profile-model, compatibility, node-reference, host-mediated guide, and README.

## Test plan

- [x] `npm test` — 298/298 pass
- [x] `npm run conformance` — 60/60 pass (includes `replay.orchestration_policy.activity_retry_fail_twice_succeed_third`)
- [x] `npm run validate-workflows` — all fixtures pass including `conformance-retry-step.workflow.json`

## Roadmap alignment

- Linked issue: BEN-87 (child: BEN-106, BEN-107) under BEN-81 GA 1.0 runtime stub replacement
- Target release: `R4`
- Type: `feature`
- RFC trace links:
  - RFC-03 §3.8 retry and timeout
  - RFC-04 ActivityRequested / ActivityFailed event semantics

## Spec and architecture traceability

- Spec artifact link (required for feature/runway PRs):
  - `docs/engine-profile.md` §5 retry/timeout
  - `docs/RFC/rfc-03-workflow-definition-schema.md` §3.8
- Architecture decision link (ADR/design note, if applicable):
  - ADR deferred — in-process timeout uses Promise.race; host-mediated timeout is advisory on ActivityRequested
- [x] Scope and constraints reviewed against `docs/engine-profile.md` and relevant `docs/RFC/*`
- [x] If behavior/contract changed, corresponding spec/design docs were updated first or in this PR

## Architecture runway impact

- [x] No runway impact

## Risk and rollback

- Risk level: `low`
- Rollback/fallback plan: revert branch; nodes without `retry`/`timeout` behave as before (default max_attempts=1, no timeout)