### PR TITLE
feat(engine): BEN-88 composition & validation epic

### DIFF
--- a/conformance/run-conformance.mjs
+++ b/conformance/run-conformance.mjs
@@ -1,5 +1,6 @@
 import { discoverVectors, runVector } from "./runner.mjs";
 import { runSdkParitySmoke } from "./sdk-parity-smoke.mjs";
+import { runSqliteStoreSmoke } from "./sqlite-store-smoke.mjs";
 
 const discovered = discoverVectors();
 const results = await Promise.all(discovered.map(runVector));
@@ -14,6 +15,19 @@ if (sdkSmoke.passed) {
     category: "sdk-parity-fail",
     passed: false,
     reason: sdkSmoke.reason,
+  });
+}
+const sqliteSmoke = await runSqliteStoreSmoke();
+if (sqliteSmoke.passed) {
+  console.error("PASS [sqlite-store-smoke] SqliteExecutionHistoryStore persistence");
+} else {
+  console.error(`FAIL [sqlite-store-smoke] ${sqliteSmoke.reason}`);
+  results.push({
+    id: "sqlite-store-smoke",
+    file: "conformance/sqlite-store-smoke.mjs",
+    category: "sqlite-store-fail",
+    passed: false,
+    reason: sqliteSmoke.reason,
   });
 }
 const failed = results.filter((result) => !result.passed);
@@ -51,6 +65,7 @@ const summary = {
     parityPending: results.filter((result) => result.category === "parity-pending").length,
     parityFail: results.filter((result) => result.category === "parity-fail").length,
     sdkParityFail: results.filter((result) => result.category === "sdk-parity-fail").length,
+    sqliteStoreFail: results.filter((result) => result.category === "sqlite-store-fail").length,
     unexpected: results.filter((result) => result.category === "unexpected").length,
   },
   vectors: results,

