### PR TITLE
feat(engine): BEN-89 GA release gate — E2E fixtures + v1 conformance

### DIFF
--- a/.claude/skills/wf-release/SKILL.md
+++ b/.claude/skills/wf-release/SKILL.md
@@ -66,7 +66,7 @@ No MCP server is required for the default release path.
 4. Verify `packages/engine/package.json` version matches tag base (e.g. tag `v0.1.3-alpha.1` → package `0.1.3`).
 5. Update `docs/releases/alpha-release-notes.md` and `docs/user/` when operator guidance changes.
 6. Run local gates: `check-engine-schema-sync`, `validate-workflows`, `conformance`, `test`, `npm pack --dry-run --workspace @agent-workflow/engine`.
-   - **GA baseline (`v0.y.z`, no `-alpha.N`):** also run `conformance:v1` and `e2e:lighthouse` per `docs/governance/ga-release-checklist.md` (stub audit gate).
+   - **GA baseline (`v0.y.z`, no `-alpha.N`):** also run `conformance:v1`, `e2e:lighthouse`, and `e2e:r3` per `docs/governance/ga-release-checklist.md` (stub audit gate).
 7. Open PR for version + release notes (preferred) or confirm working tree is release-only.
 8. Merge and re-confirm CI green on the release commit.
 

--- a/.claude/skills/wf-release/SKILL.md
+++ b/.claude/skills/wf-release/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: wf-release
 description: >-
-  Orchestrates alpha release preflight, version-tag creation, and postflight
+  Orchestrates alpha and GA release preflight, version-tag creation, and postflight
   verification for the workflows repository. Guides maintainers through
   checklist gates, tag push to trigger automated packaging/npm/docs/GitHub
   Release, and break-glass recovery. Use when cutting a release, preparing
   v0.y.z or v0.y.z-alpha.N tags, running release preflight, verifying publish
-  outcomes, or recovering a failed release workflow.
+  outcomes, GA v1 conformance gates, or recovering a failed release workflow.
 license: MIT
 metadata:
   author: workflows
@@ -23,7 +23,7 @@ metadata:
 - **Release identity:** annotated git tag `v*` on a green `master` commit (or short-lived `release/v0.y.z` tip for RC iterations)
 - **Automation trigger:** push tag → `.github/workflows/release.yml` (gates → pack → npm → docs → GitHub Release)
 - **Break-glass:** manual `release-packaging.yml`, `release-npm-publish.yml`, `docs-publish.yml`
-- **Policy docs:** `docs/governance/alpha-versioning-and-release-commit-flow.md`, `docs/governance/alpha-ci-cd-packaging-governance.md`, `docs/governance/release-process.md`
+- **Policy docs:** `docs/governance/alpha-versioning-and-release-commit-flow.md`, `docs/governance/alpha-ci-cd-packaging-governance.md`, `docs/governance/release-process.md`, `docs/governance/ga-release-checklist.md`
 
 ## Scope
 
@@ -66,6 +66,7 @@ No MCP server is required for the default release path.
 4. Verify `packages/engine/package.json` version matches tag base (e.g. tag `v0.1.3-alpha.1` → package `0.1.3`).
 5. Update `docs/releases/alpha-release-notes.md` and `docs/user/` when operator guidance changes.
 6. Run local gates: `check-engine-schema-sync`, `validate-workflows`, `conformance`, `test`, `npm pack --dry-run --workspace @agent-workflow/engine`.
+   - **GA baseline (`v0.y.z`, no `-alpha.N`):** also run `conformance:v1` and `e2e:lighthouse` per `docs/governance/ga-release-checklist.md` (stub audit gate).
 7. Open PR for version + release notes (preferred) or confirm working tree is release-only.
 8. Merge and re-confirm CI green on the release commit.
 
@@ -85,8 +86,8 @@ No MCP server is required for the default release path.
 2. Monitor `.github/workflows/release.yml` (`gh run watch`).
 
 3. Tag suffix drives automation defaults (`references/tag-and-publish.md`):
-   - `v0.y.z-alpha.N` → npm `alpha`, docs version only
-   - `v0.y.z` → npm `latest`, docs `latest` alias
+   - `v0.y.z-alpha.N` → npm `alpha`, docs version only, full `conformance` in release gates
+   - `v0.y.z` → npm `latest`, docs `latest` alias, **`conformance:v1` required** in release gates
 
 **Triggers:** "push release tag", "cut release", "publish v0.x"
 

--- a/.claude/skills/wf-release/references/preflight-checklist.md
+++ b/.claude/skills/wf-release/references/preflight-checklist.md
@@ -35,6 +35,8 @@ Per `docs/governance/alpha-versioning-and-release-commit-flow.md`:
 
 ## 4. Local quality gates (mirror CI)
 
+**Alpha iteration (`v0.y.z-alpha.N`):**
+
 ```bash
 npm run check-engine-schema-sync
 npm run validate-workflows
@@ -42,6 +44,27 @@ npm run conformance
 npm test
 npm pack --dry-run --workspace @agent-workflow/engine
 ```
+
+**GA baseline (`v0.y.z`, promotes `latest`):**
+
+```bash
+npm run check-engine-schema-sync
+npm run validate-workflows
+npm run conformance:v1
+npm run e2e:lighthouse
+npm test
+npm pack --dry-run --workspace @agent-workflow/engine
+```
+
+### GA stub audit gate
+
+Before pushing a non-alpha tag, confirm:
+
+- [ ] `npm run conformance:v1` passes (`status: "pass"`, `profile: "v1"` in JSON summary)
+- [ ] `npm run e2e:lighthouse` passes
+- [ ] `npm audit --audit-level=high` passes (CI runs this automatically)
+
+See `docs/governance/ga-release-checklist.md` for full v1 pass criteria.
 
 - [ ] All commands pass
 - [ ] Schema breaking change ack present if required (`SCHEMA_BREAKING_CHANGE_ACK` or `schemas/.schema-breaking-change-ack`)

--- a/.claude/skills/wf-release/references/preflight-checklist.md
+++ b/.claude/skills/wf-release/references/preflight-checklist.md
@@ -52,6 +52,7 @@ npm run check-engine-schema-sync
 npm run validate-workflows
 npm run conformance:v1
 npm run e2e:lighthouse
+npm run e2e:r3
 npm test
 npm pack --dry-run --workspace @agent-workflow/engine
 ```
@@ -62,6 +63,7 @@ Before pushing a non-alpha tag, confirm:
 
 - [ ] `npm run conformance:v1` passes (`status: "pass"`, `profile: "v1"` in JSON summary)
 - [ ] `npm run e2e:lighthouse` passes
+- [ ] `npm run e2e:r3` passes
 - [ ] `npm audit --audit-level=high` passes (CI runs this automatically)
 
 See `docs/governance/ga-release-checklist.md` for full v1 pass criteria.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
       checkout_ref: ${{ needs.resolve-release.outputs.tag }}
       node_version: "24"
       run_tests: true
+      conformance_profile: ${{ needs.resolve-release.outputs.promote_latest == 'true' && 'v1' || '' }}
     permissions:
       contents: read
 

--- a/.github/workflows/reusable-validate-and-test.yml
+++ b/.github/workflows/reusable-validate-and-test.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: boolean
         default: true
+      conformance_profile:
+        description: "Conformance profile tag (e.g. v1); empty runs all vectors"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -87,7 +92,14 @@ jobs:
         run: npm run validate-workflows
 
       - name: Run conformance harness
-        run: npm run conformance
+        env:
+          CONFORMANCE_PROFILE: ${{ inputs.conformance_profile }}
+        run: |
+          if [ -n "$CONFORMANCE_PROFILE" ]; then
+            npm run "conformance:${CONFORMANCE_PROFILE}"
+          else
+            npm run conformance
+          fi
 
       - name: Run lighthouse host-mediated E2E
         run: npm run e2e:lighthouse

--- a/.github/workflows/reusable-validate-and-test.yml
+++ b/.github/workflows/reusable-validate-and-test.yml
@@ -89,6 +89,9 @@ jobs:
       - name: Run conformance harness
         run: npm run conformance
 
+      - name: Run lighthouse host-mediated E2E
+        run: npm run e2e:lighthouse
+
       - name: Run package tests
         if: ${{ inputs.run_tests }}
         run: npm test

--- a/.github/workflows/reusable-validate-and-test.yml
+++ b/.github/workflows/reusable-validate-and-test.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Run lighthouse host-mediated E2E
         run: npm run e2e:lighthouse
 
+      - name: Run R3 multi-agent delegation E2E
+        run: npm run e2e:r3
+
       - name: Run package tests
         if: ${{ inputs.run_tests }}
         run: npm test

--- a/.github/workflows/reusable-validate-and-test.yml
+++ b/.github/workflows/reusable-validate-and-test.yml
@@ -94,12 +94,7 @@ jobs:
       - name: Run conformance harness
         env:
           CONFORMANCE_PROFILE: ${{ inputs.conformance_profile }}
-        run: |
-          if [ -n "$CONFORMANCE_PROFILE" ]; then
-            npm run "conformance:${CONFORMANCE_PROFILE}"
-          else
-            npm run conformance
-          fi
+        run: node conformance/run-conformance.mjs
 
       - name: Run lighthouse host-mediated E2E
         run: npm run e2e:lighthouse

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -18,6 +18,14 @@ Optional (local only): allow `pending: true` parity vectors to pass:
 CONFORMANCE_ALLOW_PENDING=1 npm run conformance
 ```
 
+**GA v1 profile** (release gate for non-alpha tags):
+
+```bash
+npm run conformance:v1
+```
+
+Pass criteria: exit code `0`, JSON summary `status: "pass"` with `profile: "v1"`. Includes all vectors without a `profiles` field (default GA surface) plus sdk-parity and sqlite-store smokes. Vectors tagged with a `profiles` array are included only when the array contains `"v1"`. See [docs/governance/ga-release-checklist.md](../docs/governance/ga-release-checklist.md).
+
 Expected behavior:
 
 - Exit code `0` when all vectors match expected outcomes.
@@ -60,6 +68,7 @@ Each vector file is JSON. Schema vector example:
 
 - `id`: stable identifier used in logs and CI output.
 - `kind`: vector executor (`schema`, `replay`, or `parity`).
+- `profiles` (optional): profile tags (e.g. `["v1"]`). When omitted, the vector runs in **all** profiles including `v1`. When set, the vector runs only when the active profile is listed.
 - `definition`: path relative to repository root.
 - `expect.ok`: expected validation outcome.
 - `expect.diagnostics` (optional): stable failure signals for expected-invalid vectors.
@@ -110,7 +119,7 @@ Replay fields:
 
 ## Discovery contract
 