--- a/conformance/sqlite-store-smoke.mjs
+++ b/conformance/sqlite-store-smoke.mjs
@@ -1,0 +1,70 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { runGraphWorkflow, SqliteExecutionHistoryStore } from "../packages/engine/src/index.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+
+/**
+ * SQLite execution history smoke: a completed run persists rows that survive store reopen.
+ */
+export async function runSqliteStoreSmoke() {
+  const definition = JSON.parse(
+    readFileSync(path.join(repoRoot, "examples", "fixtures.valid", "minimal-linear.workflow.json"), "utf8")
+  );
+  const executionId = "sqlite-store-smoke-1";
+  const dir = mkdtempSync(path.join(tmpdir(), "wf-sqlite-smoke-"));
+  const dbPath = path.join(dir, "runs.sqlite");
+
+  try {
+    const store = new SqliteExecutionHistoryStore({ path: dbPath });
+    const run = await runGraphWorkflow({
+      definition,
+      input: {},
+      executionId,
+      store,
+    });
+    if (run.status !== "completed") {
+      store.close();
+      return {
+        passed: false,
+        reason: `SQLite smoke expected status completed but got ${run.status}`,
+      };
+    }
+
+    const rowCount = store.listByExecution(executionId).length;
+    store.close();
+    if (rowCount < 2) {
+      return {
+        passed: false,
+        reason: `SQLite smoke expected persisted history rows but got ${rowCount}`,
+      };
+    }
+
+    const reopened = new SqliteExecutionHistoryStore({ path: dbPath });
+    const persisted = reopened.listByExecution(executionId);
+    reopened.close();
+    if (persisted.length !== rowCount) {
+      return {
+        passed: false,
+        reason: `SQLite smoke reopen row count mismatch: ${persisted.length} vs ${rowCount}`,
+      };
+    }
+
+    return { passed: true };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+if (import.meta.url === new URL(process.argv[1], "file:").href) {
+  const result = await runSqliteStoreSmoke();
+  if (result.passed) {
+    console.error("PASS [sqlite-store-smoke] SqliteExecutionHistoryStore persistence");
+  } else {
+    console.error(`FAIL [sqlite-store-smoke] ${result.reason}`);
+    process.exitCode = 1;
+  }
+}

--- a/conformance/vectors/parity/r2-interrupt-resume.vector.json
+++ b/conformance/vectors/parity/r2-interrupt-resume.vector.json
@@ -4,6 +4,10 @@
   "kind": "parity",
   "definition": "examples/lighthouse-customer-routing.workflow.json",
   "executionId": "parity-interrupt-resume-1",
+  "stubActivityOutputs": {
+    "classify": { "intent": "ambiguous", "confidence": 0.3 },
+    "open_ticket": { "ticket_id": "T-parity-1" }
+  },
   "steps": [
     {
       "op": "start",
@@ -19,7 +23,7 @@
       "resumePayload": { "intent": "billing" },
       "expect": {
         "status": "completed",
-        "result": { "intent": "billing", "confidence": null }
+        "result": { "intent": "billing", "confidence": 0.3 }
       }
     }
   ]

--- a/docs/architecture/arc42-assets/runbooks/mcp-stdio-host-smoke.md
+++ b/docs/architecture/arc42-assets/runbooks/mcp-stdio-host-smoke.md
@@ -42,6 +42,19 @@ To exercise **real** MCP `tools/call` for `tool_call` workflow nodes (instead of
 
 If the manifest cannot be read or fails schema validation, the process **exits with code 1** before listening on stdio (diagnostics on stderr). This path is **opt-in**; omit both to keep default in-process stub behavior.
 
+### Optional: SQLite execution history
+
+By default the stdio entrypoint keeps execution history **in memory** (non-persistent). For durable runs across process restarts:
+
+- **CLI:** `--store sqlite --store-path /absolute/or/relative/runs.sqlite`
+- **Environment:** `WORKFLOW_ENGINE_STORE=sqlite` and `WORKFLOW_ENGINE_STORE_PATH=/path/to/runs.sqlite` (CLI wins when both are set)
+
+Startup logs the selected store on stderr (`execution history store: memory` or `sqlite (<path>)`).
+
+**Shared-host risks:** one SQLite file should have a **single writer process** under normal operation. Multiple hosts or engine processes appending to the same file can break per-execution `seq` monotonicity. Restrict filesystem permissions on the database path.
+
+**Migrating from in-memory:** history in a running in-memory process is not portable. Stop the server, start with SQLite flags/env, and use new `execution_id` values for new runs (or integrate library export if you need custom migration).
+
 Trust boundaries, secrets, and when to prefer host-mediated execution: [ADR-0003](../../adr/ADR-0003-engine-direct-mcp-activity-execution.md). The host-mediated smoke steps below are unchanged; engine-direct does not replace `workflow_submit_activity` for `activity_execution_mode: host_mediated`.
 
 ## 2) Connect from an MCP-capable host (copy/paste)
@@ -250,7 +263,7 @@ Current posture for this smoke path:
 
 - Local-only stdio transport between host and adapter process.
 - No authentication or authorization layer in the adapter.
-- In-memory execution history store in the stdio entrypoint process (non-persistent and single-process POC behavior).
+- Default in-memory execution history store in the stdio entrypoint (non-persistent); optional SQLite via `--store sqlite --store-path <path>` for durable single-host runs (see section 1).
 
 Deferred hardening tracks to RFC-07:
 

--- a/docs/engine-profile.md
+++ b/docs/engine-profile.md
@@ -138,7 +138,7 @@ The full taxonomies are [RFC-04 §4.4](RFC/rfc-04-execution-model.md#44-command-
 
 - `ExecutionStarted`
 - `NodeScheduled`
-- `ActivityRequested`, `ActivityCompleted`, `ActivityFailed`
+- `ActivityRequested`, `ActivityCompleted`, `ActivityFailed` — `ActivityFailed` **MAY** include stable `code` (e.g. `OUTPUT_SCHEMA_VIOLATION` when an `llm_call` result fails `config.output_schema` validation at the activity boundary)
 - `StateUpdated` (or equivalent embedding per engine profile, per [RFC-04 §4.6](RFC/rfc-04-execution-model.md#46-state-updates-and-reducers))
 - `InterruptRaised`, `InterruptResumed`
 - `ExecutionCompleted`, `ExecutionFailed`, `ExecutionCancelled`

--- a/docs/user/node-reference.md
+++ b/docs/user/node-reference.md
@@ -63,13 +63,23 @@ Deterministic activity boundary. `config` must reference an implementation handl
 
 Model invocation. Early demos may stub transcripts without changing document shape.
 
+Optional `config.output_schema` (JSON Schema object) is validated at the **activity boundary** after completion (in-process executor or host `submitActivityOutcome`). Violations emit `ActivityFailed` with code **`OUTPUT_SCHEMA_VIOLATION`**.
+
 ```json
 {
   "id": "classify",
   "type": "llm_call",
   "config": {
     "model": "gpt-4",
-    "prompt": "Classify intent from: {{state.ticket_text}}"
+    "prompt": "Classify intent from: {{state.ticket_text}}",
+    "output_schema": {
+      "type": "object",
+      "properties": {
+        "intent": { "type": "string" },
+        "confidence": { "type": "number" }
+      },
+      "required": ["intent", "confidence"]
+    }
   }
 }
 ```

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -75,6 +75,29 @@ This starts a dedicated MCP stdio adapter layer with tools `workflow_start`, `wo
 
 Operator smoke runbook: `docs/architecture/arc42-assets/runbooks/mcp-stdio-host-smoke.md`.
 
+### Execution history store (`workflows-engine-mcp`)
+
+By default the MCP stdio bin uses an **in-memory** execution history store (non-persistent; history is lost when the process exits). For durable runs across restarts, enable SQLite:
+
+```bash
+workflows-engine-mcp --store sqlite --store-path /path/to/runs.sqlite
+```
+
+Environment equivalents (CLI flags override env):
+
+| Variable | Role |
+|----------|------|
+| `WORKFLOW_ENGINE_STORE` | `memory` (default) or `sqlite` |
+| `WORKFLOW_ENGINE_STORE_PATH` | SQLite database file path when store is `sqlite` |
+
+On startup the process logs the selected backend to stderr, for example `[engine-mcp-stdio] execution history store: sqlite (/path/to/runs.sqlite)`.
+
+**Shared-host risks:** A SQLite file is a single-writer append log. Do not point multiple MCP engine processes at the same database file unless you accept coordination risk (WAL helps readers but concurrent writers on the same `executionId` can still corrupt monotonic `seq` assumptions). Restrict filesystem permissions on the database path; backups and migration are operator responsibilities. Treat the file like any local secret-adjacent artifact on shared machines.
+
+**Migrating from in-memory:** Stop the in-memory server (history in that process cannot be exported). Start a new process with `--store sqlite --store-path <path>` (or env equivalents). In-flight executions cannot be resumed across the switch; clients must use new `execution_id` values or replay from exported history if you built a custom export path via the library store API.
+
+Requires **Node.js ≥ 22.5.0** (`node:sqlite`). See **Execution history** below for library embedder details and table layout.
+
 **Assistant hosts** that own LLM/tool credentials should pass `activity_execution_mode: "host_mediated"` and complete activities via `workflow_submit_activity`. End-user guide: [`docs/user/host-mediated-activities.md`](../../docs/user/host-mediated-activities.md) ([ADR-0002](../../docs/architecture/adr/ADR-0002-host-mediated-activity-execution.md)).
 
 ### Engine-direct `tool_call` execution (optional)

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -105,7 +105,7 @@ const activityExecutor = new LlmActivityExecutor({
 });
 ```
 
-Inject a custom **`LlmProvider`** for tests or non-OpenAI backends; the default uses fetch against `/chat/completions` with no extra SDK. Structured outputs are validated with AJV when `output_schema` is set. Failures return stable codes: `LLM_CONFIG_INVALID`, `LLM_CREDENTIALS_MISSING`, `LLM_PROVIDER_ERROR`, `LLM_OUTPUT_VALIDATION_FAILED` (surfaced as `ActivityFailed` in execution history).
+Inject a custom **`LlmProvider`** for tests or non-OpenAI backends; the default uses fetch against `/chat/completions` with no extra SDK. Structured outputs are validated with AJV when `output_schema` is set. In-process executor failures use `LLM_OUTPUT_VALIDATION_FAILED`; at the activity boundary (in-process and host-mediated submit) schema violations surface as **`OUTPUT_SCHEMA_VIOLATION`** on `ActivityFailed`. Other stable executor codes: `LLM_CONFIG_INVALID`, `LLM_CREDENTIALS_MISSING`, `LLM_PROVIDER_ERROR`.
 
 #### Prompt resolution (`buildLlmChatMessages`)
 

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -356,16 +356,22 @@ Parallel branches may attach **`parallelSpan`** on the checkpoint payload. Each 
 
 ### Workflow references
 
-`subworkflow` nodes resolve `config.workflow_ref` at runtime through an in-process registry (`src/orchestrator/workflow-ref-resolver.mjs`).
+`subworkflow` nodes resolve `config.workflow_ref` at runtime through `src/orchestrator/workflow-ref-resolver.mjs`.
 
 - **`registerWorkflowRef(workflowRef, definition)`** — register a parsed child definition object before running a parent that references `workflowRef`. Registrations last for the process lifetime.
-- **`clearWorkflowRefs()`** — reset the registry (tests and long-lived hosts).
+- **`resolveWorkflowRef(workflowRef, { versionPin? })`** — resolve a registry URN, built-in URN (monorepo checkout), or **HTTP(S) URL**. Optional `versionPin` (from `config.version_pin`) must match the SHA-256 hash of the child definition’s canonical JSON.
+- **`computeWorkflowDefinitionHash(definition)`** — SHA-256 of canonical JSON (same algorithm as checkpoint `definitionHash`).
+- **`setWorkflowRefFetchImpl(fetch)`** — inject `fetch` for tests or restricted hosts.
+- **`clearWorkflowRefs()`** — reset registry and fetch cache (tests and long-lived hosts).
 
-Import these helpers from `workflow-ref-resolver.mjs` (they are not re-exported from the package entrypoint today).
+Exported from the package entrypoint (`@agent-workflow/engine`).
 
 **Monorepo checkout:** one built-in reference resolves from disk when the **workflows** repository root is discoverable (`findWorkflowRepoRoot()`): `urn:awp:wf:unit-tests` → `examples/r3-unit-tests-child.workflow.json`.
 
-**Published npm install:** the tarball ships only `src/`, `schemas/`, and this README (`examples/` is not bundled). Built-in URNs do not resolve on disk; register every `workflow_ref` your definitions use via `registerWorkflowRef`, or load child JSON from your own artifact store and register it before `runGraphWorkflow` / MCP `workflow_start`.
+**Published npm install:** the tarball ships only `src/`, `schemas/`, and this README (`examples/` is not bundled). Built-in URNs do not resolve on disk. Choose one of:
+
+1. **`registerWorkflowRef`** — load child JSON from your artifact store (or bundle it in your app) and register each `workflow_ref` before `runGraphWorkflow` / MCP `workflow_start`.
+2. **HTTP(S) `workflow_ref`** — point `config.workflow_ref` at a hosted definition URL; the engine fetches and caches definitions keyed by ref + `version_pin`. Pin with `config.version_pin` set to `computeWorkflowDefinitionHash(childDefinition)` so cache hits and refetches are verified.
 
 Operator-oriented summary: [arc42 cross-cutting — workflow reference resolution](../../docs/architecture/arc42/08-cross-cutting-concepts.md#88-workflow-reference-resolution-subworkflow). Release notes: [alpha — known limitations](../../docs/releases/alpha-release-notes.md#known-limitations).
 

--- a/packages/engine/src/adapters/mcp/stdio-server-config.mjs
+++ b/packages/engine/src/adapters/mcp/stdio-server-config.mjs
@@ -62,6 +62,69 @@ export function resolveWorkflowEngineMcpConfigPath(argv, cwd = process.cwd()) {
 }
 
 /**
+ * @typedef {{ ok: true; kind: "memory" } | { ok: true; kind: "sqlite"; path: string } | { ok: false; error: string }} ExecutionHistoryStoreResolveResult
+ */
+
+/**
+ * Resolves execution history store options for `workflows-engine-mcp`.
+ * CLI `--store` / `--store-path` win over `WORKFLOW_ENGINE_STORE` / `WORKFLOW_ENGINE_STORE_PATH`.
+ * Default: in-memory store (backward compatible).
+ *
+ * @param {string[]} argv process.argv
+ * @param {NodeJS.ProcessEnv} [env]
+ * @param {string} [cwd]
+ * @returns {ExecutionHistoryStoreResolveResult}
+ */
+export function resolveExecutionHistoryStoreOptions(argv, env = process.env, cwd = process.cwd()) {
+  const sliced = argv.slice(2);
+  /** @type {string | null} */
+  let storeKind = null;
+  /** @type {string | null} */
+  let storePath = null;
+
+  for (let i = 0; i < sliced.length; i++) {
+    if (sliced[i] === "--store" && i + 1 < sliced.length) {
+      storeKind = sliced[i + 1];
+      i++;
+      continue;
+    }
+    if (sliced[i] === "--store-path" && i + 1 < sliced.length) {
+      storePath = sliced[i + 1];
+      i++;
+    }
+  }
+
+  if (!storeKind) {
+    const envStore = env.WORKFLOW_ENGINE_STORE;
+    if (envStore && String(envStore).trim() !== "") {
+      storeKind = String(envStore).trim();
+    }
+  }
+  if (!storePath) {
+    const envPath = env.WORKFLOW_ENGINE_STORE_PATH;
+    if (envPath && String(envPath).trim() !== "") {
+      storePath = String(envPath).trim();
+    }
+  }
+
+  const kind = storeKind ? String(storeKind).trim().toLowerCase() : "memory";
+  if (kind === "memory") {
+    return { ok: true, kind: "memory" };
+  }
+  if (kind === "sqlite") {
+    if (!storePath || String(storePath).trim() === "") {
+      return {
+        ok: false,
+        error: "SQLite store requires --store-path <path> or WORKFLOW_ENGINE_STORE_PATH",
+      };
+    }
+    const p = String(storePath).trim();
+    return { ok: true, kind: "sqlite", path: path.isAbsolute(p) ? p : path.resolve(cwd, p) };
+  }
+  return { ok: false, error: `Unknown store kind "${storeKind}"; expected memory or sqlite` };
+}
+
+/**
  * @param {string} raw Env value (inline JSON object or file path).
  * @param {string} cwd
  * @param {string} label Env var name for error messages.

--- a/packages/engine/src/index.mjs
+++ b/packages/engine/src/index.mjs
@@ -108,6 +108,13 @@ export {
 } from "./orchestrator/linear-runner.mjs";
 export { runGraphWorkflow, resumeGraphWorkflow, submitActivityOutcome, deliverSignalOutcome, cancelExecutionOutcome } from "./orchestrator/workflow-graph-walker.mjs";
 export { hydrateReplayContext } from "./orchestrator/replay-loader.mjs";
+export {
+  clearWorkflowRefs,
+  computeWorkflowDefinitionHash,
+  registerWorkflowRef,
+  resolveWorkflowRef,
+  setWorkflowRefFetchImpl,
+} from "./orchestrator/workflow-ref-resolver.mjs";
 export { createWorkflowApplicationPort } from "./application/workflow-application-port.mjs";
 export { createMcpWorkflowStdioServer } from "./adapters/mcp/stdio-server.mjs";
 export { createMcpWorkflowToolHandlers } from "./adapters/mcp/workflow-tools.mjs";

--- a/packages/engine/src/mcp-stdio-server.mjs
+++ b/packages/engine/src/mcp-stdio-server.mjs
@@ -6,18 +6,35 @@ import {
   formatMcpManifestValidationErrors,
   loadProductionActivityExecutor,
   loadProductionDelegateExecutor,
+  resolveExecutionHistoryStoreOptions,
   resolveTransportValidationOptionsFromEnv,
   resolveWorkflowEngineMcpConfigPath,
 } from "./adapters/mcp/stdio-server-config.mjs";
 import { MemoryExecutionHistoryStore } from "./persistence/memory-history-store.mjs";
 import { loadControlPlaneAuthConfigFromEnv } from "./security/control-plane-auth.mjs";
 
+/**
+ * @param {import("./adapters/mcp/stdio-server-config.mjs").ExecutionHistoryStoreResolveResult & { ok: true }} options
+ */
+async function createExecutionHistoryStoreFromOptions(options) {
+  if (options.kind === "memory") {
+    return new MemoryExecutionHistoryStore();
+  }
+  const { SqliteExecutionHistoryStore } = await import("./persistence/sqlite-history-store.mjs");
+  return new SqliteExecutionHistoryStore({ path: options.path });
+}
+
 async function main() {
   const args = process.argv.slice(2);
   if (args.includes("--help") || args.includes("-h")) {
     process.stdout.write(
-      "Usage: workflows-engine-mcp [--mcp-config <path>]\n" +
+      "Usage: workflows-engine-mcp [--mcp-config <path>] [--store memory|sqlite] [--store-path <path>]\n" +
         "Starts MCP stdio adapter with workflow_start/workflow_status/workflow_resume/workflow_submit_activity/workflow_signal/workflow_cancel/workflow_list tools.\n" +
+        "\n" +
+        "Execution history store:\n" +
+        "  --store memory|sqlite — persistence backend (default memory; env WORKFLOW_ENGINE_STORE)\n" +
+        "  --store-path <path> — SQLite database file when --store sqlite (env WORKFLOW_ENGINE_STORE_PATH)\n" +
+        "  CLI flags override env. SQLite requires Node.js >= 22.5.0 (node:sqlite).\n" +
         "\n" +
         "Production activity execution (composite router):\n" +
         "  WORKFLOW_ENGINE_MCP_CONFIG — operator MCP manifest for tool_call (or --mcp-config <path>).\n" +
@@ -88,7 +105,19 @@ async function main() {
     return;
   }
 
-  const store = new MemoryExecutionHistoryStore();
+  const storeOptions = resolveExecutionHistoryStoreOptions(process.argv);
+  if (!storeOptions.ok) {
+    process.stderr.write(`[engine-mcp-stdio] ${storeOptions.error}\n`);
+    process.exitCode = 1;
+    return;
+  }
+  const store = await createExecutionHistoryStoreFromOptions(storeOptions);
+  if (storeOptions.kind === "sqlite") {
+    process.stderr.write(`[engine-mcp-stdio] execution history store: sqlite (${storeOptions.path})\n`);
+  } else {
+    process.stderr.write("[engine-mcp-stdio] execution history store: memory\n");
+  }
+
   const workflowPort = createWorkflowApplicationPort({
     store,
     ...(activityExecutor ? { activityExecutor } : {}),

--- a/packages/engine/src/orchestrator/llm-output-schema-boundary.mjs
+++ b/packages/engine/src/orchestrator/llm-output-schema-boundary.mjs
@@ -1,0 +1,54 @@
+/**
+ * Activity-boundary validation for `llm_call` structured outputs (`output_schema`).
+ */
+import { parseLlmCallNodeConfig, validateLlmStructuredOutput } from "./llm-activity-executor.mjs";
+
+/** @typedef {"OUTPUT_SCHEMA_VIOLATION"} OutputSchemaViolationCode */
+
+export const OUTPUT_SCHEMA_VIOLATION = "OUTPUT_SCHEMA_VIOLATION";
+
+/**
+ * @param {unknown} output
+ * @returns {Record<string, unknown>}
+ */
+function normalizeActivityOutput(output) {
+  return output && typeof output === "object" && !Array.isArray(output)
+    ? /** @type {Record<string, unknown>} */ ({ .../** @type {object} */ (output) })
+    : { value: output };
+}
+
+/**
+ * Validate an activity result at the graph-walker boundary when the node is `llm_call` with `output_schema`.
+ *
+ * @param {{ type: string; config?: object }} node
+ * @param {unknown} output
+ * @returns {{ ok: true, output: Record<string, unknown> } | { ok: false, error: string, code: OutputSchemaViolationCode }}
+ */
+export function validateLlmCallOutputAtActivityBoundary(node, output) {
+  if (node.type !== "llm_call") {
+    return { ok: true, output: normalizeActivityOutput(output) };
+  }
+  const parsedCfg = parseLlmCallNodeConfig(node.config);
+  if (!parsedCfg.ok || !parsedCfg.config.outputSchema) {
+    return { ok: true, output: normalizeActivityOutput(output) };
+  }
+  const validated = validateLlmStructuredOutput(output, parsedCfg.config.outputSchema);
+  if (!validated.ok) {
+    return { ok: false, error: validated.error, code: OUTPUT_SCHEMA_VIOLATION };
+  }
+  return validated;
+}
+
+/**
+ * Map in-process executor failure codes to activity-boundary codes for `llm_call` nodes.
+ *
+ * @param {{ type: string }} node
+ * @param {string | undefined} code
+ * @returns {string | undefined}
+ */
+export function mapLlmActivityFailureCode(node, code) {
+  if (node.type === "llm_call" && code === "LLM_OUTPUT_VALIDATION_FAILED") {
+    return OUTPUT_SCHEMA_VIOLATION;
+  }
+  return code;
+}

--- a/packages/engine/src/orchestrator/subworkflow-runtime.mjs
+++ b/packages/engine/src/orchestrator/subworkflow-runtime.mjs
@@ -113,9 +113,12 @@ export async function executeSubworkflowNode(args) {
     return { kind: "failed", error: "subworkflow child invocation not allowed in this run" };
   }
 
+  const versionPin =
+    typeof cfg.version_pin === "string" && cfg.version_pin.trim() ? cfg.version_pin.trim() : undefined;
+
   let childDefinition;
   try {
-    childDefinition = resolveWorkflowRef(workflowRef);
+    childDefinition = await resolveWorkflowRef(workflowRef, { versionPin });
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     return { kind: "failed", error: msg };

--- a/packages/engine/src/orchestrator/workflow-graph-walker.mjs
+++ b/packages/engine/src/orchestrator/workflow-graph-walker.mjs
@@ -39,6 +39,9 @@ import {
   summarizePrompt,
 } from "./workflow-node-execution.mjs";
 import {
+  validateLlmCallOutputAtActivityBoundary,
+} from "./llm-output-schema-boundary.mjs";
+import {
   NondeterminismError,
   RESUME_FAILURE_CODE,
   checkpointDefinitionMeta,
@@ -1690,15 +1693,23 @@ export async function submitActivityOutcome(options) {
     };
   }
 
-  if (!outcome.ok) {
-    const { error, code } = outcome;
-    const attempt = typeof last.payload?.attempt === "number" && last.payload.attempt >= 1 ? last.payload.attempt : 1;
-    const activityNode = /** @type {{ nodes?: Array<{ id: string; retry?: object; timeout?: string }> }} */ (definition).nodes?.find(
-      (n) => n.id === nodeId
-    );
-    const maxAttempts = resolveMaxAttempts(activityNode ?? {});
-    const retryPolicy = getRetryPolicy(activityNode ?? {});
-    const timeoutMs = resolveNodeTimeoutMs(activityNode ?? {});
+  const attempt = typeof last.payload?.attempt === "number" && last.payload.attempt >= 1 ? last.payload.attempt : 1;
+  const activityNode = /** @type {{ nodes?: Array<{ id: string; type?: string; retry?: object; timeout?: string }> }} */ (
+    definition
+  ).nodes?.find((n) => n.id === nodeId);
+  const maxAttempts = resolveMaxAttempts(activityNode ?? {});
+  const retryPolicy = getRetryPolicy(activityNode ?? {});
+  const timeoutMs = resolveNodeTimeoutMs(activityNode ?? {});
+
+  /**
+   * @param {{ error: string; code?: string }} failure
+   * @returns {Promise<
+   *   | { status: "failed"; error: string; finalState?: Record<string, unknown>; code?: string }
+   *   | { status: "awaiting_activity"; executionId: string; nodeId: string; state: Record<string, unknown>; parallelSpan?: ParallelSpanPayload }
+   * >}
+   */
+  async function recordSubmittedActivityFailure(failure) {
+    const { error, code } = failure;
     const willRetry = shouldRetryAfterFailure(attempt, maxAttempts, code, retryPolicy);
 
     store.append(executionId, {
@@ -1767,7 +1778,16 @@ export async function submitActivityOutcome(options) {
       name: "ExecutionFailed",
       payload: { executionId, error },
     });
-    return { status: "failed", error, finalState: latestStateFromHistory(store.listByExecution(executionId)) };
+    return {
+      status: "failed",
+      error,
+      finalState: latestStateFromHistory(store.listByExecution(executionId)),
+      ...(code !== undefined ? { code } : {}),
+    };
+  }
+
+  if (!outcome.ok) {
+    return recordSubmittedActivityFailure({ error: outcome.error, code: outcome.code });
   }
 
   const rawResult = outcome.result;
@@ -1778,6 +1798,13 @@ export async function submitActivityOutcome(options) {
   const completedNode = validateWorkflowDefinition(definition).ok
     ? /** @type {{ nodes?: Array<{ id: string; type: string }> }} */ (definition).nodes?.find((n) => n.id === nodeId)
     : undefined;
+
+  const boundaryResult = completedNode
+    ? validateLlmCallOutputAtActivityBoundary(completedNode, resultObj)
+    : { ok: true, output: resultObj };
+  if (!boundaryResult.ok) {
+    return recordSubmittedActivityFailure({ error: boundaryResult.error, code: boundaryResult.code });
+  }
   const pendingNodeType =
     typeof last.payload?.nodeType === "string"
       ? last.payload.nodeType
@@ -1815,7 +1842,7 @@ export async function submitActivityOutcome(options) {
     }
   }
 
-  const storedResult = JSON.parse(JSON.stringify(resultObj));
+  const storedResult = JSON.parse(JSON.stringify(boundaryResult.output));
   if (isDelegateSubmit) {
     delete storedResult.delegateCorrelationId;
     delete storedResult.externalTaskId;

--- a/packages/engine/src/orchestrator/workflow-node-execution.mjs
+++ b/packages/engine/src/orchestrator/workflow-node-execution.mjs
@@ -11,6 +11,10 @@ import {
   resolveNodeTimeoutMs,
   shouldRetryAfterFailure,
 } from "./orchestration-policy.mjs";
+import {
+  mapLlmActivityFailureCode,
+  validateLlmCallOutputAtActivityBoundary,
+} from "./llm-output-schema-boundary.mjs";
 
 /**
  * @param {unknown} jqResult
@@ -234,27 +238,45 @@ export async function runPlaceholderActivityStep(args) {
       timeoutMs
     );
     if (!activityResult.ok) {
-      const willRetry = shouldRetryAfterFailure(attempt, maxAttempts, activityResult.code, retryPolicy);
+      const failureCode = mapLlmActivityFailureCode(node, activityResult.code);
+      const willRetry = shouldRetryAfterFailure(attempt, maxAttempts, failureCode, retryPolicy);
       appendEvt("ActivityFailed", {
         nodeId: node.id,
         error: activityResult.error,
         attempt,
-        ...(activityResult.code !== undefined ? { code: activityResult.code } : {}),
+        ...(failureCode !== undefined ? { code: failureCode } : {}),
         ...(willRetry ? { willRetry: true } : {}),
       });
       if (!willRetry) {
         return {
           kind: "failed",
           error: activityResult.error,
-          ...(activityResult.code !== undefined ? { code: activityResult.code } : {}),
+          ...(failureCode !== undefined ? { code: failureCode } : {}),
         };
       }
       const backoffMs = computeRetryBackoffMs(attempt, retryPolicy);
       if (backoffMs > 0) await policyDelay(backoffMs);
       continue;
     }
-    appendEvt("ActivityCompleted", { nodeId: node.id, result: activityResult.output });
-    return { kind: "completed", output: activityResult.output };
+    const boundaryResult = validateLlmCallOutputAtActivityBoundary(node, activityResult.output);
+    if (!boundaryResult.ok) {
+      const willRetry = shouldRetryAfterFailure(attempt, maxAttempts, boundaryResult.code, retryPolicy);
+      appendEvt("ActivityFailed", {
+        nodeId: node.id,
+        error: boundaryResult.error,
+        attempt,
+        code: boundaryResult.code,
+        ...(willRetry ? { willRetry: true } : {}),
+      });
+      if (!willRetry) {
+        return { kind: "failed", error: boundaryResult.error, code: boundaryResult.code };
+      }
+      const backoffMs = computeRetryBackoffMs(attempt, retryPolicy);
+      if (backoffMs > 0) await policyDelay(backoffMs);
+      continue;
+    }
+    appendEvt("ActivityCompleted", { nodeId: node.id, result: boundaryResult.output });
+    return { kind: "completed", output: boundaryResult.output };
   }
 
   return { kind: "failed", error: "activity failed after exhausting retry attempts" };

--- a/packages/engine/src/orchestrator/workflow-ref-resolver.mjs
+++ b/packages/engine/src/orchestrator/workflow-ref-resolver.mjs
@@ -82,6 +82,17 @@ function storeInFetchCache(workflowRef, definition, versionPin) {
 
 /**
  * @param {string} workflowRef
+ */
+function invalidateFetchCacheForRef(workflowRef) {
+  for (const key of fetchCache.keys()) {
+    if (key === workflowRef || key.startsWith(`${workflowRef}\0`)) {
+      fetchCache.delete(key);
+    }
+  }
+}
+
+/**
+ * @param {string} workflowRef
  * @param {object} definition
  */
 export function registerWorkflowRef(workflowRef, definition) {
@@ -92,6 +103,7 @@ export function registerWorkflowRef(workflowRef, definition) {
     throw new Error("definition must be a non-null object");
   }
   registry.set(workflowRef, definition);
+  invalidateFetchCacheForRef(workflowRef);
 }
 
 export function clearWorkflowRefs() {

--- a/packages/engine/src/orchestrator/workflow-ref-resolver.mjs
+++ b/packages/engine/src/orchestrator/workflow-ref-resolver.mjs
@@ -1,13 +1,84 @@
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { canonicalJsonStringify } from "../canonical-json.mjs";
 import { findWorkflowRepoRoot } from "../validate.mjs";
 
 /** @type {Map<string, object>} */
 const registry = new Map();
 
+/** @type {Map<string, { definition: object; definitionHash: string }>} */
+const fetchCache = new Map();
+
 /** @type {Record<string, string> | null} */
 let builtinFilenameByRef = null;
+
+/** @type {typeof fetch | null} */
+let fetchImpl = null;
+
+/**
+ * @param {object} definition
+ * @returns {string}
+ */
+export function computeWorkflowDefinitionHash(definition) {
+  return createHash("sha256").update(canonicalJsonStringify(definition)).digest("hex");
+}
+
+/**
+ * @param {typeof fetch} impl
+ */
+export function setWorkflowRefFetchImpl(impl) {
+  fetchImpl = impl;
+}
+
+/**
+ * @returns {typeof fetch}
+ */
+function resolveFetch() {
+  if (fetchImpl) return fetchImpl;
+  if (typeof globalThis.fetch !== "function") {
+    throw new Error("workflow_ref HTTP(S) resolution requires global fetch or setWorkflowRefFetchImpl()");
+  }
+  return globalThis.fetch;
+}
+
+/**
+ * @param {string} workflowRef
+ * @param {string | undefined} versionPin
+ * @returns {string}
+ */
+function cacheKey(workflowRef, versionPin) {
+  return versionPin ? `${workflowRef}\0${versionPin}` : workflowRef;
+}
+
+/**
+ * @param {object} definition
+ * @param {string | undefined} versionPin
+ * @returns {object}
+ */
+function assertVersionPin(definition, versionPin) {
+  if (!versionPin) return definition;
+  const hash = computeWorkflowDefinitionHash(definition);
+  if (hash !== versionPin) {
+    throw new Error(
+      `workflow_ref version_pin mismatch (expected ${versionPin}, resolved ${hash})`
+    );
+  }
+  return definition;
+}
+
+/**
+ * @param {string} workflowRef
+ * @param {object} definition
+ * @param {string | undefined} versionPin
+ * @returns {object}
+ */
+function storeInFetchCache(workflowRef, definition, versionPin) {
+  const definitionHash = computeWorkflowDefinitionHash(definition);
+  fetchCache.set(cacheKey(workflowRef, versionPin), { definition, definitionHash });
+  return definition;
+}
 
 /**
  * @param {string} workflowRef
@@ -25,6 +96,7 @@ export function registerWorkflowRef(workflowRef, definition) {
 
 export function clearWorkflowRefs() {
   registry.clear();
+  fetchCache.clear();
 }
 
 /**
@@ -41,14 +113,58 @@ function builtinRefs() {
 
 /**
  * @param {string} workflowRef
- * @returns {object}
+ * @returns {boolean}
  */
-export function resolveWorkflowRef(workflowRef) {
+function isHttpWorkflowRef(workflowRef) {
+  return workflowRef.startsWith("http://") || workflowRef.startsWith("https://");
+}
+
+/**
+ * @param {string} workflowRef
+ * @returns {Promise<object>}
+ */
+async function fetchWorkflowDefinition(workflowRef) {
+  const response = await resolveFetch()(workflowRef);
+  if (!response.ok) {
+    throw new Error(`workflow_ref fetch failed for "${workflowRef}" (HTTP ${response.status})`);
+  }
+  let definition;
+  try {
+    definition = await response.json();
+  } catch {
+    throw new Error(`workflow_ref fetch for "${workflowRef}" returned invalid JSON`);
+  }
+  if (!definition || typeof definition !== "object" || Array.isArray(definition)) {
+    throw new Error(`workflow_ref fetch for "${workflowRef}" must return a JSON object`);
+  }
+  return /** @type {object} */ (definition);
+}
+
+/**
+ * @param {string} workflowRef
+ * @param {{ versionPin?: string }} [options]
+ * @returns {Promise<object>}
+ */
+export async function resolveWorkflowRef(workflowRef, options = {}) {
   if (typeof workflowRef !== "string" || !workflowRef.trim()) {
     throw new Error("workflow_ref must be a non-empty string");
   }
-  const cached = registry.get(workflowRef);
-  if (cached) return cached;
+  const versionPin =
+    typeof options.versionPin === "string" && options.versionPin.trim()
+      ? options.versionPin.trim()
+      : undefined;
+
+  const cachedFetch = fetchCache.get(cacheKey(workflowRef, versionPin));
+  if (cachedFetch) {
+    assertVersionPin(cachedFetch.definition, versionPin);
+    return cachedFetch.definition;
+  }
+
+  const registered = registry.get(workflowRef);
+  if (registered) {
+    assertVersionPin(registered, versionPin);
+    return storeInFetchCache(workflowRef, registered, versionPin);
+  }
 
   const filename = builtinRefs()[workflowRef];
   if (filename) {
@@ -57,7 +173,14 @@ export function resolveWorkflowRef(workflowRef) {
     const filePath = path.join(root, "examples", filename);
     const definition = JSON.parse(readFileSync(filePath, "utf8"));
     registry.set(workflowRef, definition);
-    return definition;
+    assertVersionPin(definition, versionPin);
+    return storeInFetchCache(workflowRef, definition, versionPin);
+  }
+
+  if (isHttpWorkflowRef(workflowRef)) {
+    const definition = await fetchWorkflowDefinition(workflowRef);
+    assertVersionPin(definition, versionPin);
+    return storeInFetchCache(workflowRef, definition, versionPin);
   }
 
   throw new Error(`Unknown workflow_ref "${workflowRef}" (not registered and no built-in mapping)`);

--- a/packages/engine/test/mcp-stdio-adapter.test.mjs
+++ b/packages/engine/test/mcp-stdio-adapter.test.mjs
@@ -77,6 +77,16 @@ function loadLighthouse() {
   return JSON.parse(readFileSync(fixturePath, "utf8"));
 }
 
+/** Lighthouse classify has output_schema; ambiguous path needs schema-valid stub output. */
+function lighthouseAmbiguousPort(store) {
+  return createWorkflowApplicationPort({
+    store,
+    activityExecutor: new StubActivityExecutor({
+      classify: { intent: "ambiguous", confidence: 0.3 },
+    }),
+  });
+}
+
 function loadRepoJson(relPath) {
   const root = findWorkflowRepoRoot(__dirname);
   return JSON.parse(readFileSync(path.join(root, relPath), "utf8"));
@@ -136,7 +146,7 @@ describe("MCP workflow adapter tool handlers", () => {
   it("workflow_status deterministically projects interrupted phase and cursor from persisted history", async () => {
     const definition = loadLighthouse();
     const store = new MemoryExecutionHistoryStore();
-    const handlers = createMcpWorkflowToolHandlers(createWorkflowApplicationPort({ store }));
+    const handlers = createMcpWorkflowToolHandlers(lighthouseAmbiguousPort(store));
 
     const started = await handlers.workflow_start({
       execution_id: "exec-status-1",
@@ -221,7 +231,7 @@ describe("MCP workflow adapter tool handlers", () => {
   it("workflow_resume completes interrupted executions with valid payloads", async () => {
     const definition = loadLighthouse();
     const store = new MemoryExecutionHistoryStore();
-    const handlers = createMcpWorkflowToolHandlers(createWorkflowApplicationPort({ store }));
+    const handlers = createMcpWorkflowToolHandlers(lighthouseAmbiguousPort(store));
 
     const started = await handlers.workflow_start({
       execution_id: "exec-resume-happy",
@@ -239,7 +249,7 @@ describe("MCP workflow adapter tool handlers", () => {
     assert.equal(response.isError, undefined);
     assert.equal(response.structuredContent.execution_id, "exec-resume-happy");
     assert.equal(response.structuredContent.status, "completed");
-    assert.deepEqual(response.structuredContent.result, { intent: "billing", confidence: null });
+    assert.deepEqual(response.structuredContent.result, { intent: "billing", confidence: 0.3 });
   });
 
   it("workflow_resume maps invalid resume payload engine failures to INVALID_RESUME_PAYLOAD", async () => {

--- a/packages/engine/test/mcp-stdio-entrypoint.test.mjs
+++ b/packages/engine/test/mcp-stdio-entrypoint.test.mjs
@@ -1,10 +1,83 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { describe, it } from "node:test";
+import {
+  resolveExecutionHistoryStoreOptions,
+} from "../src/adapters/mcp/stdio-server-config.mjs";
+import { SqliteExecutionHistoryStore } from "../src/persistence/sqlite-history-store.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe("resolveExecutionHistoryStoreOptions", () => {
+  it("defaults to memory when unset", () => {
+    const result = resolveExecutionHistoryStoreOptions(["node", "mcp.mjs"], {}, process.cwd());
+    assert.deepEqual(result, { ok: true, kind: "memory" });
+  });
+
+  it("prefers --store and --store-path over env", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-store-"));
+    const dbPath = path.join(dir, "runs.sqlite");
+    const env = {
+      WORKFLOW_ENGINE_STORE: "memory",
+      WORKFLOW_ENGINE_STORE_PATH: path.join(dir, "ignored.sqlite"),
+    };
+    const argv = ["node", "mcp.mjs", "--store", "sqlite", "--store-path", dbPath];
+    const result = resolveExecutionHistoryStoreOptions(argv, env, dir);
+    assert.deepEqual(result, { ok: true, kind: "sqlite", path: dbPath });
+  });
+
+  it("uses WORKFLOW_ENGINE_STORE env when flags absent", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-store-"));
+    const dbPath = path.join(dir, "env.sqlite");
+    const result = resolveExecutionHistoryStoreOptions(
+      ["node", "mcp.mjs"],
+      { WORKFLOW_ENGINE_STORE: "sqlite", WORKFLOW_ENGINE_STORE_PATH: "env.sqlite" },
+      dir
+    );
+    assert.deepEqual(result, { ok: true, kind: "sqlite", path: dbPath });
+  });
+
+  it("rejects sqlite without store path", () => {
+    const result = resolveExecutionHistoryStoreOptions(["node", "mcp.mjs", "--store", "sqlite"], {}, process.cwd());
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.match(result.error, /store-path/i);
+    }
+  });
+
+  it("rejects unknown store kind", () => {
+    const result = resolveExecutionHistoryStoreOptions(["node", "mcp.mjs", "--store", "postgres"], {}, process.cwd());
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.match(result.error, /Unknown store kind/i);
+    }
+  });
+});
+
+describe("resolveExecutionHistoryStoreOptions persistence", () => {
+  it("persists rows in sqlite and survives reopen", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-store-"));
+    const dbPath = path.join(dir, "runs.sqlite");
+    try {
+      const options = { ok: true, kind: "sqlite", path: dbPath };
+      const store = new SqliteExecutionHistoryStore({ path: dbPath });
+      store.append("exec-1", { kind: "command", name: "StartRun", payload: { executionId: "exec-1" } });
+      store.close();
+
+      const reopened = new SqliteExecutionHistoryStore({ path: dbPath });
+      const rows = reopened.listByExecution("exec-1");
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].name, "StartRun");
+      reopened.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("MCP stdio entrypoint", () => {
   it("prints usage on --help", () => {
@@ -14,6 +87,8 @@ describe("MCP stdio entrypoint", () => {
     assert.equal(run.status, 0);
     assert.match(run.stdout, /workflow_submit_activity/i);
     assert.match(run.stdout, /workflow_start\/workflow_status\/workflow_resume/i);
+    assert.match(run.stdout, /--store memory\|sqlite/i);
+    assert.match(run.stdout, /--store-path/i);
     assert.equal(run.stderr, "");
   });
 
@@ -30,6 +105,7 @@ describe("MCP stdio entrypoint", () => {
       timeout: 2000,
     });
 
+    assert.match(run.stderr, /\[engine-mcp-stdio\] execution history store: memory/);
     assert.match(
       run.stderr,
       /\[engine-mcp-stdio\] activity routing: llm_call=production, tool_call=missing, step=missing/
@@ -53,5 +129,40 @@ describe("MCP stdio entrypoint", () => {
       run.stderr,
       /WORKFLOW_ENGINE_AUTH_TOKENS is set but stdio does not enforce bearer auth/
     );
+  });
+
+  it("exits when sqlite store is requested without store path", () => {
+    const scriptPath = path.resolve(__dirname, "../src/mcp-stdio-server.mjs");
+    const run = spawnSync(process.execPath, [scriptPath, "--store", "sqlite"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        WORKFLOW_ENGINE_MCP_CONFIG: "",
+      },
+    });
+
+    assert.equal(run.status, 1);
+    assert.match(run.stderr, /SQLite store requires --store-path/i);
+  });
+
+  it("logs sqlite store path on startup", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wf-mcp-sqlite-"));
+    const dbPath = path.join(dir, "runs.sqlite");
+    const scriptPath = path.resolve(__dirname, "../src/mcp-stdio-server.mjs");
+    const run = spawnSync(process.execPath, [scriptPath, "--store", "sqlite", "--store-path", dbPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        WORKFLOW_ENGINE_MCP_CONFIG: "",
+      },
+      timeout: 2000,
+    });
+
+    try {
+      assert.match(run.stderr, /execution history store: sqlite/);
+      assert.match(run.stderr, new RegExp(dbPath.replace(/\\/g, "\\\\")));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/engine/test/mcp-stdio-server-config.test.mjs
+++ b/packages/engine/test/mcp-stdio-server-config.test.mjs
@@ -14,6 +14,7 @@ import {
   loadProductionDelegateExecutor,
   loadStepHandlerRegistryFromEnv,
   resolveA2AOperatorConfigFromEnv,
+  resolveExecutionHistoryStoreOptions,
   resolveLlmOperatorConfigFromEnv,
   resolveWorkflowEngineMcpConfigPath,
 } from "../src/adapters/mcp/stdio-server-config.mjs";

--- a/packages/engine/test/rest-adapter.test.mjs
+++ b/packages/engine/test/rest-adapter.test.mjs
@@ -9,6 +9,7 @@ import { DefinitionRegistry } from "../src/adapters/rest/definition-registry.mjs
 import { MCP_ADAPTER_ERROR } from "../src/adapters/mcp/errors.mjs";
 import { buildControlPlaneAuthConfig } from "../src/security/control-plane-auth.mjs";
 import { createWorkflowApplicationPort } from "../src/application/workflow-application-port.mjs";
+import { StubActivityExecutor } from "../src/orchestrator/activity-executor.mjs";
 import { MemoryExecutionHistoryStore } from "../src/persistence/memory-history-store.mjs";
 import { findWorkflowRepoRoot } from "../src/validate.mjs";
 
@@ -70,12 +71,18 @@ function loadLighthouse() {
 
 /**
  * @param {(port: number) => Promise<void>} run
- * @param {{ authConfig?: import("../src/security/control-plane-auth.mjs").ControlPlaneAuthConfig }} [options]
+ * @param {{
+ *   authConfig?: import("../src/security/control-plane-auth.mjs").ControlPlaneAuthConfig;
+ *   activityExecutor?: import("../orchestrator/activity-executor.mjs").ActivityExecutor;
+ * }} [options]
  */
 async function withRestServer(run, options = {}) {
   const store = new MemoryExecutionHistoryStore();
   const definitionRegistry = new DefinitionRegistry();
-  const workflowPort = createWorkflowApplicationPort({ store });
+  const workflowPort = createWorkflowApplicationPort({
+    store,
+    ...(options.activityExecutor ? { activityExecutor: options.activityExecutor } : {}),
+  });
   const handler = createRestWorkflowHandler(workflowPort, {
     definitionRegistry,
     store,
@@ -191,23 +198,30 @@ describe("REST workflow adapter", () => {
   });
 
   it("resumes interrupted lighthouse execution", async () => {
-    await withRestServer(async (port) => {
-      const definition = loadLighthouse();
-      const registered = await requestJson(port, "POST", "/v1/workflows", { definition });
-      const started = await requestJson(port, "POST", `/v1/workflows/${registered.body.wf_id}/executions`, {
-        execution_id: "rest-resume-1",
-        input: { ticket_text: "unclear" },
-      });
-      assert.equal(started.body.status, "interrupted");
+    await withRestServer(
+      async (port) => {
+        const definition = loadLighthouse();
+        const registered = await requestJson(port, "POST", "/v1/workflows", { definition });
+        const started = await requestJson(port, "POST", `/v1/workflows/${registered.body.wf_id}/executions`, {
+          execution_id: "rest-resume-1",
+          input: { ticket_text: "unclear" },
+        });
+        assert.equal(started.body.status, "interrupted");
 
-      const resumed = await requestJson(port, "POST", "/v1/executions/rest-resume-1:resume", {
-        definition,
-        resume_payload: { intent: "billing" },
-      });
-      assert.equal(resumed.status, 200);
-      assert.equal(resumed.body.status, "completed");
-      assert.deepEqual(resumed.body.result, { intent: "billing", confidence: null });
-    });
+        const resumed = await requestJson(port, "POST", "/v1/executions/rest-resume-1:resume", {
+          definition,
+          resume_payload: { intent: "billing" },
+        });
+        assert.equal(resumed.status, 200);
+        assert.equal(resumed.body.status, "completed");
+        assert.deepEqual(resumed.body.result, { intent: "billing", confidence: 0.3 });
+      },
+      {
+        activityExecutor: new StubActivityExecutor({
+          classify: { intent: "ambiguous", confidence: 0.3 },
+        }),
+      }
+    );
   });
 
   it("maps stale resume attempts to INVALID_RESUME_PAYLOAD", async () => {

--- a/packages/engine/test/subworkflow.test.mjs
+++ b/packages/engine/test/subworkflow.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, it, beforeEach } from "node:test";
+import { describe, it, beforeEach, afterEach } from "node:test";
 import { findWorkflowRepoRoot, validateWorkflowDefinition } from "../src/validate.mjs";
 import { MemoryExecutionHistoryStore } from "../src/persistence/memory-history-store.mjs";
 import { runGraphWorkflow } from "../src/orchestrator/workflow-graph-walker.mjs";
@@ -10,7 +10,10 @@ import { hydrateReplayContext } from "../src/orchestrator/replay-loader.mjs";
 import { mintChildExecutionId } from "../src/orchestrator/subworkflow-runtime.mjs";
 import {
   clearWorkflowRefs,
+  computeWorkflowDefinitionHash,
   registerWorkflowRef,
+  resolveWorkflowRef,
+  setWorkflowRefFetchImpl,
 } from "../src/orchestrator/workflow-ref-resolver.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -23,6 +26,11 @@ function loadJson(rel) {
 describe("subworkflow", () => {
   beforeEach(() => {
     clearWorkflowRefs();
+    setWorkflowRefFetchImpl(null);
+  });
+
+  afterEach(() => {
+    setWorkflowRefFetchImpl(null);
   });
 
   it("runs parent with nested child execution and merges child state", async () => {
@@ -252,5 +260,43 @@ describe("subworkflow", () => {
     assert.equal(out.status, "completed");
     assert.equal(out.finalState?.tests_passed, true);
     assert.equal(store.listByExecution(childExecutionId).length, 0);
+  });
+
+  it("resolves HTTP workflow_ref with version_pin during parent run", async () => {
+    const parent = loadJson("examples/conformance-subworkflow-parent.workflow.json");
+    const child = loadJson("examples/r3-unit-tests-child.workflow.json");
+    const childUrl = "https://example.test/r3-unit-tests-child.workflow.json";
+    const versionPin = computeWorkflowDefinitionHash(child);
+
+    const parentWithHttpRef = structuredClone(parent);
+    const verifyNode = parentWithHttpRef.nodes.find((n) => n.id === "verify");
+    assert.ok(verifyNode);
+    verifyNode.config.workflow_ref = childUrl;
+    verifyNode.config.version_pin = versionPin;
+
+    setWorkflowRefFetchImpl(async (url) => {
+      assert.equal(url, childUrl);
+      return {
+        ok: true,
+        async json() {
+          return child;
+        },
+      };
+    });
+
+    const store = new MemoryExecutionHistoryStore();
+    const out = await runGraphWorkflow({
+      definition: parentWithHttpRef,
+      input: { repo: "acme/widget" },
+      executionId: "test-subworkflow-http-ref",
+      store,
+      stubActivityOutputs: {
+        run_tests: { tests_passed: true },
+      },
+    });
+
+    assert.equal(out.status, "completed");
+    assert.equal(out.finalState?.tests_passed, true);
+    assert.equal(out.finalState?.done, true);
   });
 });

--- a/packages/engine/test/workflow-graph-walker.test.mjs
+++ b/packages/engine/test/workflow-graph-walker.test.mjs
@@ -590,6 +590,245 @@ describe("runGraphWorkflow (host-mediated activities)", () => {
     assert.equal(executionCompleted.length, 1);
   });
 
+  it("host_mediated llm_call validates output_schema on submit (OUTPUT_SCHEMA_VIOLATION)", async () => {
+    /** @type {object} */
+    const definition = {
+      document: {
+        schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
+        name: "host-llm-schema",
+        version: "1.0.0",
+      },
+      state_schema: {
+        type: "object",
+        properties: {
+          intent: { type: "string" },
+          confidence: { type: "number" },
+        },
+      },
+      nodes: [
+        { id: "start", type: "start" },
+        {
+          id: "classify",
+          type: "llm_call",
+          config: {
+            model: "stub",
+            system_prompt: "classify",
+            output_schema: {
+              type: "object",
+              properties: {
+                intent: { type: "string" },
+                confidence: { type: "number" },
+              },
+              required: ["intent", "confidence"],
+            },
+          },
+          retry: { max_attempts: 1 },
+        },
+        { id: "end", type: "end", config: { output_mapping: ".intent" } },
+      ],
+      edges: [
+        { source: "__start__", target: "start" },
+        { source: "start", target: "classify" },
+        { source: "classify", target: "end" },
+      ],
+    };
+    assert.equal(validateWorkflowDefinition(definition).ok, true);
+
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "exec-host-llm-schema";
+    const input = { ticket_text: "help" };
+
+    const awaiting = await runGraphWorkflow({
+      definition,
+      input,
+      executionId,
+      store,
+      activityExecutionMode: "host_mediated",
+    });
+    assert.equal(awaiting.status, "awaiting_activity");
+    assert.equal(awaiting.nodeId, "classify");
+
+    const invalid = await submitActivityOutcome({
+      definition,
+      executionId,
+      store,
+      input,
+      nodeId: "classify",
+      outcome: { ok: true, result: { intent: "billing" } },
+    });
+    assert.equal(invalid.status, "failed");
+    assert.equal(invalid.code, "OUTPUT_SCHEMA_VIOLATION");
+
+    const rows = store.listByExecution(executionId);
+    const failedEvt = rows.find((r) => r.kind === "event" && r.name === "ActivityFailed");
+    assert.ok(failedEvt);
+    assert.equal(failedEvt.payload?.code, "OUTPUT_SCHEMA_VIOLATION");
+    assert.equal(
+      rows.filter((r) => r.kind === "event" && r.name === "ActivityCompleted" && r.payload?.nodeId === "classify")
+        .length,
+      0
+    );
+  });
+
+  it("host_mediated llm_call accepts valid output_schema on submit", async () => {
+    /** @type {object} */
+    const definition = {
+      document: {
+        schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
+        name: "host-llm-schema-ok",
+        version: "1.0.0",
+      },
+      state_schema: {
+        type: "object",
+        properties: {
+          intent: { type: "string" },
+          confidence: { type: "number" },
+        },
+      },
+      nodes: [
+        { id: "start", type: "start" },
+        {
+          id: "classify",
+          type: "llm_call",
+          config: {
+            model: "stub",
+            system_prompt: "classify",
+            output_schema: {
+              type: "object",
+              properties: {
+                intent: { type: "string" },
+                confidence: { type: "number" },
+              },
+              required: ["intent", "confidence"],
+            },
+          },
+        },
+        { id: "end", type: "end", config: { output_mapping: ".intent" } },
+      ],
+      edges: [
+        { source: "__start__", target: "start" },
+        { source: "start", target: "classify" },
+        { source: "classify", target: "end" },
+      ],
+    };
+    assert.equal(validateWorkflowDefinition(definition).ok, true);
+
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "exec-host-llm-schema-ok";
+    const input = { ticket_text: "help" };
+
+    const awaiting = await runGraphWorkflow({
+      definition,
+      input,
+      executionId,
+      store,
+      activityExecutionMode: "host_mediated",
+    });
+    assert.equal(awaiting.status, "awaiting_activity");
+
+    const done = await submitActivityOutcome({
+      definition,
+      executionId,
+      store,
+      input,
+      nodeId: "classify",
+      outcome: { ok: true, result: { intent: "technical", confidence: 0.9 } },
+    });
+    assert.equal(done.status, "completed");
+    assert.equal(done.result, "technical");
+  });
+
+  it("lighthouse classify host_mediated submit passes output_schema validation", async () => {
+    const definition = loadLighthouse();
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "exec-lighthouse-host-classify";
+    const input = { ticket_text: "VPN will not connect" };
+
+    const awaiting = await runGraphWorkflow({
+      definition,
+      input,
+      executionId,
+      store,
+      activityExecutionMode: "host_mediated",
+    });
+    assert.equal(awaiting.status, "awaiting_activity");
+    assert.equal(awaiting.nodeId, "classify");
+
+    const done = await submitActivityOutcome({
+      definition,
+      executionId,
+      store,
+      input,
+      nodeId: "classify",
+      outcome: { ok: true, result: { intent: "technical", confidence: 0.9 } },
+    });
+    assert.equal(done.status, "awaiting_activity");
+    assert.notEqual(done.nodeId, "classify");
+  });
+
+  it("in-process llm_call maps executor schema failure to OUTPUT_SCHEMA_VIOLATION", async () => {
+    /** @type {object} */
+    const definition = {
+      document: {
+        schema: "https://agent-workflow.dev/schemas/workflow-definition.json",
+        name: "inproc-llm-schema",
+        version: "1.0.0",
+      },
+      state_schema: {
+        type: "object",
+        properties: {
+          intent: { type: "string" },
+        },
+      },
+      nodes: [
+        { id: "start", type: "start" },
+        {
+          id: "classify",
+          type: "llm_call",
+          config: {
+            model: "stub",
+            output_schema: {
+              type: "object",
+              properties: { intent: { type: "string" }, confidence: { type: "number" } },
+              required: ["intent", "confidence"],
+            },
+          },
+          retry: { max_attempts: 1 },
+        },
+        { id: "end", type: "end", config: { output_mapping: ".intent" } },
+      ],
+      edges: [
+        { source: "__start__", target: "start" },
+        { source: "start", target: "classify" },
+        { source: "classify", target: "end" },
+      ],
+    };
+    assert.equal(validateWorkflowDefinition(definition).ok, true);
+
+    const store = new MemoryExecutionHistoryStore();
+    const executionId = "exec-inproc-llm-schema";
+    const executor = {
+      async executeActivity() {
+        return { ok: false, error: "schema mismatch", code: "LLM_OUTPUT_VALIDATION_FAILED" };
+      },
+    };
+
+    const result = await runGraphWorkflow({
+      definition,
+      input: {},
+      executionId,
+      store,
+      activityExecutor: executor,
+    });
+    assert.equal(result.status, "failed");
+
+    const failedEvt = store
+      .listByExecution(executionId)
+      .find((r) => r.kind === "event" && r.name === "ActivityFailed");
+    assert.ok(failedEvt);
+    assert.equal(failedEvt.payload?.code, "OUTPUT_SCHEMA_VIOLATION");
+  });
+
   it("submit continuation rejects mismatched input keys vs ExecutionStarted", async () => {
     /** @type {object} */
     const definition = {

--- a/packages/engine/test/workflow-ref-resolver.test.mjs
+++ b/packages/engine/test/workflow-ref-resolver.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, beforeEach, afterEach } from "node:test";
+import { findWorkflowRepoRoot } from "../src/validate.mjs";
+import {
+  clearWorkflowRefs,
+  computeWorkflowDefinitionHash,
+  registerWorkflowRef,
+  resolveWorkflowRef,
+  setWorkflowRefFetchImpl,
+} from "../src/orchestrator/workflow-ref-resolver.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = findWorkflowRepoRoot(__dirname);
+
+function loadJson(rel) {
+  return JSON.parse(readFileSync(path.join(repoRoot, rel), "utf8"));
+}
+
+describe("workflow-ref-resolver", () => {
+  beforeEach(() => {
+    clearWorkflowRefs();
+    setWorkflowRefFetchImpl(null);
+  });
+
+  afterEach(() => {
+    clearWorkflowRefs();
+    setWorkflowRefFetchImpl(null);
+  });
+
+  it("resolves registered workflow_ref", async () => {
+    const child = loadJson("examples/r3-unit-tests-child.workflow.json");
+    registerWorkflowRef("urn:test:child", child);
+    const resolved = await resolveWorkflowRef("urn:test:child");
+    assert.equal(resolved.document.name, "r3-unit-tests-child");
+  });
+
+  it("honors version_pin on registered refs", async () => {
+    const child = loadJson("examples/r3-unit-tests-child.workflow.json");
+    const pin = computeWorkflowDefinitionHash(child);
+    registerWorkflowRef("urn:test:child", child);
+    const resolved = await resolveWorkflowRef("urn:test:child", { versionPin: pin });
+    assert.equal(resolved.document.name, "r3-unit-tests-child");
+  });
+
+  it("rejects version_pin mismatch on registered refs", async () => {
+    const child = loadJson("examples/r3-unit-tests-child.workflow.json");
+    registerWorkflowRef("urn:test:child", child);
+    await assert.rejects(
+      () => resolveWorkflowRef("urn:test:child", { versionPin: "0".repeat(64) }),
+      /version_pin mismatch/
+    );
+  });
+
+  it("fetches HTTP(S) workflow_ref and caches by ref + version_pin", async () => {
+    const child = loadJson("examples/r3-unit-tests-child.workflow.json");
+    const url = "https://example.test/child.workflow.json";
+    const pin = computeWorkflowDefinitionHash(child);
+    let fetchCount = 0;
+
+    setWorkflowRefFetchImpl(async (requestedUrl) => {
+      assert.equal(requestedUrl, url);
+      fetchCount += 1;
+      return {
+        ok: true,
+        async json() {
+          return child;
+        },
+      };
+    });
+
+    const first = await resolveWorkflowRef(url, { versionPin: pin });
+    const second = await resolveWorkflowRef(url, { versionPin: pin });
+    assert.equal(fetchCount, 1);
+    assert.equal(first.document.name, "r3-unit-tests-child");
+    assert.equal(second.document.name, "r3-unit-tests-child");
+  });
+
+  it("rejects HTTP fetch when version_pin does not match payload", async () => {
+    const child = loadJson("examples/r3-unit-tests-child.workflow.json");
+    const url = "https://example.test/child.workflow.json";
+
+    setWorkflowRefFetchImpl(async () => ({
+      ok: true,
+      async json() {
+        return child;
+      },
+    }));
+
+    await assert.rejects(
+      () => resolveWorkflowRef(url, { versionPin: "f".repeat(64) }),
+      /version_pin mismatch/
+    );
+  });
+
+  it("surfaces HTTP fetch failures", async () => {
+    const url = "https://example.test/missing.workflow.json";
+    setWorkflowRefFetchImpl(async () => ({ ok: false, status: 404 }));
+
+    await assert.rejects(() => resolveWorkflowRef(url), /fetch failed.*404/);
+  });
+});

--- a/packages/engine/test/workflow-ref-resolver.test.mjs
+++ b/packages/engine/test/workflow-ref-resolver.test.mjs
@@ -54,6 +54,20 @@ describe("workflow-ref-resolver", () => {
     );
   });
 
+  it("registerWorkflowRef invalidates cached resolutions for the same ref", async () => {
+    const child = loadJson("examples/r3-unit-tests-child.workflow.json");
+    const updated = structuredClone(child);
+    updated.document = { ...updated.document, name: "r3-unit-tests-child-v2" };
+
+    registerWorkflowRef("urn:test:child", child);
+    const first = await resolveWorkflowRef("urn:test:child");
+    assert.equal(first.document.name, "r3-unit-tests-child");
+
+    registerWorkflowRef("urn:test:child", updated);
+    const second = await resolveWorkflowRef("urn:test:child");
+    assert.equal(second.document.name, "r3-unit-tests-child-v2");
+  });
+
   it("fetches HTTP(S) workflow_ref and caches by ref + version_pin", async () => {
     const child = loadJson("examples/r3-unit-tests-child.workflow.json");
     const url = "https://example.test/child.workflow.json";


### PR DESCRIPTION
## Summary
- BEN-108: Subworkflow definition registry with HTTP(S) fetch, version_pin hash verification, and caching
- BEN-109: llm_call output_schema validation at activity boundary (in-process + host_mediated submit) with OUTPUT_SCHEMA_VIOLATION
- BEN-110: SQLite-backed execution store for workflows-engine-mcp via CLI/env flags
- Follow-up fixes: lighthouse adapter tests and interrupt-resume parity vector aligned with output_schema behavior

## Spec and architecture traceability
- Linear epic: [BEN-88](https://linear.app/ben-van-den-bergh/issue/BEN-88/epic-composition-and-validation-subworkflow-registry-output-schema)
- Features: BEN-108, BEN-109, BEN-110 (parent BEN-81 GA stub replacement umbrella)
- Target release: R4 GA 1.0
- Type: feature
- RFC trace: RFC-03 workflow_ref / subworkflow; RFC-07 secrets unchanged; engine-profile llm_call output_schema
- ADR: ADR-0004 delegation/subworkflow (registry extension)
- Scope reviewed against docs/engine-profile.md

## Test plan
- [x] npm test (317 pass)
- [x] npm run validate-workflows
- [x] npm run conformance (60 pass, sqlite store smoke included)

Made with [Cursor](https://cursor.com)