-Vectors are discovered by recursively scanning `conformance/vectors/` for `*.vector.json` and sorting by lexical path order before execution.
+Vectors are discovered by recursively scanning `conformance/vectors/` for `*.vector.json` and sorting by lexical path order before execution. When a profile is requested (`--profile=v1` or `CONFORMANCE_PROFILE`), vectors are filtered: include when `profiles` is omitted or when `profiles` contains the requested tag.
 
 This guarantees deterministic ordering across local and CI runs.
 

--- a/conformance/run-conformance.mjs
+++ b/conformance/run-conformance.mjs
@@ -2,7 +2,21 @@ import { discoverVectors, runVector } from "./runner.mjs";
 import { runSdkParitySmoke } from "./sdk-parity-smoke.mjs";
 import { runSqliteStoreSmoke } from "./sqlite-store-smoke.mjs";
 
-const discovered = discoverVectors();
+/**
+ * @returns {string | undefined}
+ */
+function parseProfile() {
+  for (const arg of process.argv.slice(2)) {
+    if (arg.startsWith("--profile=")) {
+      return arg.slice("--profile=".length);
+    }
+  }
+  const envProfile = process.env.CONFORMANCE_PROFILE;
+  return envProfile && envProfile.length > 0 ? envProfile : undefined;
+}
+
+const profile = parseProfile();
+const discovered = discoverVectors({ profile });
 const results = await Promise.all(discovered.map(runVector));
 const sdkSmoke = await runSdkParitySmoke();
 if (sdkSmoke.passed) {
@@ -53,6 +67,7 @@ for (const result of results) {
 
 const summary = {
   status: failed.length === 0 ? "pass" : "fail",
+  profile: profile ?? null,
   total: results.length,
   passed: results.length - failed.length,
   failed: failed.length,

--- a/conformance/run-conformance.mjs
+++ b/conformance/run-conformance.mjs
@@ -17,6 +17,12 @@ function parseProfile() {
 
 const profile = parseProfile();
 const discovered = discoverVectors({ profile });
+if (profile && discovered.length === 0) {
+  console.error(`FAIL [profile] No conformance vectors match profile "${profile}"`);
+  console.log(JSON.stringify({ status: "fail", profile, total: 0, passed: 0, failed: 1, reason: "no_vectors_for_profile" }, null, 2));
+  process.exitCode = 1;
+  process.exit(1);
+}
 const results = await Promise.all(discovered.map(runVector));
 const sdkSmoke = await runSdkParitySmoke();
 if (sdkSmoke.passed) {

--- a/conformance/runner.mjs
+++ b/conformance/runner.mjs
@@ -60,6 +60,7 @@ const vectorsRoot = path.join(__dirname, "vectors");
  *   signingPolicy?: { mode: "optional" | "require" };
  *   publicKeys?: Record<string, string>;
  *   tamperSignatureValue?: boolean;
+ *   profiles?: string[];
  *   expect:
  *     | {
  *         ok: boolean;
@@ -106,15 +107,35 @@ function walk(directory) {
 }
 
 /**
+ * @param {{ profile?: string }} [options]
+ * @returns {boolean}
+ */
+function vectorMatchesProfile(vector, profile) {
+  if (!profile) {
+    return true;
+  }
+  const profiles = vector.profiles;
+  if (profiles === undefined) {
+    return true;
+  }
+  return Array.isArray(profiles) && profiles.includes(profile);
+}
+
+/**
  * Deterministic vector discovery in lexical path order.
+ * When `profile` is set, includes vectors with no `profiles` field (all profiles)
+ * or whose `profiles` array contains the requested tag (e.g. `"v1"`).
+ * @param {{ profile?: string }} [options]
  * @returns {{ file: string, vector: ConformanceVector }[]}
  */
-export function discoverVectors() {
+export function discoverVectors({ profile } = {}) {
   const vectorFiles = walk(vectorsRoot).sort((a, b) => a.localeCompare(b));
-  return vectorFiles.map((file) => {
-    const vector = JSON.parse(readFileSync(file, "utf8"));
-    return { file, vector };
-  });
+  return vectorFiles
+    .map((file) => {
+      const vector = JSON.parse(readFileSync(file, "utf8"));
+      return { file, vector };
+    })
+    .filter(({ vector }) => vectorMatchesProfile(vector, profile));
 }
 
 /**

--- a/docs/architecture/arc42-assets/runbooks/lighthouse-e2e-host-mediated.md
+++ b/docs/architecture/arc42-assets/runbooks/lighthouse-e2e-host-mediated.md
@@ -1,0 +1,70 @@
+# Lighthouse host-mediated E2E
+
+This runbook documents the scripted end-to-end path for the lighthouse golden fixture using **host-mediated** activity completion (not stub-only `in_process` execution).
+
+## Scope and non-goals
+
+- **Scope:** Prove the real `ActivityRequested` → host `submitActivityOutcome` → `ActivityCompleted` continuation path for lighthouse `classify` (`llm_call`) and `search_kb` (`tool_call`) on the **technical** routing branch.
+- **Non-goals:** MCP stdio host wiring (see [mcp-stdio-host-smoke.md](./mcp-stdio-host-smoke.md)), engine-direct MCP `tools/call`, production auth, or billing/interrupt paths (covered by conformance parity vectors).
+
+## Prerequisites
+
+- Node.js `>=22.5.0`
+- Repository clone with dependencies installed:
+
+```bash
+npm install
+```
+
+## Run the E2E script
+
+From repository root:
+
+```bash
+npm run e2e:lighthouse
+```
+
+Or directly:
+
+```bash
+node scripts/e2e-lighthouse-host-mediated.mjs
+```
+
+## What the script does
+
+1. Loads and validates `examples/lighthouse-customer-routing.workflow.json` via `validateWorkflowDefinition`.
+2. Starts execution with `activityExecutionMode: "host_mediated"` and input `{ "ticket_text": "My API returns 500 on /payments endpoint." }`.
+3. Asserts the walker yields `awaiting_activity` at node `classify` (no in-process stub completion).
+4. Submits host outcomes:
+   - `classify` → `{ intent: "technical", confidence: 0.9 }` (passes `output_schema` validation).
+   - `search_kb` → `{ snippets: [{ id: "kb-42", title: "Payments API 500" }] }`.
+5. Asserts `status: "completed"` with result `{ intent: "technical", confidence: 0.9 }`.
+6. Asserts routing: `NodeScheduled` includes `search_kb` and excludes `human_review` and `open_ticket`.
+7. Asserts append-only history contains `ActivityCompleted` for both activities (not replay-only stubs) and ends with `ExecutionCompleted`.
+
+Exit code `0` on success; non-zero on any assertion failure.
+
+## Expected output (success)
+
+```
+Lighthouse host-mediated E2E: PASS
+- execution_id: e2e-lighthouse-host-mediated-tech
+- result: {"intent":"technical","confidence":0.9}
+- routed nodes: search_kb (technical path)
+```
+
+## How this proves the real activity path
+
+| Check | Why it matters |
+|-------|----------------|
+| `activityExecutionMode: "host_mediated"` on start | Walker emits `ActivityRequested` and returns without calling `StubActivityExecutor` for pending nodes. |
+| Two `submitActivityOutcome` calls | Host supplies activity results at the boundary; engine appends `ActivityCompleted` and continues the graph. |
+| `output_schema` on `classify` submit | Validates host-mediated `llm_call` completion semantics (see `packages/engine/test/workflow-graph-walker.test.mjs`). |
+| Technical branch scheduling | Confirms `switch` routing after host classify, not a single-shot stub run. |
+| History assertions | Ensures completions are persisted events, not replay markers from stub-only paths. |
+
+Related conformance coverage: `parity.r2.host_mediated_lighthouse_classify` (billing path via `open_ticket`). This E2E complements that vector with the **technical** path via `search_kb`.
+
+## CI
+
+`npm run e2e:lighthouse` runs in the reusable validation workflow (`.github/workflows/reusable-validate-and-test.yml`) after conformance on pull requests and pushes to `master`.

--- a/docs/architecture/arc42-assets/runbooks/r3-multi-agent-delegation-e2e.md
+++ b/docs/architecture/arc42-assets/runbooks/r3-multi-agent-delegation-e2e.md
@@ -1,0 +1,70 @@
+# R3 multi-agent delegation E2E
+
+This runbook documents the scripted end-to-end path for the `r3-multi-agent-coding` golden fixture using **real A2A delegation** via `A2ADelegateExecutor` (not `MockA2ADelegateExecutor` or stub-only in-process paths).
+
+## Scope and non-goals
+
+- **Scope:** Prove `agent_delegate` with `protocol: "a2a"` submits to an HTTP A2A endpoint, polls until terminal, and persists `externalTaskId` / `delegateCorrelationId` on `ActivityCompleted`; then continues through the `verify` subworkflow to the `review` interrupt.
+- **Non-goals:** Production A2A agent hosts, MCP/SDK delegate paths, or human resume after `review` (covered by unit tests and conformance vectors).
+
+## Prerequisites
+
+- Node.js `>=22.5.0`
+- Repository clone with dependencies installed:
+
+```bash
+npm install
+```
+
+## Run the E2E script
+
+From repository root:
+
+```bash
+npm run e2e:r3
+```
+
+Or directly:
+
+```bash
+node scripts/e2e-r3-multi-agent-delegation.mjs
+```
+
+## What the script does
+
+1. Loads and validates `examples/r3-multi-agent-coding.workflow.json` via `validateWorkflowDefinition`.
+2. Registers child workflow `urn:awp:wf:unit-tests` from `examples/r3-unit-tests-child.workflow.json`.
+3. Starts an in-process mock A2A HTTP server (`packages/engine/test/helpers/a2a-mock-http-server.mjs`) on `127.0.0.1`.
+4. Runs the parent workflow with `A2ADelegateExecutor` pointed at the mock server and `stubActivityOutputs.run_tests` for the child `tool_call` (subworkflow verify path only).
+5. Asserts:
+   - `implement` `ActivityCompleted` includes `externalTaskId: "a2a-task-1"` and expected `delegateCorrelationId`.
+   - Mock server received exactly one delegated task.
+   - Workflow reaches `status: "interrupted"` at node `review` with `patch` and `tests_passed: true` in state.
+   - `InterruptRaised` for `review` is present in history.
+
+Exit code `0` on success; non-zero on any assertion failure.
+
+## Expected output (success)
+
+```
+R3 multi-agent delegation E2E: PASS
+- execution_id: e2e-r3-multi-agent-delegation
+- status: interrupted at node review
+- external_task_id: a2a-task-1
+- patch: // A2A patch for: fix bug...
+```
+
+## How this proves the real delegation path
+
+| Check | Why it matters |
+|-------|----------------|
+| `A2ADelegateExecutor` (not mock executor) | Exercises HTTP submit + poll transport and credential resolution. |
+| In-process A2A mock server | Deterministic external task lifecycle without a live agent host. |
+| `externalTaskId` on `ActivityCompleted` | Confirms GA correlation fields for native `agent_delegate`. |
+| Subworkflow + interrupt continuation | Shows delegate completion feeds verify/review graph, not an isolated delegate unit test. |
+
+Related coverage: `packages/engine/test/a2a-delegate-executor.test.mjs` ("runs r3-multi-agent-coding implement step via A2A against mock server"). This E2E script mirrors that test as a standalone CI gate.
+
+## CI
+
+`npm run e2e:r3` runs in the reusable validation workflow (`.github/workflows/reusable-validate-and-test.yml`) after `e2e:lighthouse` on pull requests and pushes to `master`.

--- a/docs/governance/ga-release-checklist.md
+++ b/docs/governance/ga-release-checklist.md
@@ -11,6 +11,7 @@ npm run check-engine-schema-sync
 npm run validate-workflows
 npm run conformance:v1
 npm run e2e:lighthouse
+npm run e2e:r3
 npm test
 npm pack --dry-run --workspace @agent-workflow/engine
 ```
@@ -32,6 +33,7 @@ Before pushing a GA tag, confirm:
 
 - [ ] `npm run conformance:v1` passes (v1 profile conformance)
 - [ ] `npm run e2e:lighthouse` passes (host-mediated lighthouse E2E)
+- [ ] `npm run e2e:r3` passes (real A2A delegation E2E)
 - [ ] `npm audit --audit-level=high` passes (mirrored in CI reusable workflow)
 - [ ] `packages/engine/package.json` version matches tag base (`v0.2.0` → `0.2.0`)
 - [ ] Release notes section exists for the tag

--- a/docs/governance/ga-release-checklist.md
+++ b/docs/governance/ga-release-checklist.md
@@ -1,0 +1,61 @@
+# GA release checklist (v1 conformance gate)
+
+**Last reviewed:** 2026-06-24
+
+Use this checklist when cutting a **non-alpha** release tag (`v0.y.z` without `-alpha.N`). Tag-triggered automation (`.github/workflows/release.yml`) promotes npm `latest`, docs `latest`, and creates a GitHub Release only after these gates pass on the tagged commit.
+
+## Preflight (local, exact release commit)
+
+```bash
+npm run check-engine-schema-sync
+npm run validate-workflows
+npm run conformance:v1
+npm run e2e:lighthouse
+npm test
+npm pack --dry-run --workspace @agent-workflow/engine
+```
+
+### v1 conformance pass criteria
+
+`npm run conformance:v1` must:
+
+1. Exit with code **0**
+2. Emit JSON summary on stdout with `"status": "pass"` and `"profile": "v1"`
+3. Pass every vector in the v1 profile (schema, replay, parity, signing under `conformance/vectors/`, plus sdk-parity-smoke and sqlite-store-smoke)
+4. Fail on any `parity-pending` vector (same as full `npm run conformance` in CI)
+
+Vectors without a `profiles` field are included in v1 (backward compatible). Future experimental vectors may set `"profiles": ["alpha-only"]` to exclude them from this gate.
+
+### Stub audit gate (GA preflight)
+
+Before pushing a GA tag, confirm:
+
+- [ ] `npm run conformance:v1` passes (v1 profile conformance)
+- [ ] `npm run e2e:lighthouse` passes (host-mediated lighthouse E2E)
+- [ ] `npm audit --audit-level=high` passes (mirrored in CI reusable workflow)
+- [ ] `packages/engine/package.json` version matches tag base (`v0.2.0` → `0.2.0`)
+- [ ] Release notes section exists for the tag
+- [ ] CI green on target SHA (`Validate workflow definitions / validate-workflows`)
+
+## Automation (tag push)
+
+Push annotated tag `v0.y.z` on green `master`. `release.yml` runs `conformance:v1` (not full conformance) when `promote_latest` is true. Failed v1 conformance blocks npm `latest`, docs promotion, and GitHub Release creation.
+
+| Tag pattern | Conformance in release gates | npm dist-tag |
+|-------------|------------------------------|--------------|
+| `v0.y.z-alpha.N` | full `npm run conformance` | `alpha` |
+| `v0.y.z` | `npm run conformance:v1` | `latest` |
+
+## Postflight
+
+- [ ] `npm view @agent-workflow/engine@<version> version`
+- [ ] Docs site shows version with `latest` alias
+- [ ] `gh release view v0.y.z`
+- [ ] Conformance summary JSON archived in release notes when practical
+
+## Related docs
+
+- [release-process.md](release-process.md) — alpha and GA automation map
+- [conformance/README.md](../../conformance/README.md) — harness and profile semantics
+- [migration-alpha-to-ga.md](../migration-alpha-to-ga.md) — operator migration guide
+- `.claude/skills/wf-release/` — maintainer orchestration skill

--- a/docs/governance/ga-release-checklist.md
+++ b/docs/governance/ga-release-checklist.md
@@ -27,13 +27,13 @@ npm pack --dry-run --workspace @agent-workflow/engine
 
 Vectors without a `profiles` field are included in v1 (backward compatible). Future experimental vectors may set `"profiles": ["alpha-only"]` to exclude them from this gate.
 
-### Stub audit gate (GA preflight)
+### Real-path audit gate (GA preflight)
 
-Before pushing a GA tag, confirm:
+Before pushing a GA tag, confirm production-relevant execution paths are exercised (not default stub/mock-only):
 
 - [ ] `npm run conformance:v1` passes (v1 profile conformance)
-- [ ] `npm run e2e:lighthouse` passes (host-mediated lighthouse E2E)
-- [ ] `npm run e2e:r3` passes (real A2A delegation E2E)
+- [ ] `npm run e2e:lighthouse` passes (host-mediated activity completion)
+- [ ] `npm run e2e:r3` passes (real `A2ADelegateExecutor` against mock A2A server; child `run_tests` may use in-process stub)
 - [ ] `npm audit --audit-level=high` passes (mirrored in CI reusable workflow)
 - [ ] `packages/engine/package.json` version matches tag base (`v0.2.0` → `0.2.0`)
 - [ ] Release notes section exists for the tag

--- a/docs/governance/release-process.md
+++ b/docs/governance/release-process.md
@@ -36,4 +36,5 @@ If an alpha release is broken or mislabeled: stop promotion, document the impact
 
 - [alpha-versioning-and-release-commit-flow.md](alpha-versioning-and-release-commit-flow.md) — SemVer, checklist, changelog template
 - [alpha-ci-cd-packaging-governance.md](alpha-ci-cd-packaging-governance.md) — workflow permissions, check names, troubleshooting
+- [ga-release-checklist.md](ga-release-checklist.md) — v1 conformance and GA preflight gates
 - [alpha-release-notes.md](../releases/alpha-release-notes.md) — shipped version history (feeds GitHub Releases)

--- a/docs/migration-alpha-to-ga.md
+++ b/docs/migration-alpha-to-ga.md
@@ -79,16 +79,16 @@ Reference engine: in-process mock A2A for `protocol: "a2a"`; MCP/SDK paths may s
 npm run check-engine-schema-sync
 npm run validate-workflows
 npm test
-npm run conformance
+npm run conformance:v1
 ```
 
-Record conformance summary JSON in release notes when tagging GA artifacts.
+Record conformance summary JSON (`"profile": "v1"`, `"status": "pass"`) in release notes when tagging GA artifacts.
 
 ---
 
 ## Open items (stub)
 
 - [ ] Published GA semver and npm dist-tag policy  
-- [ ] Conformance profile name and badge (`passes-v1-core`)  
+- [x] Conformance profile name and badge (`v1` profile; `npm run conformance:v1`; release gate in `release.yml`)  
 - [ ] Changelog entries for any breaking MCP error code changes  
 - [ ] HTTP version negotiation (deferred; see [profile-model.md](./profile-model.md))

--- a/docs/migration-alpha-to-ga.md
+++ b/docs/migration-alpha-to-ga.md
@@ -80,6 +80,8 @@ npm run check-engine-schema-sync
 npm run validate-workflows
 npm test
 npm run conformance:v1
+npm run e2e:lighthouse
+npm run e2e:r3
 ```
 
 Record conformance summary JSON (`"profile": "v1"`, `"status": "pass"`) in release notes when tagging GA artifacts.

--- a/docs/migration-alpha-to-ga.md
+++ b/docs/migration-alpha-to-ga.md
@@ -43,7 +43,7 @@ Alpha milestones often modeled agent work as MCP-shaped **`tool_call`** nodes (`
 3. Re-run conformance/replay fixtures; event prefixes should remain valid when lifecycle timing is preserved (`docs/engine-profile.md` §2.2).
 4. Keep `tool_call` for non-agent tools (CRM, search, calculators); remove agent-shaped tools once hosts support delegate.
 
-Reference engine: in-process mock A2A for `protocol: "a2a"`; MCP/SDK paths may still use host-mediated activities.
+Reference engine: in-process mock A2A for `protocol: "a2a"`; MCP/SDK paths may still use host-mediated activities. Verify the native delegate path with `npm run e2e:r3` (see [r3-multi-agent-delegation-e2e.md](../architecture/arc42-assets/runbooks/r3-multi-agent-delegation-e2e.md)).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "conformance": "node conformance/run-conformance.mjs",
     "conformance:v1": "node conformance/run-conformance.mjs --profile=v1",
     "e2e:lighthouse": "node scripts/e2e-lighthouse-host-mediated.mjs",
+    "e2e:r3": "node scripts/e2e-r3-multi-agent-delegation.mjs",
     "conformance:parity-sdk": "node conformance/sdk-parity-smoke.mjs",
     "test": "npm test --workspace=@agent-workflow/engine",
     "sdk:test": "npm test --workspace=@agent-workflow/sdk",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "engine:mcp:stdio": "node packages/engine/src/mcp-stdio-server.mjs",
     "engine:rest:serve": "node packages/engine/src/rest-server.mjs",
     "conformance": "node conformance/run-conformance.mjs",
+    "e2e:lighthouse": "node scripts/e2e-lighthouse-host-mediated.mjs",
     "conformance:parity-sdk": "node conformance/sdk-parity-smoke.mjs",
     "test": "npm test --workspace=@agent-workflow/engine",
     "sdk:test": "npm test --workspace=@agent-workflow/sdk",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "engine:mcp:stdio": "node packages/engine/src/mcp-stdio-server.mjs",
     "engine:rest:serve": "node packages/engine/src/rest-server.mjs",
     "conformance": "node conformance/run-conformance.mjs",
+    "conformance:v1": "node conformance/run-conformance.mjs --profile=v1",
     "e2e:lighthouse": "node scripts/e2e-lighthouse-host-mediated.mjs",
     "conformance:parity-sdk": "node conformance/sdk-parity-smoke.mjs",
     "test": "npm test --workspace=@agent-workflow/engine",

--- a/scripts/e2e-lighthouse-host-mediated.mjs
+++ b/scripts/e2e-lighthouse-host-mediated.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  MemoryExecutionHistoryStore,
+  runGraphWorkflow,
+  submitActivityOutcome,
+  validateWorkflowDefinition,
+} from "../packages/engine/src/index.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const lighthousePath = path.join(repoRoot, "examples", "lighthouse-customer-routing.workflow.json");
+const executionId = "e2e-lighthouse-host-mediated-tech";
+
+function loadDefinition() {
+  const definition = JSON.parse(readFileSync(lighthousePath, "utf8"));
+  const validation = validateWorkflowDefinition(definition);
+  assert.equal(validation.ok, true, "lighthouse definition must validate before E2E run");
+  return definition;
+}
+
+function assertTechnicalRouting(store, executionId) {
+  const scheduled = store
+    .listByExecution(executionId)
+    .filter((r) => r.name === "NodeScheduled")
+    .map((r) => r.payload.nodeId);
+  assert.ok(scheduled.includes("search_kb"), "technical route must schedule search_kb");
+  assert.ok(!scheduled.includes("human_review"), "technical route must not schedule human_review");
+  assert.ok(!scheduled.includes("open_ticket"), "technical route must not schedule open_ticket");
+}
+
+async function run() {
+  const definition = loadDefinition();
+  const input = { ticket_text: "My API returns 500 on /payments endpoint." };
+  const store = new MemoryExecutionHistoryStore();
+
+  const awaitingClassify = await runGraphWorkflow({
+    definition,
+    input,
+    executionId,
+    store,
+    activityExecutionMode: "host_mediated",
+  });
+  assert.equal(awaitingClassify.status, "awaiting_activity", "run must yield at first activity");
+  assert.equal(awaitingClassify.nodeId, "classify");
+
+  const awaitingSearchKb = await submitActivityOutcome({
+    definition,
+    executionId,
+    store,
+    input,
+    nodeId: "classify",
+    outcome: { ok: true, result: { intent: "technical", confidence: 0.9 } },
+    activityExecutionMode: "host_mediated",
+  });
+  assert.equal(awaitingSearchKb.status, "awaiting_activity", "classify submit must continue to next activity");
+  assert.equal(awaitingSearchKb.nodeId, "search_kb");
+
+  const completed = await submitActivityOutcome({
+    definition,
+    executionId,
+    store,
+    input,
+    nodeId: "search_kb",
+    outcome: { ok: true, result: { snippets: [{ id: "kb-42", title: "Payments API 500" }] } },
+    activityExecutionMode: "host_mediated",
+  });
+  assert.equal(completed.status, "completed", "search_kb submit must complete execution");
+  assert.deepEqual(completed.result, { intent: "technical", confidence: 0.9 });
+
+  assertTechnicalRouting(store, executionId);
+
+  const rows = store.listByExecution(executionId);
+  const activityCompleted = rows.filter((r) => r.kind === "event" && r.name === "ActivityCompleted");
+  assert.equal(
+    activityCompleted.filter((r) => r.payload?.nodeId === "classify").length,
+    1,
+    "classify must have exactly one ActivityCompleted"
+  );
+  assert.equal(
+    activityCompleted.filter((r) => r.payload?.nodeId === "search_kb").length,
+    1,
+    "search_kb must have exactly one ActivityCompleted"
+  );
+  assert.ok(
+    activityCompleted.every((r) => r.payload?.replayed !== true),
+    "host-mediated submits must not be replay-only stubs"
+  );
+  assert.equal(rows.at(-1)?.name, "ExecutionCompleted");
+
+  console.log("Lighthouse host-mediated E2E: PASS");
+  console.log(`- execution_id: ${executionId}`);
+  console.log(`- result: ${JSON.stringify(completed.result)}`);
+  console.log(`- routed nodes: search_kb (technical path)`);
+}
+
+run().catch((error) => {
+  console.error("Lighthouse host-mediated E2E: FAIL");
+  console.error(error instanceof Error ? error.stack : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/e2e-r3-multi-agent-delegation.mjs
+++ b/scripts/e2e-r3-multi-agent-delegation.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  A2ADelegateExecutor,
+  clearWorkflowRefs,
+  MemoryExecutionHistoryStore,
+  mintDelegateCorrelationId,
+  registerWorkflowRef,
+  runGraphWorkflow,
+  validateWorkflowDefinition,
+} from "../packages/engine/src/index.mjs";
+import { createA2AMockHttpServer } from "../packages/engine/test/helpers/a2a-mock-http-server.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const parentPath = path.join(repoRoot, "examples", "r3-multi-agent-coding.workflow.json");
+const childPath = path.join(repoRoot, "examples", "r3-unit-tests-child.workflow.json");
+const executionId = "e2e-r3-multi-agent-delegation";
+
+function loadJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function loadDefinition() {
+  const definition = loadJson(parentPath);
+  const validation = validateWorkflowDefinition(definition);
+  assert.equal(validation.ok, true, "r3-multi-agent-coding definition must validate before E2E run");
+  return definition;
+}
+
+/**
+ * @param {import("../packages/engine/test/helpers/a2a-mock-http-server.mjs").ReturnType<typeof createA2AMockHttpServer>} mock
+ */
+async function withMockA2AServer(mock, fn) {
+  const { baseUrl, close } = await mock.listen();
+  try {
+    await fn(baseUrl);
+  } finally {
+    await close();
+  }
+}
+
+async function run() {
+  clearWorkflowRefs();
+  registerWorkflowRef("urn:awp:wf:unit-tests", loadJson(childPath));
+
+  const definition = loadDefinition();
+  const input = { task: "fix bug", repo: "acme/app" };
+  const mock = createA2AMockHttpServer();
+
+  await withMockA2AServer(mock, async (baseUrl) => {
+    const store = new MemoryExecutionHistoryStore();
+    const runResult = await runGraphWorkflow({
+      definition,
+      input,
+      executionId,
+      store,
+      delegateExecutor: new A2ADelegateExecutor({
+        operatorConfig: {
+          baseUrl,
+          apiKeyEnv: "A2A_TEST_KEY",
+          pollIntervalMs: 10,
+          pollTimeoutMs: 5_000,
+        },
+        env: { A2A_TEST_KEY: "secret" },
+      }),
+      stubActivityOutputs: {
+        run_tests: { tests_passed: true },
+      },
+    });
+
+    assert.equal(runResult.status, "interrupted", "workflow must interrupt at human review");
+    assert.equal(runResult.nodeId, "review", "interrupt must be at review node");
+    assert.equal(typeof runResult.state?.patch, "string", "implement delegate must write patch to state");
+    assert.equal(runResult.state?.tests_passed, true, "verify subworkflow must set tests_passed");
+
+    const rows = store.listByExecution(executionId);
+    const implementCompleted = rows.find(
+      (r) => r.name === "ActivityCompleted" && r.payload?.nodeId === "implement"
+    );
+    assert.ok(implementCompleted, "implement must have ActivityCompleted with real A2A delegate");
+    assert.equal(implementCompleted.payload?.externalTaskId, "a2a-task-1");
+    assert.equal(
+      implementCompleted.payload?.delegateCorrelationId,
+      mintDelegateCorrelationId(executionId, "implement")
+    );
+    assert.equal(mock.tasks.size, 1, "mock A2A server must receive exactly one delegated task");
+
+    const interruptRaised = rows.find(
+      (r) => r.name === "InterruptRaised" && r.payload?.nodeId === "review"
+    );
+    assert.ok(interruptRaised, "review interrupt must be raised after verify subworkflow");
+
+    console.log("R3 multi-agent delegation E2E: PASS");
+    console.log(`- execution_id: ${executionId}`);
+    console.log(`- status: ${runResult.status} at node ${runResult.nodeId}`);
+    console.log(`- external_task_id: ${implementCompleted.payload?.externalTaskId}`);
+    console.log(`- patch: ${String(runResult.state?.patch).slice(0, 60)}...`);
+  });
+}
+
+run().catch((error) => {
+  console.error("R3 multi-agent delegation E2E: FAIL");
+  console.error(error instanceof Error ? error.stack : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- **BEN-111:** Lighthouse host-mediated E2E script (`npm run e2e:lighthouse`) with runbook; wired into CI reusable workflow.
- **BEN-112:** Conformance harness `v1` profile filter (`npm run conformance:v1`); GA release checklist; release.yml gates npm `latest` on green v1 conformance; wf-release preflight updated.
- **BEN-113:** R3 multi-agent delegation E2E with real `A2ADelegateExecutor` against mock A2A server (`npm run e2e:r3`) + runbook.

Linear: [BEN-89](https://linear.app/ben-van-den-bergh/issue/BEN-89/epic-ga-10-release-gate-e2e-fixtures-v1-conformance-tag) (children BEN-111, BEN-112, BEN-113)

## Roadmap alignment

- Linked issue: BEN-89 (GA 1.0 release gate epic under BEN-81)
- Target release: `R4`
- Type: `feature`
- RFC trace links:
  - RFC-04 execution model (E2E replay/host-mediated paths)
  - RFC-05 MCP control plane (interop surfaces)
  - docs/engine-profile.md GA adopter bar

## Spec and architecture traceability

- Spec artifact link: `docs/governance/ga-release-checklist.md`, `docs/migration-alpha-to-ga.md`
- Architecture decision link: ADR deferred — release gate is operational harness only
- [x] Scope reviewed against `docs/engine-profile.md` (E2E proves non-stub activity/delegation paths)
- [x] Docs updated for GA conformance profile and runbooks

## Architecture runway impact

- [x] No runway impact

## Validation

- [x] `npm run validate-workflows`
- [x] `npm run conformance` (60 vectors pass)
- [x] `npm run conformance:v1` (60 vectors pass)
- [x] `npm run e2e:lighthouse`
- [x] `npm run e2e:r3`
- [x] `npm test` (318 pass)
- [x] Docs updated

## Risk and rollback

- Risk level: `low`
- Rollback/fallback plan: Revert PR; alpha tags continue using full conformance; E2E scripts are additive CI steps.

## Test plan

- [x] Local full gate suite (validate, conformance, conformance:v1, e2e:lighthouse, e2e:r3, test)
- [ ] CI green on PR
- [ ] Verify release.yml passes `conformance_profile: v1` input on GA tag path (dry review)
